### PR TITLE
feat: real-time post-reboot call detection + debug tooling + 24k audio (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.2.0] — unreleased
+
+A reliability release focused on **recording the first call after a reboot**, plus a rebuilt,
+user-facing debug/bug-report flow and an audio default better suited to voice.
+
+### Added
+- **Debug section (always visible).** Settings now has a simple **Debug** section: turn on diagnostic
+  logging, see an **"ON" reminder** (in-app warning + a persistent notification) so you don't leave it
+  running, and **Share debug logs** in one tap via the system share-sheet to send a bug report. Logs
+  are phone-number **redacted**.
+- **24 kbps audio bit rate**, flagged **Recommended** and now the **default** for Opus — plenty for
+  intelligible voice; higher rates only inflate file size.
+
+### Changed
+- **Removed the hidden "Developer Options"** (the 7-tap unlock, test-call simulator, and the
+  redaction-off "Debug mode"). Log **redaction is now always on** and cannot be turned off.
+- After a reboot the app briefly shows **"Call recorder starting up…"**, flipping to **"Ready to record
+  calls"** once recording is actually possible — so you know when a call will be captured.
+
+### Fixed
+- **First call after a reboot now records.** A new bounded post-boot **live call-state listener**
+  detects calls in real time instead of relying on the system `PHONE_STATE` broadcast, which on a
+  freshly-booted device could arrive **~9 seconds late** — after the call had already ended.
+- **Faster recorder warm-up after boot** (~5 s vs ~15 s): trimmed a redundant Wireless-Debugging wait
+  and skip the stale-daemon scan in the first 90 s after boot (a reboot already cleared any daemon).
+- **Daemon cold-start no longer over-waits.** The launcher returns the instant the daemon's binder
+  arrives instead of blocking out the full keep-alive window, recovering calls that were previously
+  aborted 1–3 s too late.
+- **Redaction can no longer be left disabled.** A leftover developer "Debug mode" flag could keep real
+  phone numbers in shared logs; redaction is now unconditional.
+- **Number-less recordings rename correctly.** The end-of-call CallLog rename now uses
+  `DocumentsContract.renameDocument` (the previous call threw on single-document SAF URIs), so files
+  get the contact/number in their name.
+
 ## [1.1.1] — unreleased
 
 A stability + features release built on top of v1.1.0. It keeps v1.1.0's proven on-demand

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,8 +109,12 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
     into(outputDir)
 }
 
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(1)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.0.0")
+// In-repo source of truth for the app version. CI overrides these via -PversionName / -PversionCode
+// (versionCode = the CI run number), but local builds and the in-app "About" version use these
+// defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
+// to the build workflow.
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10200)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.2.0")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -138,6 +138,19 @@
             android:exported="true" />
 
 
+        <!-- FileProvider used to share the diagnostic log report via the system share-sheet
+             (ACTION_SEND). Not exported; access is granted per-share via temporary read URI
+             permissions. Only the cache/logs sub-folder is exposed (see res/xml/file_paths.xml). -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <!-- Foreground service used by BootReceiver to reconnect ADB off the main thread -->
         <service
             android:name=".services.boot.AdbConnectionService"
@@ -146,6 +159,18 @@
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="Re-establish ADB wireless-debugging connection after boot." />
+        </service>
+
+        <!-- Post-boot foreground service that holds a LIVE telephony call-state listener for a bounded
+             window, so the first call(s) after a reboot are detected in real time instead of via the
+             post-boot-delayed PHONE_STATE broadcast. Stops itself after the window. -->
+        <service
+            android:name=".services.call.CallMonitorService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Call recording: listen for call state after reboot to record reliably." />
         </service>
 
     </application>

--- a/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
+++ b/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
@@ -11,6 +11,7 @@ package com.baba.callvault
 import android.app.Application
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.server.RecorderServerLauncher
+import com.baba.callvault.services.debug.DebugNotificationHelper
 import com.baba.callvault.system.storage.RetentionScheduler
 import com.baba.callvault.utils.AppLogger
 
@@ -25,6 +26,11 @@ class CallVaultApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         AppLogger.init(applicationContext)
+
+        // Re-assert the "debug logging is on" reminder if the user left logging enabled across an
+        // app restart, so the nudge to turn it back off survives process death.
+        runCatching { DebugNotificationHelper.sync(applicationContext) }
+            .onFailure { AppLogger.w(TAG, "Debug notification sync failed: ${it.message}") }
 
         // Reconcile the daily retention sweep with the saved prefs (schedules it when retention is on,
         // cancels it when off). Idempotent; ensures the sweep persists across reinstalls/reboots.

--- a/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
@@ -19,8 +19,12 @@ object AdbShell {
     private const val CONNECT_SETTLE_MS = 2500L
     /** Reduced from 25 s so the recording path fails fast instead of hanging while falsely appearing to record. */
     private const val MDNS_TIMEOUT_MS = 12_000L
-    /** How long to wait for adbd to start advertising after we toggle Wireless debugging on. */
-    private const val WD_START_WAIT_MS = 4_000L
+    /**
+     * Small settle after toggling Wireless debugging on, before we begin mDNS discovery. Kept short
+     * (was 4 s) because [AdbMdns.discoverPort] is event-driven and already blocks until adbd actually
+     * advertises — so a long fixed pre-sleep was mostly dead time on the post-boot cold-start path.
+     */
+    private const val WD_START_WAIT_MS = 750L
 
     /**
      * Ensures the ADB connection is up (mDNS-discover the connect port, connect, settle).

--- a/app/src/main/java/com/baba/callvault/integrations/scrcpy/ScrcpyAudioCodec.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/scrcpy/ScrcpyAudioCodec.kt
@@ -14,6 +14,14 @@ import com.baba.callvault.R
 import com.baba.callvault.services.recording.RecordingForegroundService
 
 /**
+ * Recommended bit rate (bps) for voice/call recording: 24 kbps is plenty for intelligible speech,
+ * and going higher only inflates file size. Used as the Opus default and flagged "Recommended" in the
+ * bit-rate picker. Top-level (not in the companion) so it can be referenced from an enum entry
+ * initializer below.
+ */
+const val RECOMMENDED_AUDIO_BIT_RATE = 24000
+
+/**
  * The audio codecs supported by scrcpy-server, each carrying all container metadata needed
  * by [ScrcpyAudioMuxer] and [RecordingForegroundService].
  *
@@ -40,7 +48,8 @@ enum class ScrcpyAudioCodec(
 
     /**
      * Opus codec — preferred for call recording because it delivers intelligible voice quality
-     * at very low bit rates (16 kbps).
+     * at very low bit rates. We default to [RECOMMENDED_AUDIO_BIT_RATE] (24 kbps): for voice/call audio
+     * higher bit rates add size without audible benefit, and lower ones aren't worth it.
      * Recordings are stored in an OGG container ([MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG],
      * available since Android 10 / API 29).
      *
@@ -49,7 +58,7 @@ enum class ScrcpyAudioCodec(
     OPUS(
         cliKey             = "opus",
         codecFourCC        = 0x6F707573,
-        defaultBitRate     = 16000,
+        defaultBitRate     = RECOMMENDED_AUDIO_BIT_RATE,
         outputFormat       = MediaMuxer.OutputFormat.MUXER_OUTPUT_OGG,
         mimeType           = MediaFormat.MIMETYPE_AUDIO_OPUS,
         containerExtension = ".ogg",

--- a/app/src/main/java/com/baba/callvault/server/RecorderServerLauncher.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderServerLauncher.kt
@@ -9,6 +9,7 @@
 package com.baba.callvault.server
 
 import android.content.Context
+import android.os.SystemClock
 import com.baba.callvault.integrations.adb.AdbShell
 import com.baba.callvault.utils.AppLogger
 
@@ -76,6 +77,14 @@ object RecorderServerLauncher {
 
     /** Drain cap for [killStaleDaemons]; the command isn't backgrounded, so it usually EOFs sooner. */
     private const val KILL_DRAIN_MS = 1500L
+
+    /**
+     * Below this device uptime, a reboot has just cleared every process, so no stale/orphaned daemon
+     * can exist — [killStaleDaemons] would only burn a shell round-trip on the latency-critical
+     * post-boot cold start. Stale daemons only accumulate from reinstall-over WITHOUT a reboot, which
+     * happens at much higher uptimes.
+     */
+    private const val RECENT_BOOT_GRACE_MS = 90_000L
 
     /** Poll interval while waiting for the daemon to deliver its binder to [RecorderConnection]. */
     private const val POLL_INTERVAL_MS = 150L
@@ -167,29 +176,63 @@ object RecorderServerLauncher {
     }
 
     /**
-     * Fires the detached launch command once over the embedded ADB shell and drains briefly so it is
-     * delivered. A "Stream closed" here is expected (the `&`-backgrounded launcher shell exits at
+     * Fires the detached launch command once over the embedded ADB shell and returns as soon as the
+     * daemon's binder has arrived — WITHOUT waiting out the whole keep-alive window.
+     *
+     * The launching shell must stay open for [LAUNCH_KEEPALIVE_SEC] so the daemon fully detaches
+     * before the stream closes; we satisfy that by draining the shell on a background thread (which
+     * also delivers the command). But once the binder is in [RecorderConnection] the daemon has
+     * ALREADY detached, so there is no reason to keep blocking the caller. Previously this method
+     * block-read the shell for the full ~3-4s keep-alive on every launch, which meant a binder that
+     * arrived early (the common case) was not noticed until the drain ended — adding ~3s of dead
+     * latency that could push readiness PAST the end of a short call (the "call ended before the
+     * daemon was ready" abort).
+     *
+     * A "Stream closed" on the drain thread is expected (the `&`-backgrounded launcher shell exits at
      * once and the daemon's own stdio is /dev/null), so failures are logged at debug, not error.
      */
     private fun launchOnce(context: Context, apk: String, attempt: Int) {
         // Clear any stale/orphaned daemon (e.g. old code surviving a reinstall) before launching fresh,
-        // so at most one daemon — matching the installed code — is ever running.
-        killStaleDaemons(context)
+        // so at most one daemon — matching the installed code — is ever running. Skipped shortly after
+        // boot: a reboot already cleared every process, so the scan can only cost time on the
+        // latency-critical first post-boot launch.
+        if (SystemClock.elapsedRealtime() > RECENT_BOOT_GRACE_MS) {
+            killStaleDaemons(context)
+        } else {
+            AppLogger.d(TAG, "Recent boot (uptime < ${RECENT_BOOT_GRACE_MS}ms); skipping killStaleDaemons — reboot already cleared any stale daemon")
+        }
         val command = String.format(PRIMARY_CMD_FORMAT, apk)
         AppLogger.i(TAG, "Attempt $attempt: launching recorder daemon. apk=$apk")
-        runCatching {
-            AdbShell.openShell(context, command).use { shell ->
-                val deadline = System.currentTimeMillis() + DRAIN_BUDGET_MS
-                shell.openInputStream().use { input ->
-                    val buf = ByteArray(256)
-                    while (System.currentTimeMillis() < deadline) {
-                        val read = input.read(buf)
-                        if (read < 0) break
-                        if (read > 0) AppLogger.d(TAG, "[launch] ${String(buf, 0, read)}")
+
+        // Background thread: send the command and hold the shell's stream open for the keep-alive
+        // window so the daemon detaches. Owns the shell's whole lifetime; outlives this method if the
+        // binder arrives first (harmless — it just finishes draining and closes).
+        Thread {
+            runCatching {
+                AdbShell.openShell(context, command).use { shell ->
+                    val deadline = System.currentTimeMillis() + DRAIN_BUDGET_MS
+                    shell.openInputStream().use { input ->
+                        val buf = ByteArray(256)
+                        while (System.currentTimeMillis() < deadline) {
+                            val read = input.read(buf)
+                            if (read < 0) break
+                            if (read > 0) AppLogger.d(TAG, "[launch] ${String(buf, 0, read)}")
+                        }
                     }
                 }
+            }.onFailure { AppLogger.d(TAG, "Attempt $attempt drain ended (expected for detached &): ${it.message}") }
+        }.apply { isDaemon = true; name = "recorder-launch-drain-$attempt" }.start()
+
+        // Return the moment the binder lands; otherwise wait out the keep-alive window (the launch
+        // failed to come up and the caller's retry will reconnect + relaunch).
+        val deadline = System.currentTimeMillis() + DRAIN_BUDGET_MS
+        while (System.currentTimeMillis() < deadline) {
+            if (RecorderConnection.isConnected) {
+                AppLogger.d(TAG, "Attempt $attempt: binder arrived during launch; not waiting out keep-alive")
+                return
             }
-        }.onFailure { AppLogger.d(TAG, "Attempt $attempt drain ended (expected for detached &): ${it.message}") }
+            runCatching { Thread.sleep(POLL_INTERVAL_MS) }
+        }
     }
 
     /**

--- a/app/src/main/java/com/baba/callvault/services/boot/BootReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/services/boot/BootReceiver.kt
@@ -12,6 +12,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.services.call.CallMonitorService
 import com.baba.callvault.utils.AppLogger
 
 /**
@@ -23,8 +24,11 @@ class BootReceiver : BroadcastReceiver() {
         val action = intent?.action ?: return
         if (action != Intent.ACTION_BOOT_COMPLETED && action != "android.intent.action.QUICKBOOT_POWERON") return
         if (!AppPreferences(context).isAdbPaired()) return
-        AppLogger.i(TAG, "Boot completed; starting ADB connection service")
+        AppLogger.i(TAG, "Boot completed; starting ADB connection service + post-boot call monitor")
         AdbConnectionService.start(context)
+        // Hold a live telephony listener for a bounded window so the first call(s) after a reboot are
+        // detected in real time, instead of via the post-boot-delayed PHONE_STATE broadcast.
+        CallMonitorService.start(context)
     }
 
     companion object {

--- a/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
@@ -1,0 +1,262 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.call
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.telephony.PhoneStateListener
+import android.telephony.TelephonyCallback
+import android.telephony.TelephonyManager
+import androidx.annotation.RequiresApi
+import com.baba.callvault.server.RecorderConnection
+import com.baba.callvault.utils.AppLogger
+
+/**
+ * Short-lived, post-reboot foreground service that holds a LIVE telephony call-state listener so the
+ * first call(s) after a reboot are detected promptly.
+ *
+ * **Why this exists.** Call detection normally rides the static [PhoneStateReceiver]
+ * `PHONE_STATE` broadcast. On the first call after a reboot, the freshly-booted, overloaded system
+ * delivers that broadcast ~9s late — after the call has already ended — so the call is missed
+ * (confirmed via the framework's own IMS logs vs. the app's broadcast time). A registered
+ * [TelephonyCallback]/[PhoneStateListener] is delivered straight from the telephony service over
+ * binder and is NOT stuck behind the post-boot broadcast queue, so it fires in real time.
+ *
+ * **Bounded by design.** Keeping a registered listener requires the process alive, which on modern
+ * Android means a foreground service + notification. In steady state the broadcast is reliable (cold
+ * app starts still record fine), so we only need this during the post-boot window: the service runs
+ * for [WINDOW_MS] after boot and then stops, so there is no permanent notification.
+ *
+ * **Authority hand-off.** While this service is listening ([isListening] = true) it is the
+ * authoritative call-state source; [PhoneStateReceiver] defers to it (ignores the often-delayed
+ * broadcast) to avoid double-handling and stale late-broadcast sessions. The listener forwards STATE
+ * only (no number); the number is reconciled exactly as it already is for a number-less start — via
+ * the end-of-call CallLog lookup in the recording service.
+ */
+class CallMonitorService : Service() {
+
+    private val telephonyManager: TelephonyManager? by lazy { getSystemService(TelephonyManager::class.java) }
+
+    /** The currently-registered listener: a [TelephonyCallback] (API 31+) or [PhoneStateListener] (API 30). */
+    private var registeredListener: Any? = null
+
+    private val stopHandler = Handler(Looper.getMainLooper())
+    private val windowElapsed = object : Runnable {
+        override fun run() {
+            // Don't pull the only authoritative call-state source out from under an in-progress call;
+            // re-arm a short extension and re-check instead.
+            if (isCallActive()) {
+                AppLogger.i(TAG, "Call-monitor window elapsed but a call is active; deferring stop")
+                stopHandler.postDelayed(this, WINDOW_EXTENSION_MS)
+                return
+            }
+            AppLogger.i(TAG, "Post-boot call-monitor window elapsed; stopping live listener")
+            stopSelf()
+        }
+    }
+
+    // Detection (the listener) is ready instantly, but the privileged audio daemon takes ~10-15s to
+    // cold-start after a reboot — until then a call is detected but CAN'T be recorded. We poll the
+    // daemon's connection state and flip the notification between "starting up" and "ready" so it stays
+    // accurate for the whole window (including if the daemon later dies), telling the user when a call
+    // will actually be captured.
+    private val readinessHandler = Handler(Looper.getMainLooper())
+    private var lastReadyState: Boolean? = null
+    private val readinessPoll = object : Runnable {
+        override fun run() {
+            val ready = RecorderConnection.isConnected
+            if (ready != lastReadyState) {
+                lastReadyState = ready
+                updateNotification(ready)
+                AppLogger.i(TAG, "Recording readiness changed: ready=$ready")
+            }
+            readinessHandler.postDelayed(this, READINESS_POLL_MS)
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        getSystemService(NotificationManager::class.java).createNotificationChannel(
+            NotificationChannel(CHANNEL_ID, "Call monitor", NotificationManager.IMPORTANCE_MIN).apply {
+                setSound(null, null)
+                setShowBadge(false)
+            },
+        )
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val startedForeground = runCatching {
+            startForeground(NOTIF_ID, buildNotification(RecorderConnection.isConnected), ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+        }.onFailure { AppLogger.e(TAG, "startForeground failed", it) }.isSuccess
+        // A foreground service that can't enter the foreground will be ANR'd/killed on modern Android —
+        // bail out cleanly rather than run illegally.
+        if (!startedForeground) {
+            AppLogger.e(TAG, "Cannot run CallMonitorService without foreground; stopping")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        registerListener()
+
+        // Continuously track daemon readiness so the notification stays accurate for the whole window.
+        lastReadyState = null
+        readinessHandler.removeCallbacks(readinessPoll)
+        readinessHandler.post(readinessPoll)
+
+        // (Re)arm the bounded window. START_STICKY may re-deliver with a null intent after a kill;
+        // re-arming keeps the listener alive for a fresh window in that case.
+        stopHandler.removeCallbacks(windowElapsed)
+        stopHandler.postDelayed(windowElapsed, WINDOW_MS)
+
+        return START_STICKY
+    }
+
+    private fun updateNotification(ready: Boolean) {
+        runCatching {
+            getSystemService(NotificationManager::class.java).notify(NOTIF_ID, buildNotification(ready))
+        }.onFailure { AppLogger.w(TAG, "Failed to update monitor notification: ${it.message}") }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        stopHandler.removeCallbacks(windowElapsed)
+        readinessHandler.removeCallbacks(readinessPoll)
+        unregisterListener()
+        super.onDestroy()
+    }
+
+    /** Registers the live call-state listener (idempotent). Requires READ_PHONE_STATE; logs and no-ops if denied. */
+    private fun registerListener() {
+        if (registeredListener != null) return
+        val tm = telephonyManager ?: run {
+            AppLogger.w(TAG, "TelephonyManager unavailable; cannot register live call listener")
+            return
+        }
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val callback = CallStateCallback()
+                tm.registerTelephonyCallback(mainExecutor, callback)
+                registeredListener = callback
+            } else {
+                val listener = LegacyCallStateListener()
+                @Suppress("DEPRECATION")
+                tm.listen(listener, PhoneStateListener.LISTEN_CALL_STATE)
+                registeredListener = listener
+            }
+        }.onFailure {
+            AppLogger.e(TAG, "Failed to register live call listener (READ_PHONE_STATE missing?)", it)
+            return
+        }
+        isListening = true
+        AppLogger.i(TAG, "Live call-state listener registered for the post-boot window")
+    }
+
+    private fun unregisterListener() {
+        val tm = telephonyManager
+        val listener = registeredListener
+        registeredListener = null
+        if (tm != null && listener != null) {
+            runCatching {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && listener is TelephonyCallback) {
+                    tm.unregisterTelephonyCallback(listener)
+                } else if (listener is PhoneStateListener) {
+                    @Suppress("DEPRECATION")
+                    tm.listen(listener, PhoneStateListener.LISTEN_NONE)
+                }
+            }.onFailure { AppLogger.w(TAG, "Failed to unregister live call listener: ${it.message}") }
+        }
+        // Flip the authority flag only AFTER the listener is actually torn down, so PhoneStateReceiver
+        // never resumes the broadcast path while the live listener is still firing (no double-handling).
+        isListening = false
+    }
+
+    /** Whether the telephony service currently reports an active (non-idle) call. */
+    private fun isCallActive(): Boolean =
+        runCatching {
+            (telephonyManager?.callState ?: TelephonyManager.CALL_STATE_IDLE) != TelephonyManager.CALL_STATE_IDLE
+        }.getOrDefault(false)
+
+    /** Maps a [TelephonyManager] call-state int to the broadcast's EXTRA_STATE string and feeds the session manager. */
+    private fun forwardState(state: Int) {
+        val stateString = when (state) {
+            TelephonyManager.CALL_STATE_RINGING  -> TelephonyManager.EXTRA_STATE_RINGING
+            TelephonyManager.CALL_STATE_OFFHOOK  -> TelephonyManager.EXTRA_STATE_OFFHOOK
+            TelephonyManager.CALL_STATE_IDLE     -> TelephonyManager.EXTRA_STATE_IDLE
+            else -> return
+        }
+        AppLogger.i(TAG, "Live telephony callback: state=$stateString -> forwarding to CallSessionManager")
+        // STATE only (no number); the number is reconciled via the end-of-call CallLog lookup, exactly
+        // as in the existing number-less start path.
+        CallSessionManager.getInstance(this).handlePhoneState(stateString, null)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private inner class CallStateCallback : TelephonyCallback(), TelephonyCallback.CallStateListener {
+        override fun onCallStateChanged(state: Int) = forwardState(state)
+    }
+
+    @Suppress("DEPRECATION")
+    private inner class LegacyCallStateListener : PhoneStateListener() {
+        override fun onCallStateChanged(state: Int, phoneNumber: String?) = forwardState(state)
+    }
+
+    private fun buildNotification(ready: Boolean): Notification =
+        Notification.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setContentTitle(if (ready) "Ready to record calls" else "Call recorder starting up…")
+            .setContentText(
+                if (ready) "Listening for calls after restart."
+                else "Connecting the recorder — calls won't record until this finishes.",
+            )
+            .setOnlyAlertOnce(true)
+            .build()
+
+    companion object {
+        private const val TAG = "CV:CallMonitorService"
+        private const val CHANNEL_ID = "call_monitor"
+        private const val NOTIF_ID = 4714
+
+        /** How long after boot the live listener stays registered before the broadcast path takes over. */
+        private const val WINDOW_MS = 10 * 60 * 1000L
+
+        /** If the window elapses mid-call, defer the stop by this much and re-check. */
+        private const val WINDOW_EXTENSION_MS = 60 * 1000L
+
+        /** How often to poll the daemon's connection state to flip the notification to "ready". */
+        private const val READINESS_POLL_MS = 1500L
+
+        /**
+         * True while the live listener is registered and authoritative. [PhoneStateReceiver] reads this
+         * to defer to the listener (ignore the delayed broadcast) during the post-boot window.
+         */
+        @Volatile
+        @JvmStatic
+        var isListening: Boolean = false
+            private set
+
+        fun start(context: Context) {
+            val intent = Intent(context, CallMonitorService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt
@@ -59,6 +59,15 @@ class PhoneStateReceiver : BroadcastReceiver() {
 
         AppLogger.v(TAG, "Raw broadcast received: state=$state number=$number")
 
+        // During the post-boot window, CallMonitorService holds a LIVE telephony listener and is the
+        // authoritative call-state source. The PHONE_STATE broadcast can be delivered seconds late on a
+        // freshly-booted system (after the call has already ended), which would otherwise spawn a stale
+        // session for a call that's over. So while the live listener is active, defer to it.
+        if (CallMonitorService.isListening) {
+            AppLogger.v(TAG, "CallMonitorService active; deferring to the live listener (broadcast ignored)")
+            return
+        }
+
         // Forward the phone state and number to the session manager.
         // We now forward everything (including null) to let the CallSessionManager handle the Verification Window.
         CallSessionManager.getInstance(context).handlePhoneState(state, number)

--- a/app/src/main/java/com/baba/callvault/services/debug/DebugNotificationHelper.kt
+++ b/app/src/main/java/com/baba/callvault/services/debug/DebugNotificationHelper.kt
@@ -1,0 +1,89 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.debug
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.baba.callvault.MainActivity
+import com.baba.callvault.R
+import com.baba.callvault.data.AppPreferences
+
+/**
+ * Posts (and clears) the persistent reminder that debug logging is currently enabled.
+ *
+ * Debug logging quietly grows a log file and is meant to be a temporary, "turn it on to reproduce a
+ * bug" state — so while it is on we keep an ongoing, low-importance notification visible to nudge the
+ * user to turn it back off. Tapping the notification opens the app (where the Debug section's toggle
+ * lives).
+ */
+object DebugNotificationHelper {
+
+    private const val CHANNEL_ID = "debug_logging_channel"
+    private const val NOTIFICATION_ID = 4242
+
+    /** Posts the reminder when logging is enabled, or clears it when disabled. Safe to call anytime. */
+    fun sync(context: Context) {
+        if (AppPreferences(context).isLoggingEnabled()) show(context) else cancel(context)
+    }
+
+    /** Shows the ongoing "debug logging is on" reminder. No-op if POST_NOTIFICATIONS is denied. */
+    fun show(context: Context) {
+        createChannel(context)
+
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            0,
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_sys_warning)
+            .setContentTitle(context.getString(R.string.debug_notification_title))
+            .setContentText(context.getString(R.string.debug_notification_text))
+            .setStyle(NotificationCompat.BigTextStyle().bigText(context.getString(R.string.debug_notification_text)))
+            .setContentIntent(contentIntent)
+            .setOngoing(true)
+            .setAutoCancel(false)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setVisibility(NotificationCompat.VISIBILITY_SECRET)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+
+        // notify() silently no-ops when POST_NOTIFICATIONS is not granted (Android 13+); the in-app
+        // warning banner still informs the user, so we don't force a permission prompt here.
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
+    }
+
+    /** Clears the reminder. */
+    fun cancel(context: Context) {
+        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID)
+    }
+
+    private fun createChannel(context: Context) {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            context.getString(R.string.debug_notification_channel_name),
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            setShowBadge(false)
+            enableVibration(false)
+            setSound(null, null)
+        }
+        context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/java/com/baba/callvault/services/recording/RecordingForegroundService.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/RecordingForegroundService.kt
@@ -17,6 +17,7 @@ import android.os.Build
 import android.os.IBinder
 import android.content.pm.ServiceInfo
 import android.provider.CallLog
+import android.provider.DocumentsContract
 import androidx.documentfile.provider.DocumentFile
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.integrations.adb.AdbShell
@@ -366,19 +367,20 @@ class RecordingForegroundService : Service() {
                 if (finalNumber.isNotBlank()) {
                     val updatedMeta = originalMetadata.copy(rawPhoneNumber = finalNumber)
                     val newName = RecordingFileNameFormatter.formatFileName(applicationContext, updatedMeta, activeSession.currentCodecEnum)
-                    val doc = DocumentFile.fromSingleUri(applicationContext, uriToRename)
-                    var renamed = false
+                    // Use DocumentsContract.renameDocument (NOT DocumentFile.renameTo): the latter is a
+                    // SingleDocumentFile here and throws UnsupportedOperationException, while
+                    // renameDocument is supported by ExternalStorageProvider and returns the new URI.
+                    var renamedUri: Uri? = null
                     try {
-                        renamed = doc?.renameTo(newName) ?: false
-                        if (renamed) {
+                        renamedUri = DocumentsContract.renameDocument(applicationContext.contentResolver, uriToRename, newName)
+                        if (renamedUri != null) {
                             AppLogger.d(TAG, "Successfully renamed wrongly detected anonymous recording to: $newName")
                         }
                     } catch (e: Exception) {
                         AppLogger.e(TAG, "Failed to rename file using CallLog fallback", e)
                     }
-                    // After a successful renameTo the DocumentFile's uri reflects the new name;
-                    // on failure fall back to the original URI.
-                    finalUri = if (renamed && doc != null) doc.uri else uriToRename
+                    // renameDocument may return a new document URI; fall back to the original on failure.
+                    finalUri = renamedUri ?: uriToRename
                 } else {
                     AppLogger.d(TAG, "Call log confirmed the call is anonymous, or no actual number was found. Keeping file name as is.")
                     finalUri = uriToRename

--- a/app/src/main/java/com/baba/callvault/system/SystemIntentHelpers.kt
+++ b/app/src/main/java/com/baba/callvault/system/SystemIntentHelpers.kt
@@ -21,10 +21,12 @@ import android.provider.DocumentsContract
 import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import com.baba.callvault.BuildConfig
 import com.baba.callvault.R
 import com.baba.callvault.utils.AppLogger
+import java.io.File
 
 /**
  * SystemIntentHelpers.kt contains shortcuts for opening system screens and doing
@@ -148,6 +150,28 @@ fun Context.openWirelessDebugging() {
 /** Opens the upstream project repository (required fork attribution, GPLv3 §7). */
 fun Context.openOriginalProjectRepo() {
     launchSmartIntent(Intent(Intent.ACTION_VIEW).apply { data = ORIGINAL_PROJECT_URL.toUri() })
+}
+
+/**
+ * Shares [file] (the diagnostic log report) through the system share-sheet (ACTION_SEND), so the
+ * user can attach it to an email, chat, or GitHub issue in one tap.
+ *
+ * The file is exposed via [FileProvider] (authority `${applicationId}.fileprovider`) and the receiving
+ * app is granted temporary read access for the lifetime of the share.
+ *
+ * @param file The report file produced by `AppLogger.buildShareableReport`.
+ */
+fun Context.shareLogFile(file: File) {
+    val uri = FileProvider.getUriForFile(this, "$packageName.fileprovider", file)
+    val sendIntent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        putExtra(Intent.EXTRA_SUBJECT, "CallVault debug logs")
+        // Grant the chosen app temporary read access to the report URI.
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        clipData = android.content.ClipData.newRawUri("CallVault debug logs", uri)
+    }
+    launchSmartIntent(Intent.createChooser(sendIntent, getString(R.string.settings_bugreport_share_chooser)))
 }
 
 /**

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -21,8 +21,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
 import androidx.compose.material.icons.automirrored.filled.CallMade
@@ -41,20 +39,24 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import android.widget.Toast
 import com.baba.callvault.R
 import com.baba.callvault.system.PersistentFolderPickerContract
 import com.baba.callvault.system.copyToClipboard
 import com.baba.callvault.system.openOriginalProjectRepo
+import com.baba.callvault.system.shareLogFile
+import com.baba.callvault.utils.AppLogger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.data.RetentionPeriod
 import com.baba.callvault.data.StorageTarget
+import com.baba.callvault.integrations.scrcpy.RECOMMENDED_AUDIO_BIT_RATE
 import com.baba.callvault.integrations.scrcpy.ScrcpyAudioCodec
 import com.baba.callvault.integrations.scrcpy.ScrcpyAudioSource
 import com.baba.callvault.integrations.scrcpy.ScrcpyConfig
@@ -71,7 +73,6 @@ import com.baba.callvault.ui.common.M3DropdownField
 import com.baba.callvault.ui.common.OptionItem
 import com.baba.callvault.ui.viewmodels.ContactPickerType
 import com.baba.callvault.ui.viewmodels.ContactPickerViewModel
-import com.baba.callvault.ui.viewmodels.DebugAction
 import com.baba.callvault.ui.viewmodels.SettingsActions
 import com.baba.callvault.ui.viewmodels.SettingsViewModel
 import com.baba.callvault.ui.viewmodels.ContactPickerState
@@ -81,7 +82,6 @@ import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.mikepenz.aboutlibraries.ui.compose.android.produceLibraries
-import androidx.activity.result.contract.ActivityResultContracts
 import android.net.Uri
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.animation.fadeIn
@@ -90,13 +90,11 @@ import androidx.compose.material.icons.filled.DriveFileRenameOutline
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Gavel
-import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalResources
-import androidx.compose.ui.text.input.KeyboardType
 import org.xmlpull.v1.XmlPullParser
 import java.util.Locale
 
@@ -115,6 +113,7 @@ fun SettingsScreen(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     // Trigger recomposition when settings change by viewmodel.refresh()
     val updateTrigger by viewModel.updateTrigger.collectAsState()
@@ -141,13 +140,6 @@ fun SettingsScreen(
         viewModel.refresh()
     }
 
-    // Export logs picker — creates a new text file and gives us access to write to it, then passes the URI to the viewmodel for writing.
-    val exportLogLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("text/plain")) { uri: Uri? ->
-        if (uri != null) {
-            viewModel.exportLogs(uri)
-        }
-    }
-
     SettingsContent(
         preferences = viewModel.preferences,
         updateTrigger = updateTrigger,
@@ -167,7 +159,18 @@ fun SettingsScreen(
             viewModel.refresh()
         },
         onDismissContacts = { contactPickerViewModel.dismissContactPicker() },
-        onExportLogs = { exportLogLauncher.launch("callvault_bug_report.log") },
+        // Build the report off the main thread, then hand it to the system share-sheet. The Share
+        // entry point is only shown when a valid log file exists, so the null branch is a safety net.
+        onShareLogs = {
+            scope.launch {
+                val report = withContext(Dispatchers.IO) { AppLogger.buildShareableReport(context) }
+                if (report != null) {
+                    context.shareLogFile(report)
+                } else {
+                    Toast.makeText(context, R.string.settings_bugreport_share_empty, Toast.LENGTH_LONG).show()
+                }
+            }
+        },
         modifier = modifier
     )
 }
@@ -190,7 +193,7 @@ fun SettingsScreen(
  * @param onOpenContactsOutgoing Called to open picker for outgoing contacts.
  * @param onConfirmContacts      Called when contacts are confirmed from the dialog.
  * @param onDismissContacts      Called when we want to close the dialog without confirmation/saving.
- * @param onExportLogs           Called to export diagnostic logs using SAF.
+ * @param onShareLogs            Called to share diagnostic logs via the system share-sheet (Debug section).
  * @param modifier               Optional size/position modifier.
  */
 @Composable
@@ -206,12 +209,10 @@ fun SettingsContent(
     onOpenContactsOutgoing: () -> Unit,
     onConfirmContacts: (Set<String>) -> Unit,
     onDismissContacts: () -> Unit,
-    onExportLogs: () -> Unit,
+    onShareLogs: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var showLicensesDialog by remember { mutableStateOf(false) }
-    // Read in the composable scope (not the LazyListScope) so the Debug item recomposes on unlock.
-    val isDeveloperModeUnlocked = remember(updateTrigger) { preferences.isDeveloperModeUnlocked() }
 
     // Accordion: at most one section open at a time; Recording & storage is open on entry. State is
     // hoisted here (above the LazyColumn) so it is shared across all sections. Tapping the open section
@@ -282,22 +283,19 @@ fun SettingsContent(
                     onToggle = { onToggleSection(SECTION_VISUAL) }
                 )
             }
-            // Debug section is hidden until developer options are unlocked (7-tap on the version row).
-            if (isDeveloperModeUnlocked) {
-                item {
-                    DebugSection(
-                        preferences, updateTrigger, actions, onExportLogs,
-                        expanded = openSection == SECTION_DEBUG,
-                        onToggle = { onToggleSection(SECTION_DEBUG) }
-                    )
-                }
+            // Debug section: always visible so anyone can enable logging and share logs to report an issue.
+            item {
+                BugReportSection(
+                    preferences, updateTrigger, actions, onShareLogs,
+                    expanded = openSection == SECTION_BUG_REPORT,
+                    onToggle = { onToggleSection(SECTION_BUG_REPORT) }
+                )
             }
             // About moved to the bottom; the fork attribution stays visible (GPLv3 §7 requirement).
             item {
                 AboutSection(
                     versionString = actions.getAppVersion(),
                     onShowLicenses = { showLicensesDialog = true },
-                    onUnlockDeveloperMode = { actions.unlockDeveloperMode() },
                     expanded = openSection == SECTION_ABOUT,
                     onToggle = { onToggleSection(SECTION_ABOUT) }
                 )
@@ -357,9 +355,6 @@ fun SettingsContent(
     }
 }
 
-/** Number of consecutive taps on the version row required to unlock developer options. */
-private const val DEVELOPER_UNLOCK_TAPS = 7
-
 // Settings accordion: stable keys identifying each section. At most one section is open at a time;
 // [SECTION_RECORDING] is the one open when Settings is first entered.
 private const val SECTION_RECORDING = "recording"
@@ -367,7 +362,7 @@ private const val SECTION_STORAGE = "storage"
 private const val SECTION_RETENTION = "retention"
 private const val SECTION_AUDIO = "audio"
 private const val SECTION_VISUAL = "visual"
-private const val SECTION_DEBUG = "debug"
+private const val SECTION_BUG_REPORT = "bug_report"
 private const val SECTION_ABOUT = "about"
 
 // ── Settings sections ──────────────────────────────────────────────────────────────────────
@@ -707,8 +702,8 @@ private fun RetentionSection(
 
 /** Shows the audio source, codec, and bit-rate dropdowns.
  *
- * The audio-source list is generated from [ScrcpyAudioSource.entries], filtered by
- * [ScrcpyAudioSource.isDebugOnly] based on [AppPreferences.isDebugEnabled]. Items whose
+ * The audio-source list is generated from [ScrcpyAudioSource.entries] with debug-only entries
+ * ([ScrcpyAudioSource.isDebugOnly]) always hidden. Items whose
  * [ScrcpyAudioSource.minApi]/[ScrcpyAudioSource.maxApi] range does not include the current
  * device's API level are shown grayed out and cannot be selected.
  *
@@ -719,7 +714,6 @@ private fun RetentionSection(
 @Composable
 private fun AudioSection(preferences: AppPreferences, updateTrigger: Int, actions: SettingsActions, expanded: Boolean, onToggle: () -> Unit) {
 
-    val isDebugEnabled = remember(updateTrigger) { preferences.isDebugEnabled() }
     val audioSource = remember(updateTrigger) { preferences.getAudioSource() }
     val audioCodec = remember(updateTrigger) { preferences.getAudioCodec() }
     val savedBitRate = remember(updateTrigger) { preferences.getAudioBitRate() }
@@ -727,10 +721,10 @@ private fun AudioSection(preferences: AppPreferences, updateTrigger: Int, action
     SettingsSection(title = stringResource(R.string.settings_section_audio), expanded = expanded, onToggle = onToggle) {
         val currentSdk = Build.VERSION.SDK_INT
 
-        // Build the source list from the enum, hiding debug-only entries when debug is off.
+        // Build the source list from the enum, always hiding debug-only entries.
         // Items that require an API level not available on this device are shown as disabled.
         val audioSourceOptions = ScrcpyAudioSource.entries
-            .filter { !it.isDebugOnly || isDebugEnabled }
+            .filter { !it.isDebugOnly }
             .map { source ->
                 OptionItem(
                     key         = source.cliKey,
@@ -776,8 +770,14 @@ private fun AudioSection(preferences: AppPreferences, updateTrigger: Int, action
             }
         }
 
-        val bitrateOptions = listOf(8000, 16000, 32000, 64000, 128000)
-            .map { OptionItem(it.toString(), stringResource(R.string.audio_bitrate_kbps, it / 1000)) }
+        val recommendedLabel = stringResource(R.string.general_recommended)
+        val bitrateOptions = listOf(8000, 16000, 24000, 32000, 64000, 128000)
+            .map { bps ->
+                val kbpsLabel = stringResource(R.string.audio_bitrate_kbps, bps / 1000)
+                // 24 kbps is the recommended sweet spot for voice — flag it right in the dropdown.
+                val label = if (bps == RECOMMENDED_AUDIO_BIT_RATE) "$kbpsLabel ($recommendedLabel)" else kbpsLabel
+                OptionItem(bps.toString(), label)
+            }
 
         DropdownRow {
             M3DropdownField(
@@ -897,18 +897,36 @@ private fun VisualSection(preferences: AppPreferences, updateTrigger: Int, actio
     }
 }
 
-/** Shows the debug toggle, and when enabled, a caller-number field and test-call buttons.
+/**
+ * Debug section (always visible). The flow is: turn logging on, reproduce the issue, turn logging
+ * off, then share the captured log.
+ *
+ * - While logging is **on**, we show a red reminder to turn it back off; sharing is intentionally
+ *   hidden so the user isn't sharing a log that is still being written to.
+ * - While logging is **off**, the Share button appears only if a valid (non-empty) log file from a
+ *   previous session still exists — there is nothing to share otherwise.
+ *
+ * Logs stay redacted (phone numbers masked). Each time logging is turned on the previous capture is
+ * cleared (see [SettingsViewModel.setLoggingEnabled]) so every report is a fresh, focused log.
  *
  * @param preferences   The [AppPreferences] instance to read data from.
  * @param updateTrigger Trigger value to force recomposition when settings change.
  * @param actions       Implementation of [SettingsActions] to handle user interaction.
- * @param onExportLogs  Called to export logs via SAF when logging is enabled.
+ * @param onShareLogs   Called to share the diagnostic log report via the system share-sheet.
  */
 @Composable
-private fun DebugSection(preferences: AppPreferences, updateTrigger: Int, actions: SettingsActions, onExportLogs: () -> Unit, expanded: Boolean, onToggle: () -> Unit) {
-    val isDebugEnabled = remember(updateTrigger) { preferences.isDebugEnabled() }
-    val debugCallerNumber = remember(updateTrigger) { preferences.getDebugCallerNumber() }
+private fun BugReportSection(
+    preferences: AppPreferences,
+    updateTrigger: Int,
+    actions: SettingsActions,
+    onShareLogs: () -> Unit,
+    expanded: Boolean,
+    onToggle: () -> Unit
+) {
     val isLoggingEnabled = remember(updateTrigger) { preferences.isLoggingEnabled() }
+    // Re-checked on every settings change (e.g. right after the toggle flips off) so the Share
+    // button appears as soon as a capture is frozen on disk.
+    val hasLogs = remember(updateTrigger) { AppLogger.hasLogs() }
 
     SettingsSection(title = stringResource(R.string.settings_section_debug), expanded = expanded, onToggle = onToggle) {
         SettingsToggleRow(
@@ -916,95 +934,36 @@ private fun DebugSection(preferences: AppPreferences, updateTrigger: Int, action
             label           = stringResource(R.string.settings_debug_logging_enabled),
             checked         = isLoggingEnabled,
             onCheckedChange = { actions.setLoggingEnabled(it) },
-            description     = if (!isLoggingEnabled) stringResource(R.string.settings_debug_logging_enabled_description) else null
+            description     = stringResource(R.string.settings_debug_logging_enabled_description)
         )
 
         if (isLoggingEnabled) {
             Column(modifier = Modifier.padding(horizontal = 16.dp)) {
                 Text(
-                    text = stringResource(R.string.settings_debug_logging_title),
-                    style = MaterialTheme.typography.titleSmall,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    text = stringResource(R.string.settings_bugreport_active_warning),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.error
                 )
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+        } else if (hasLogs) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
                 Text(
-                    text = stringResource(R.string.settings_debug_logging_steps),
+                    text = stringResource(R.string.settings_bugreport_share_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurface
                 )
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                Text(
-                    text = stringResource(R.string.settings_debug_logging_step_warning),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.error
-                )
-
-                if (isDebugEnabled) {
-                    Spacer(modifier = Modifier.height(5.dp))
-                    Text(
-                        text = stringResource(R.string.settings_debug_logging_step_warning_no_redaction),
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                Button(
+                    onClick = onShareLogs,
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    Button(
-                        onClick = onExportLogs,
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Text(stringResource(R.string.settings_debug_logging_generate_report))
-                    }
+                    Text(stringResource(R.string.settings_bugreport_share))
                 }
-            }
-        }
 
-        SettingsDivider()
-
-        SettingsToggleRow(
-            icon            = Icons.Filled.GraphicEq,
-            label           = stringResource(R.string.settings_debug_mode),
-            checked         = isDebugEnabled,
-            onCheckedChange = { actions.setDebugEnabled(it) },
-            description = stringResource(R.string.settings_debug_mode_description)
-        )
-        if (isDebugEnabled) {
-            Column(
-                modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                var textState by remember(debugCallerNumber) { mutableStateOf(debugCallerNumber) }
-                val allowedChars = "^[0-9+-]*$".toRegex()
-                val keyboardController = LocalSoftwareKeyboardController.current
-
-                OutlinedTextField(
-                    value    = textState,
-                    onValueChange = { newValue ->
-                        if (newValue.matches(allowedChars)) {
-                            textState = newValue
-                            // We aggressively update the setting on every change so that
-                            // the test buttons always use the latest number.
-                            actions.setDebugCallerNumber(newValue)
-                        }
-                    },
-                    label    = { Text(stringResource(R.string.settings_debug_caller_number)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, keyboardType = KeyboardType.Phone, showKeyboardOnFocus = true),
-                    keyboardActions = KeyboardActions(onDone = {
-                        actions.setDebugCallerNumber(textState)
-                        keyboardController?.hide()
-                    })
-                )
-                DebugActionGrid(actions)
+                Spacer(modifier = Modifier.height(4.dp))
             }
         }
     }
@@ -1012,39 +971,26 @@ private fun DebugSection(preferences: AppPreferences, updateTrigger: Int, action
 
 /** Shows the app version, server version, clipboard buttons, and a GitHub link.
  *
- * Tapping the version row [DEVELOPER_UNLOCK_TAPS] times in a row unlocks the hidden Debug section.
- *
  * @param versionString         The formatted app-version string to display.
  * @param onShowLicenses        Called when the user taps "View Licenses".
- * @param onUnlockDeveloperMode Called once the hidden 7-tap gesture completes.
  */
 @Composable
 private fun AboutSection(
     versionString: String,
     onShowLicenses: () -> Unit,
-    onUnlockDeveloperMode: () -> Unit,
     expanded: Boolean,
     onToggle: () -> Unit
 ) {
     val context = LocalContext.current
     val serverVersion = ScrcpyConfig.SCRCPY_VERSION
-    var versionTapCount by remember { mutableIntStateOf(0) }
 
     SettingsSection(title = stringResource(R.string.settings_section_about), expanded = expanded, onToggle = onToggle) {
-        // Hidden 7-tap developer unlock lives on the app-version row.
         NavigationRow(
             icon = Icons.Filled.Save,
             label = stringResource(R.string.settings_ui_about_app),
             value = versionString,
             supporting = stringResource(R.string.settings_scrcpy_server, serverVersion),
-            showChevron = false,
-            onClick = {
-                versionTapCount += 1
-                if (versionTapCount >= DEVELOPER_UNLOCK_TAPS) {
-                    versionTapCount = 0
-                    onUnlockDeveloperMode()
-                }
-            }
+            showChevron = false
         )
 
         SettingsDivider()
@@ -1201,14 +1147,14 @@ private fun NavigationRow(
     icon: ImageVector,
     label: String,
     value: String,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)? = null,
     supporting: String? = null,
     showChevron: Boolean = true
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { onClick() }
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -1357,33 +1303,6 @@ private fun IgnoreContactsOptions(
     }
 }
 
-/** A row of buttons for simulating different call events during testing.
- *
- * @param actions Called via proxy for each button press.
- */
-@Composable
-private fun DebugActionGrid(actions: SettingsActions) {
-    val items = listOf(
-        DebugAction.RINGING  to stringResource(R.string.settings_debug_action_ringing),
-        DebugAction.OFFHOOK  to stringResource(R.string.settings_debug_action_offhook),
-        DebugAction.IDLE     to stringResource(R.string.settings_debug_action_idle)
-    )
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        items.forEach { (action, label) ->
-            FilledTonalButton(
-                onClick = { actions.triggerDebugAction(action) },
-                modifier = Modifier.weight(1f),
-                contentPadding = PaddingValues(horizontal = 4.dp)
-            ) {
-                Text(label, style = MaterialTheme.typography.labelSmall)
-            }
-        }
-    }
-}
-
 /**
  * Safe Compose Preview for Settings.
  */
@@ -1410,11 +1329,6 @@ private fun SettingsScreenPreview() {
             override fun setShowToastsEnabled(enabled: Boolean) {}
             override fun setAppLanguage(languageCode: String) {}
             override fun setLoggingEnabled(enabled: Boolean) {}
-            override fun setDebugEnabled(enabled: Boolean) {}
-            override fun setDebugCallerNumber(number: String) {}
-            override fun unlockDeveloperMode() {}
-            override fun triggerDebugAction(action: DebugAction) {}
-            override fun exportLogs(uri: Uri) {}
             override fun getAppVersion(): String = "Version 1.0.0 (Mock)"
             override fun setFileNameTemplate(template: String) {}
             override fun setStorageTarget(target: StorageTarget) {}
@@ -1438,7 +1352,7 @@ private fun SettingsScreenPreview() {
             onOpenContactsOutgoing = {},
             onConfirmContacts = {},
             onDismissContacts = {},
-            onExportLogs = {}
+            onShareLogs = {}
         )
     }
 }

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
@@ -9,14 +9,11 @@
 package com.baba.callvault.ui.viewmodels
 
 import android.app.Application
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.viewModelScope
 import com.baba.callvault.BuildConfig
-import com.baba.callvault.R
-import com.baba.callvault.services.call.CallSessionManager
+import com.baba.callvault.services.debug.DebugNotificationHelper
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.data.StorageTarget
 import com.baba.callvault.integrations.scrcpy.ScrcpyAudioCodec
@@ -25,25 +22,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import com.baba.callvault.utils.AppLogger
 
 // -------- Screen state & action types owned by this ViewModel
-
-/**
- * The four phone-call lifecycle events that can be simulated from the debug panel.
- *
- * Used by [SettingsViewModel.triggerDebugAction] to fire a broadcast that exercises the
- * recording pipeline without needing a real phone call.
- */
-enum class DebugAction {
-    /** Simulate an incoming call starting to ring. */
-    RINGING,
-    /** Simulate the call being answered (off-hook) or an outgoing call being placed. */
-    OFFHOOK,
-    /** Simulate the call being idle (no active call). */
-    IDLE
-}
 
 /**
  * Interface defining all user actions that can be triggered from the Settings screen.
@@ -66,11 +47,6 @@ interface SettingsActions {
     fun setShowToastsEnabled(enabled: Boolean)
     fun setAppLanguage(languageCode: String)
     fun setLoggingEnabled(enabled: Boolean)
-    fun setDebugEnabled(enabled: Boolean)
-    fun setDebugCallerNumber(number: String)
-    fun unlockDeveloperMode()
-    fun triggerDebugAction(action: DebugAction)
-    fun exportLogs(uri: android.net.Uri)
     fun getAppVersion(): String
     fun setFileNameTemplate(template: String)
     fun setStorageTarget(target: StorageTarget)
@@ -374,71 +350,20 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     // -------- Debug settings
 
-    /** Enables or disables application background logging.
+    /** Turns diagnostic logging on or off.
      *
-     * @param enabled `true` to log application flow.
+     * Turning it **on** clears any previous capture so each bug report is a fresh, focused log.
+     * Turning it **off** keeps the captured log on disk so the user can still share it afterwards.
+     * Either way the persistent "debug logging is on" reminder is posted/cleared to match.
+     *
+     * @param enabled `true` to start capturing application logs.
      */
     override fun setLoggingEnabled(enabled: Boolean) {
-        preferences.setLoggingEnabled(enabled)
-        if (!enabled) {
+        if (enabled) {
             AppLogger.clearLogs()
         }
+        preferences.setLoggingEnabled(enabled)
+        DebugNotificationHelper.sync(appContext)
         refresh()
-    }
-
-    /** Enables or disables the debug panel and other internal debug checks like log redactions.
-     *
-     * @param enabled `true` to show the debug panel.
-     */
-    override fun setDebugEnabled(enabled: Boolean) {
-        preferences.setDebugEnabled(enabled)
-        refresh()
-    }
-
-    /**
-     * Saves the phone number used when simulating a call in debug mode.
-     * Does not call [refresh] because the text field already shows the correct value.
-     *
-     * @param number The phone number to simulate (digits, `+`, and `-` only).
-     */
-    override fun setDebugCallerNumber(number: String) {
-        preferences.setDebugCallerNumber(number)
-    }
-
-    /**
-     * Unlocks the hidden developer options (the Debug section). Triggered by the 7-tap gesture on
-     * the app-version row. Idempotent: if already unlocked, only re-shows the confirmation toast.
-     */
-    override fun unlockDeveloperMode() {
-        preferences.setDeveloperModeUnlocked(true)
-        Toast.makeText(appContext, R.string.settings_developer_mode_unlocked, Toast.LENGTH_SHORT).show()
-        refresh()
-    }
-
-    /**
-     * Fires a simulated call broadcast so you can test the recording flow without making
-     * a real phone call.
-     *
-     * @param action The type of simulated call event to fire (see [DebugAction]).
-     */
-    override fun triggerDebugAction(action: DebugAction) {
-        viewModelScope.launch {
-            val actionType = when (action) {
-                DebugAction.IDLE     -> CallSessionManager.ACTION_DEBUG_IDLE
-                DebugAction.RINGING  -> CallSessionManager.ACTION_DEBUG_RINGING
-                DebugAction.OFFHOOK  -> CallSessionManager.ACTION_DEBUG_OFFHOOK
-            }
-            CallSessionManager.getInstance(appContext).handleDebugAction(actionType)
-        }
-    }
-
-    /**
-     * Exports the application logs to a user-selected SAF file destination.
-     * Starts an async coroutine to avoid blocking the main UI thread during physical disk writes.
-     */
-    override fun exportLogs(uri: android.net.Uri) {
-        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
-            AppLogger.exportReport(appContext, uri)
-        }
     }
 }

--- a/app/src/main/java/com/baba/callvault/utils/AppLogger.kt
+++ b/app/src/main/java/com/baba/callvault/utils/AppLogger.kt
@@ -23,7 +23,6 @@ import java.io.FileWriter
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import android.net.Uri
 import android.os.Build
 import com.baba.callvault.BuildConfig
 import com.baba.callvault.integrations.scrcpy.ScrcpyConfig
@@ -66,10 +65,13 @@ object AppLogger {
     private var logFile: File? = null
 
     /**
-     * Helper to gracefully determine if log redaction is active.
+     * Redaction is always on. The shareable diagnostic log must never contain raw phone numbers.
+     *
+     * (Previously this was gated by a developer-only "Debug mode" toggle that disabled redaction;
+     * that toggle has been removed, so redaction is now unconditional and cannot be turned off.)
      */
     private val isRedactionEnabled: Boolean
-        get() = prefs?.isDebugEnabled() != true
+        get() = true
 
     /**
      * Initializes the logging mechanism for the main application process.
@@ -141,39 +143,72 @@ object AppLogger {
     }
 
     /**
-     * Gathers system/app metadata and concatenates it with the existing debug log history,
-     * streaming the complete report to a destination URI via the Storage Access Framework.
+     * Whether a valid (existing, non-empty) log file is currently on disk and therefore worth
+     * sharing. Used by the Settings Debug section to decide whether to offer the Share action.
+     */
+    fun hasLogs(): Boolean {
+        val file = logFile
+        return file != null && file.exists() && file.length() > 0L
+    }
+
+    /**
+     * Builds a self-contained diagnostic report (metadata header + the redacted log history) into a
+     * file inside the app's cache directory, ready to be attached to a share-sheet via FileProvider.
+     *
+     * The report lives under `cacheDir/logs/` (the only folder exposed by the FileProvider) and is
+     * overwritten on each call. Phone numbers remain redacted.
+     *
+     * Suspends and copies the log body under [fileMutex] so it never captures a half-flushed or
+     * mid-rotation file (the logger's IO coroutine writes under the same lock).
      *
      * @param context Application context.
-     * @param destinationUri Target SAF URI to which the file will be generated.
+     * @return The report [File], or `null` if no log file exists yet (nothing to share).
      */
-    fun exportReport(context: Context, destinationUri: Uri) {
-        val file = logFile ?: return
-        context.contentResolver.openOutputStream(destinationUri, "w")?.use { outputStream ->
-            PrintWriter(OutputStreamWriter(outputStream, Charsets.UTF_8)).use { writer ->
-                writer.println("=== CallVault AppLogger Export ===")
-                writer.println("Generated: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss z", Locale.US).format(Date())}")
-                writer.println("App Version: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
-                writer.println("Scrcpy Server: ${ScrcpyConfig.SCRCPY_VERSION}")
-                writer.println("Manufacturer: ${Build.MANUFACTURER}")
-                writer.println("Model: ${Build.MODEL}")
-                writer.println("Device: ${Build.DEVICE}")
-                writer.println("Product: ${Build.PRODUCT}")
-                writer.println("Android Version: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
-                writer.println("Device Country Iso Estimation: ${PhoneNumberManager.getInstance(context).getDeviceCountryIso()}")
-                writer.println("===========================================")
-                writer.println()
-                writer.flush()
+    suspend fun buildShareableReport(context: Context): File? {
+        val source = logFile
+        if (source == null || !source.exists() || source.length() == 0L) return null
 
-                if (file.exists()) {
-                    file.inputStream().use { inputStream ->
-                        inputStream.copyTo(outputStream)
-                    }
-                } else {
-                    writer.println("[No logs found in internal storage]")
+        val shareDir = File(context.cacheDir, "logs").apply { mkdirs() }
+        val report = File(shareDir, "callvault_debug_report.txt")
+        return try {
+            // Write the header and the log body into ONE output stream. The PrintWriter is flushed
+            // (not closed) before copying the body so its text lands ahead of the log bytes; the
+            // `use` block closes the underlying stream once both have been written.
+            report.outputStream().use { out ->
+                val writer = PrintWriter(OutputStreamWriter(out, Charsets.UTF_8))
+                writeReportHeader(writer, context)
+                writer.flush()
+                // Snapshot the live log under the writer's lock so the copy is consistent.
+                fileMutex.withLock {
+                    if (source.exists()) source.inputStream().use { input -> input.copyTo(out) }
+                }
+                out.flush()
+                if (writer.checkError()) {
+                    e(TAG, "PrintWriter reported an error while building the shareable report")
+                    return null
                 }
             }
+            report
+        } catch (e: Exception) {
+            e(TAG, "Failed to build shareable report", e)
+            null
         }
+    }
+
+    /** Writes the common report metadata header (app/device/runtime info) to [writer]. */
+    private fun writeReportHeader(writer: PrintWriter, context: Context) {
+        writer.println("=== CallVault AppLogger Export ===")
+        writer.println("Generated: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss z", Locale.US).format(Date())}")
+        writer.println("App Version: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+        writer.println("Scrcpy Server: ${ScrcpyConfig.SCRCPY_VERSION}")
+        writer.println("Manufacturer: ${Build.MANUFACTURER}")
+        writer.println("Model: ${Build.MODEL}")
+        writer.println("Device: ${Build.DEVICE}")
+        writer.println("Product: ${Build.PRODUCT}")
+        writer.println("Android Version: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+        writer.println("Device Country Iso Estimation: ${PhoneNumberManager.getInstance(context).getDeviceCountryIso()}")
+        writer.println("===========================================")
+        writer.println()
     }
 
     /** Logs a Verbose level message and optionally its throwable trace. */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <!-- ========================================== -->
     <string name="app_name" translatable="false">CallVault</string>
     <string name="general_close">Close</string>
+    <string name="general_recommended">Recommended</string>
     <string name="general_continue">Continue</string>
     <string name="general_ok">OK</string>
     <string name="general_cancel">Cancel</string>
@@ -121,10 +122,9 @@
     <string name="retention_confirm_message">Recordings older than the selected period will be permanently deleted from your device and/or Google Drive. This can\'t be undone.</string>
     <string name="retention_confirm_enable">Enable</string>
     <string name="settings_section_recording_storage">Recording &amp; storage</string>
-    <string name="settings_developer_mode_unlocked">Developer options unlocked</string>
     <string name="settings_section_visual">Visual settings</string>
     <string name="settings_section_audio">Audio configuration</string>
-    <string name="settings_section_debug">Debug Options</string>
+    <string name="settings_section_debug">Debug</string>
     <string name="settings_section_security">Security</string>
     <string name="settings_section_recorder_server">Recorder service</string>
 
@@ -235,25 +235,19 @@
     <string name="audio_source_voice_performance" translatable="false">Voice performance</string>
     <string name="audio_source_voice_performance_description">High-speed microphone mode designed for live music and real-time audio apps.</string>
 
-    <!-- Settings Screen: Debug Section -->
+    <!-- Settings Screen: Debug section (always visible) -->
     <string name="settings_debug_logging_enabled">Enable log recording</string>
-    <string name="settings_debug_logging_enabled_description">To report a bug, enable this, restart the app, and reproduce the issue.</string>
-    <string name="settings_debug_logging_title">Bug Reporting Steps</string>
-    <string name="settings_debug_logging_steps">
-        1. Check if your issue has already been reported on GitHub, if not, continue.\n
-        2. Reproduce the bug while keeping log recording enabled.\n
-        3. Press Generate Report below to save the logs to your phone.\n
-        4. Press Report on GitHub to open a new issue, fill up the fields, and attach the log file.
-    </string>
-    <string name="settings_debug_logging_step_warning">Please review the generated file for sensitive info before sharing. Disable log recording once done.</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️ Debug Mode is ON. Log redaction is disabled.</string>
-    <string name="settings_debug_logging_generate_report">Generate Report</string>
-    <string name="settings_debug_mode">Enable debug mode</string>
-    <string name="settings_debug_mode_description">Show developers options, disable log redaction.</string>
-    <string name="settings_debug_caller_number">Debug phone number</string>
-    <string name="settings_debug_action_ringing" translatable="false">Ringing</string>
-    <string name="settings_debug_action_offhook" translatable="false">Off Hook</string>
-    <string name="settings_debug_action_idle" translatable="false">Idle / End</string>
+    <string name="settings_debug_logging_enabled_description">To report a bug, enable this, reproduce the issue, then turn it off and share the logs.</string>
+    <string name="settings_bugreport_active_warning">Debug logging is ON. Remember to turn it off when you\'re done to save space.</string>
+    <string name="settings_bugreport_share_hint">Logs from your last debug session are ready to share.</string>
+    <string name="settings_bugreport_share">Share debug logs</string>
+    <string name="settings_bugreport_share_empty">No logs yet. Enable debug logging, reproduce the issue, then tap share.</string>
+    <string name="settings_bugreport_share_chooser">Share debug logs</string>
+
+    <!-- Persistent reminder that debug logging is enabled -->
+    <string name="debug_notification_channel_name">Debug logging</string>
+    <string name="debug_notification_title">Debug logging is on</string>
+    <string name="debug_notification_text">Tap to open CallVault and turn it off when you\'re done.</string>
 
     <!-- Settings Screen: About/Server Section -->
     <string name="settings_copy_version">Copy Version</string>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ CallVault: FOSS call recording, self-contained over embedded ADB
+  ~  Copyright (C) 2026-present The CallVault Authors
+  ~  Licensed under the GNU General Public License v3 or later (see LICENSE).
+  -->
+<paths>
+    <!-- Exposes the diagnostic report written by AppLogger.buildShareableReport() so it can be
+         attached to a share-sheet (ACTION_SEND) via FileProvider. Limited to the dedicated
+         cache/logs sub-folder so nothing else in the cache directory is shareable. -->
+    <cache-path name="debug_logs" path="logs/" />
+</paths>


### PR DESCRIPTION
## Summary

Reliability + features for **v1.2.0**, focused on recording the **first call after a reboot**, plus a rebuilt user-facing debug/bug-report flow and a voice-appropriate audio default.

### Call detection (first-call-after-reboot fix)
- New `CallMonitorService`: a bounded (~10 min) post-boot foreground service that registers a **live** `TelephonyCallback` (API 31+) / `PhoneStateListener` (API 30) and forwards call state to `CallSessionManager`. On a freshly-booted device the `PHONE_STATE` broadcast can arrive **~9 s late** (after the call ended); the live listener fires in real time. `PhoneStateReceiver` defers to it while active.
- Notification reflects **actual recorder readiness** ("starting up…" → "ready").

### Recorder warm-up / cold-start
- `launchOnce` returns the instant the daemon binder arrives (drain moved to a background thread) instead of blocking out the keep-alive window.
- Skip `killStaleDaemons` within 90 s of boot; trim `AdbShell` WD wait 4000 → 750 ms (~5 s vs ~15 s warm-up).

### Debug / bug reports
- Restored a user-facing **Debug** section (enable logging, ON reminder + persistent notification, **Share logs** via a non-exported FileProvider + `ACTION_SEND`). Removed the gated Developer Options (7-tap unlock, test-call simulator, redaction-off "Debug mode").
- **Redaction is now always on** (a stale developer flag could leave it off).

### Fixes
- Number-less recordings rename via `DocumentsContract.renameDocument` (`DocumentFile.renameTo` throws on single-document SAF URIs).

### Audio
- Added **24 kbps** bit rate flagged **Recommended**; default for Opus.

### Release
- Bumped in-repo `versionName` default to **1.2.0** in `app/build.gradle.kts` (was hardcoded 1.0.0 fallback) + CHANGELOG.

## Test plan (verified on-device, OnePlus CPH2581 / Android 16)
- [x] First call after reboot now records + syncs to Drive (live listener caught it; broadcast deferred).
- [x] Boot warm-up ~5 s; "starting up → ready" notification accurate.
- [x] Debug section: enable → warning + notification; disable → Share logs (redacted) via share-sheet.
- [x] Redaction confirmed always-on (numbers masked in shared report).
- [x] 24 kbps shows "(Recommended)", default for Opus; About shows v1.2.0.
- [x] Code review applied (4 HIGH + worthwhile MED/LOW fixed); builds clean.