### PR TITLE
fix(release): unblock release build (R8 conscrypt + orphaned translations)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -37,3 +37,9 @@
 -assumenosideeffects class com.baba.callvault.utils.AppLogger {
   v(...);
 }
+
+# Conscrypt (pulled in transitively by the embedded-ADB TLS layer) references optional legacy platform
+# SSL classes that are not on the compile classpath and are never present at runtime on supported
+# Android versions. Without these rules R8 fails the release build on the dangling references.
+-dontwarn com.android.org.conscrypt.**
+-dontwarn org.apache.harmony.xnet.provider.jsse.**

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -62,12 +62,6 @@
     <string name="settings_audio_source">Audioquelle</string>
     <string name="settings_debug_logging_enabled">Logging aktivieren</string>
     <string name="settings_debug_logging_enabled_description">Um einen Fehler zu melden, aktivieren Sie diese Einstellung, starten Sie die App neu und reproduzieren die das Problem.</string>
-    <string name="settings_debug_logging_title">Schritte zur Fehlermeldung</string>
-    <string name="settings_debug_logging_steps">1. Überprüfen Sie, ob Ihr Problem bereits auf GitHub gemeldet wurde; falls nicht, fahren Sie fort.\n 2. Reproduzieren Sie den Fehler, während die Log-Aufzeichnung aktiviert ist.­­\n 3. Tippen Sie unten auf „Bericht erstellen“, um die Logs auf Ihrem Smartphone zu speichern.\n 4. Tippen Sie auf „Auf GitHub melden“, um ein neues Issue zu eröffnen, füllen Sie die Felder aus und fügen Sie die Log-Datei bei.</string>
-    <string name="settings_debug_logging_step_warning">Bitte überprüfen Sie die generierte Datei vor dem Teilen auf sensible Informationen. Deaktivieren Sie die Log-Aufzeichnung, sobald Sie fertig sind.</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️ Debug-Modus ist aktiv. Log-Redaktion ist deaktiviert.</string>
-    <string name="settings_debug_logging_generate_report">Bericht generieren</string>
-    <string name="settings_debug_mode">Debug-Modus aktivieren</string>
     <string name="settings_copy_version">Version kopieren</string>
     <string name="settings_view_licenses">Lizenzen ansehen</string>
     <string name="contact_search_hint">Nach Name oder Nummer suchen...</string>
@@ -106,6 +100,4 @@
     <string name="audio_source_voice_call_uplink_description">Zeichnet nur Ihre Seite eines Telefonats auf (Uplink).</string>
     <string name="audio_source_voice_call_downlink_description">Zeichnet nur die Seite der anderen Person bei einem Telefonat auf (Downlink).</string>
     <string name="audio_source_voice_performance_description">Hochgeschwindigkeits-Mikrofonmodus, konzipiert für Live-Musik und Echtzeit-Audioanwendungen.</string>
-    <string name="settings_debug_mode_description">Entwickleroptionen anzeigen, Log-Redaktion deaktivieren.</string>
-    <string name="settings_debug_caller_number">Telefonnummer debuggen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -81,14 +81,6 @@
     <string name="audio_source_voice_performance_description">Modo de micrófono de alta velocidad diseñado para música en vivo y aplicaciones de audio en tiempo real.</string>
     <string name="settings_debug_logging_enabled">Activar el registro de eventos</string>
     <string name="settings_debug_logging_enabled_description">Para informar de un error, activa esta opción, reinicia la aplicación y reproduce el problema.</string>
-    <string name="settings_debug_logging_title">Pasos para reportar errores</string>
-    <string name="settings_debug_logging_steps">1. Comprueba si tu problema ya se ha reportado en GitHub; si no, continúa.\n2. Reproduce el error manteniendo el registro de eventos activado.\n3. Pulsa Generar informe a continuación para guardar los registros en tu teléfono.\n4. Pulsa Reportar en GitHub para abrir un nuevo problema, completa los campos y adjunta el archivo de registro.</string>
-    <string name="settings_debug_logging_step_warning">Revisa el archivo generado para comprobar que no contiene información sensible antes de compartirlo. Desactiva el registro de eventos cuando termines.</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️ El modo de depuración está ACTIVADO. La redacción de registros está desactivada.</string>
-    <string name="settings_debug_logging_generate_report">Generar informe</string>
-    <string name="settings_debug_mode">Activar el modo de depuración</string>
-    <string name="settings_debug_mode_description">Mostrar las opciones de desarrollador, desactivar la redacción de registros.</string>
-    <string name="settings_debug_caller_number">Depurar número de teléfono</string>
     <string name="settings_copy_version">Copiar versión</string>
     <string name="settings_view_licenses">Ver licencias</string>
     <string name="contact_search_hint">Buscar por nombre o número…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -79,14 +79,6 @@
     <string name="audio_source_voice_performance_description">Mode microphone haute vitesse conçu pour la musique en direct et les applications audio en temps réel.</string>
     <string name="settings_debug_logging_enabled">Activer l\'enregistrement des journaux</string>
     <string name="settings_debug_logging_enabled_description">Pour signaler un bug, activez cette option, redémarrez l\'application et reproduisez le problème.</string>
-    <string name="settings_debug_logging_title">Étapes de signalement des bogues</string>
-    <string name="settings_debug_logging_steps">1. Vérifiez si votre problème a déjà été signalé sur GitHub. Si ce n\'est pas le cas, poursuivez.\n 2. Reproduisez le bug en activant l\'enregistrement des journaux.\n 3. Appuyez sur « Générer un rapport » ci-dessous pour enregistrer les journaux sur votre téléphone.\n 4. Appuyez sur « Signaler sur GitHub » pour créer un nouveau ticket, remplissez les champs et joignez le fichier journal.</string>
-    <string name="settings_debug_logging_step_warning">Vérifier que le fichier généré ne contient pas d\'informations sensibles avant de le partager. Désactivez l\'enregistrement des journaux une fois l\'opération terminée.</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️ Le mode débogage est ACTIVÉ. La rédaction des journaux est désactivée.</string>
-    <string name="settings_debug_logging_generate_report">Générer un rapport</string>
-    <string name="settings_debug_mode">Activer le mode débogage</string>
-    <string name="settings_debug_mode_description">Afficher les options développeurs, désactiver la rédaction des journaux.</string>
-    <string name="settings_debug_caller_number">Numéro de téléphone de débogage</string>
     <string name="settings_copy_version">Copier la version</string>
     <string name="settings_view_licenses">Afficher les licences</string>
     <string name="contact_search_hint">Recherche par nom ou numéro...</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -89,14 +89,6 @@
     <string name="audio_source_voice_performance_description">Nagy sebességű mikrofon üzemmód - leginkább élő zenei előadásokhoz és valós idejű hangalkalmazásokhoz.</string>
     <string name="settings_debug_logging_enabled">Naplózás bekapcsolása</string>
     <string name="settings_debug_logging_enabled_description">Hibajelentéshez engedélyezd ezt a beállítást, indítsd újra az alkalmazást majd próbáld reprodukálni a problémát.</string>
-    <string name="settings_debug_logging_title">A hibajelentés lépései</string>
-    <string name="settings_debug_logging_steps">1. Ellenőrizd, hogy a problémádat jelentették-e már a GitHubon; ha nem, folytasd.\n2. Reprodukáld a hibát úgy, hogy a naplózás engedélyezve legyen.\n3. Használd az alul található „Jelentés létrehozása” gombot a naplófájlok telefonra mentéséhez.\n4. Használd a „Jelentés a GitHubon” gombot egy új hibajelentés nyitásához, töltsd ki a mezőket és csatold a naplófájlt.</string>
-    <string name="settings_debug_logging_step_warning">Kérjük, a megosztás előtt ellenőrizd a létrehozott fájlt, hogy nem tartalmaz-e bizalmas információkat. Ha elkészült, tiltsd le a naplózást.</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️ Hibakeresési mód bekapcsolva. A naplószűrés nincs bekapcsolva.</string>
-    <string name="settings_debug_logging_generate_report">Jelentés generálása</string>
-    <string name="settings_debug_mode">Hibakeresés mód bekapcsolása</string>
-    <string name="settings_debug_mode_description">Fejlesztői beállítások megjelenítése, a naplószűrés kikapcsolása.</string>
-    <string name="settings_debug_caller_number">Telefonszám</string>
     <string name="settings_copy_version">Verziószám másolása</string>
     <string name="settings_view_licenses">Licenszek megtekintése</string>
     <string name="contact_search_hint">Keresés név vagy szám alapján...</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -81,14 +81,6 @@
     <string name="audio_source_voice_performance_description">Tryb mikrofonu o dużej czułości przeznaczony do nagrywania muzyki na żywo i aplikacji audio działających w czasie rzeczywistym.</string>
     <string name="settings_debug_logging_enabled">Włącz rejestrowanie logów</string>
     <string name="settings_debug_logging_enabled_description">Aby zgłosić błąd, włącz tę opcję, uruchom ponownie aplikację i spróbuj odtworzyć problem.</string>
-    <string name="settings_debug_logging_title">Jak zgłaszać błędy</string>
-    <string name="settings_debug_logging_steps">1. Sprawdź, czy problem nie został już zgłoszony na GitHubie; jeśli nie, kontynuuj.\n 2. Odtwórz błąd, pozostawiając włączoną funkcję rejestrowania logów.\n 3. Naciśnij przycisk „Generuj raport” poniżej, aby zapisać logi w telefonie.\n 4. Naciśnij przycisk „Zgłoś na GitHubie”, aby otworzyć nowe zgłoszenie, wypełnij pola i załącz plik logu.</string>
-    <string name="settings_debug_logging_step_warning">Przed udostępnieniem pliku sprawdź, czy nie zawiera on danych wrażliwych. Po zakończeniu wyłącz rejestrowanie logów.</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️ Tryb debugowania jest włączony. Redagowanie logów jest wyłączone.</string>
-    <string name="settings_debug_logging_generate_report">Generuj Raport</string>
-    <string name="settings_debug_mode">Włącz tryb debugowania</string>
-    <string name="settings_debug_mode_description">Pokaż opcje programisty, wyłącz redagowanie logów.</string>
-    <string name="settings_debug_caller_number">Debuguj numer telefonu</string>
     <string name="settings_copy_version">Kopiuj Wersję</string>
     <string name="settings_view_licenses">Wyświetl licencje</string>
     <string name="contact_search_hint">Wyszukaj według nazwy lub numeru...</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -77,14 +77,6 @@
     <string name="audio_source_voice_performance_description">Высокоскоростной режим микрофона для живой музыки и приложений для работы со звуком в реальном времени.</string>
     <string name="settings_debug_logging_enabled">Включить логи записи</string>
     <string name="settings_debug_logging_enabled_description">Чтобы сообщить об ошибке, включите это, перезапустите приложение, и повторите проблему.</string>
-    <string name="settings_debug_logging_title">Шаги сообщения об ошибке</string>
-    <string name="settings_debug_logging_steps">1. Проверьте, не сообщали ли об этой проблеме на GitHub ранее. Если нет, переходите к следующему шагу.\n 2. Воспроизведите ошибку, не выключая запись логов.\n 3. Нажмите «Создать отчет» ниже, чтобы сохранить логи на телефон.\n 4. Нажмите «Сообщить на GitHub», чтобы открыть новую тему, заполните поля и прикрепите файл логов.</string>
-    <string name="settings_debug_logging_step_warning">Пожалуйста, проверьте созданный файл на наличие личных данных перед отправкой. По окончании не забудьте отключить запись логов.</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️ Включен режим отладки. Скрытие личных данных в логах отключено.</string>
-    <string name="settings_debug_logging_generate_report">Создать отчёт</string>
-    <string name="settings_debug_mode">Включить режим отладки</string>
-    <string name="settings_debug_mode_description">Показывать меню разработчика и не скрывать личные данные в логах.</string>
-    <string name="settings_debug_caller_number">Отладка телефонного номера</string>
     <string name="settings_copy_version">Копировать версию</string>
     <string name="settings_view_licenses">Посмотреть лицензии</string>
     <string name="contact_search_hint">Искать по имени или номеру...</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -90,14 +90,6 @@
     <string name="audio_source_voice_performance_description">Chế độ micro tốc độ cao được thiết kế cho nhạc sống và các ứng dụng âm thanh thời gian thực.</string>
     <string name="settings_debug_logging_enabled">Bật ghi nhật ký</string>
     <string name="settings_debug_logging_enabled_description">Để báo cáo lỗi, hãy bật chức năng này, khởi động lại ứng dụng và tái hiện lỗi.</string>
-    <string name="settings_debug_logging_title">Các bước báo cáo lỗi</string>
-    <string name="settings_debug_logging_steps">1. Kiểm tra xem sự cố của bạn đã được báo cáo trên GitHub chưa, nếu chưa, hãy tiếp tục.\n2. Tái hiện lỗi trong khi vẫn bật ghi nhật ký.\n3. Nhấn Tạo báo cáo bên dưới để lưu nhật ký vào điện thoại của bạn.\n4. Nhấn Báo cáo trên GitHub để mở một sự cố mới, điền đầy đủ thông tin và đính kèm tệp nhật ký.</string>
-    <string name="settings_debug_logging_step_warning">Vui lòng xem lại tệp được tạo để kiểm tra thông tin nhạy cảm trước khi chia sẻ. Sau khi hoàn tất, hãy tắt chức năng ghi nhật ký.</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️ Chế độ gỡ lỗi đang BẬT. Chức năng ẩn nhật ký đã bị vô hiệu hóa.</string>
-    <string name="settings_debug_logging_generate_report">Tạo báo cáo</string>
-    <string name="settings_debug_mode">Bật chế độ gỡ lỗi</string>
-    <string name="settings_debug_mode_description">Hiển thị tùy chọn dành cho nhà phát triển, tắt tính năng ẩn nhật ký.</string>
-    <string name="settings_debug_caller_number">Gỡ lỗi số điện thoại</string>
     <string name="settings_copy_version">Sao chép phiên bản</string>
     <string name="settings_view_licenses">Xem giấy phép</string>
     <string name="contact_search_hint">Tìm kiếm theo tên hoặc số...</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -65,7 +65,6 @@
     <string name="settings_audio_bitrate">码率</string>
     <string name="settings_audio_source">音源</string>
     <string name="audio_source_voice_call_description">同时录制双方的声音，即原始音频。将会包含运营商的提示铃音。</string>
-    <string name="settings_debug_logging_title">请参照以下步骤反馈Bug：</string>
     <string name="settings_debug_logging_enabled_description">若要反馈Bug，请先开启此开关，然后在重启App之后再重复您刚才的操作。</string>
     <string name="settings_debug_logging_enabled">记录运行日志</string>
     <string name="general_record">录音</string>
@@ -85,12 +84,6 @@
     <string name="audio_source_mic_unprocessed_description">录制原始的麦克风音频，不做任何优化和过滤。</string>
     <string name="audio_source_voice_call_uplink_description">仅录制您的声音（仅上行）。</string>
     <string name="audio_source_voice_call_downlink_description">仅录制对方的声音（仅下行）。</string>
-    <string name="settings_debug_logging_step_warning">上传文件之前，请务必先检查一下文件内容是否涉及您的隐私信息。操作完毕后，请立即禁用此功能。</string>
-    <string name="settings_debug_logging_step_warning_no_redaction">⚠️调试模式已经开启，将不再对日志进行任何隐私优化。</string>
-    <string name="settings_debug_logging_generate_report">生成日志文件</string>
-    <string name="settings_debug_mode">开启调试模式</string>
-    <string name="settings_debug_mode_description">将显示开发者选项，并停止对日志进行隐私优化。</string>
-    <string name="settings_debug_caller_number">请输入用于调试的电话号码</string>
     <string name="settings_copy_version">复制S-S版本号</string>
     <string name="settings_view_licenses">阅读许可协议</string>
     <string name="contact_search_hint">输入姓名或电话号码来搜索…</string>
@@ -119,7 +112,6 @@
     <string name="audio_source_mic_camcorder_description">此选项面向视频录制，将尽可能从拍摄的方向来录取音频。</string>
     <string name="audio_source_mic_voice_recognition_description">处理过的麦克风音频（本是为了语音助手识别优化而留的系统接口）（含降噪）。</string>
     <string name="audio_source_voice_performance_description">高速麦克风模式（此选项专为Live音乐和实时音频而设）。</string>
-    <string name="settings_debug_logging_steps">1、请先确认一下，您想提的问题是否已经有人反馈过了（包括Closed Issues）。如果确认没有，请继续。\n2、打开日志记录功能，然后尝试重现要反馈的错误。\n3、点击下方的“生成日志文件”按钮，将日志保存至您的设备。\n4、点击“反馈到GitHub”按钮，创建新的 Issue，填写相关的信息并上传日志文件。</string>
     <string name="recording_toast_standby">即将录制通话：%1$s。</string>
     <string name="recording_error_server_missing">Scrcpy-server二进制文件缺失，或者SHA256安全校验失败。如果看到此消息，请直接反馈此问题。</string>
 </resources>


### PR DESCRIPTION
Two **release-only** build failures surfaced when dispatching the v1.2.0 release workflow (neither is exercised by `assembleDebug`):

1. **R8 / `minifyReleaseWithR8`** failed on conscrypt's optional legacy platform SSL classes (`com.android.org.conscrypt.SSLParametersImpl`, `org.apache.harmony.xnet.provider.jsse.SSLParametersImpl`) — pulled in transitively by the embedded-ADB TLS layer. Fixed with `-dontwarn` rules in `proguard-rules.pro`.
2. **`lintVitalRelease` / ExtraTranslation** — removing the Developer Options section dropped `settings_debug_*` strings from the default locale, but they remained in 8 translation files (de, es, fr, hu, pl, ru, vi, zh-rCN). Removed the orphaned keys.

Verified locally: `./gradlew :app:assembleRelease -PversionName=1.2.0` → **BUILD SUCCESSFUL** (R8 + lint pass; produces `app-release-unsigned.apk`).