### PR TITLE
fix(release): disable R8 minify (keeps the daemon) + cold-start readiness notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ user-facing debug/bug-report flow and an audio default better suited to voice.
 ### Changed
 - **Removed the hidden "Developer Options"** (the 7-tap unlock, test-call simulator, and the
   redaction-off "Debug mode"). Log **redaction is now always on** and cannot be turned off.
-- After a reboot the app briefly shows **"Call recorder starting up…"**, flipping to **"Ready to record
-  calls"** once recording is actually possible — so you know when a call will be captured.
+- After a reboot **or an app update** the app briefly shows **"Call recorder starting up…"**, flipping
+  to **"Ready to record calls"** once recording is actually possible — so you know when a call will be
+  captured. Only appears while the recorder daemon is cold (nothing shown when it's already warm).
 
 ### Fixed
 - **First call after a reboot now records.** A new bounded post-boot **live call-state listener**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,8 +148,13 @@ android {
     }
     buildTypes {
         release {
-            isMinifyEnabled = true
-            isShrinkResources = true
+            // R8/minification is DISABLED: the privileged recorder daemon is launched out-of-process
+            // by `app_process` via a string classpath reference (com.baba.callvault.server.RecorderServer),
+            // so R8 can't see it as reachable and strips its internals — breaking recording. This matches
+            // the (un-minified) v1.1.x releases. Re-enabling minify would require comprehensive -keep rules
+            // for the whole daemon class graph plus on-device verification.
+            isMinifyEnabled = false
+            isShrinkResources = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
+++ b/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
@@ -10,8 +10,10 @@ package com.baba.callvault
 
 import android.app.Application
 import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.server.RecorderServerLauncher
 import com.baba.callvault.services.debug.DebugNotificationHelper
+import com.baba.callvault.services.recording.RecorderReadinessNotifier
 import com.baba.callvault.system.storage.RetentionScheduler
 import com.baba.callvault.utils.AppLogger
 
@@ -43,8 +45,20 @@ class CallVaultApplication : Application() {
         // WD is off when idle, with no user action. Best-effort; the call path also ensures it on demand.
         if (AppPreferences(applicationContext).isAdbPaired()) {
             Thread {
-                runCatching { RecorderServerLauncher.ensureServerRunning(applicationContext) }
+                // If the daemon is cold at app start (fresh install/update, post-reboot, or after the OS
+                // killed us), surface a "starting up… → ready to record" notification so the user knows
+                // when a call will actually be captured — the same signal the post-reboot path gives.
+                val coldAtStart = !RecorderConnection.isConnected
+                if (coldAtStart) RecorderReadinessNotifier.showStarting(applicationContext)
+
+                val connected = runCatching { RecorderServerLauncher.ensureServerRunning(applicationContext) }
                     .onFailure { AppLogger.w(TAG, "Startup recorder-daemon warmup failed: ${it.message}") }
+                    .getOrDefault(false)
+
+                if (coldAtStart) {
+                    if (connected) RecorderReadinessNotifier.showReadyThenDismiss(applicationContext)
+                    else RecorderReadinessNotifier.dismiss(applicationContext)
+                }
             }.apply { isDaemon = true }.start()
         }
     }

--- a/app/src/main/java/com/baba/callvault/services/recording/RecorderReadinessNotifier.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/RecorderReadinessNotifier.kt
@@ -1,0 +1,99 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.baba.callvault.services.call.CallMonitorService
+import com.baba.callvault.utils.AppLogger
+
+/**
+ * Posts a transient "Call recorder starting up… → Ready to record calls" notification while the
+ * privileged recorder daemon is cold-starting at app launch.
+ *
+ * The daemon is a separate `app_process` that must be (re)launched over ADB whenever it isn't already
+ * running — after a reboot, an app update/reinstall, or whenever the OS killed the app process. Until
+ * it connects (~5–15s, ADB/adbd-bound) a call is detected but CAN'T be recorded, so this tells the
+ * user when it's actually safe to place a call.
+ *
+ * Triggered from the existing startup warm-up ([com.baba.callvault.CallVaultApplication]); it only
+ * appears when the daemon is genuinely cold (so opening the app with a warm daemon shows nothing) and
+ * auto-dismisses shortly after it's ready. The post-reboot path already shows readiness via
+ * [CallMonitorService]'s foreground notification, so this defers to it ([CallMonitorService.isListening])
+ * to avoid a duplicate.
+ */
+object RecorderReadinessNotifier {
+
+    private const val TAG = "CV:RecorderReadiness"
+    private const val CHANNEL_ID = "recorder_readiness"
+    private const val NOTIFICATION_ID = 4715
+
+    /** How long the "ready" notification lingers before auto-dismissing. */
+    private const val READY_LINGER_MS = 6_000L
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /** Daemon is cold and warming up — show "starting up". No-op if the reboot listener owns the UI. */
+    fun showStarting(context: Context) {
+        if (CallMonitorService.isListening) return
+        post(context, ready = false)
+    }
+
+    /** Daemon connected — flip to "ready" and auto-dismiss shortly after. */
+    fun showReadyThenDismiss(context: Context) {
+        if (CallMonitorService.isListening) {
+            dismiss(context)
+            return
+        }
+        post(context, ready = true)
+        mainHandler.postDelayed({ dismiss(context) }, READY_LINGER_MS)
+    }
+
+    fun dismiss(context: Context) {
+        mainHandler.removeCallbacksAndMessages(null)
+        runCatching { NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID) }
+    }
+
+    private fun post(context: Context, ready: Boolean) {
+        createChannel(context)
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setContentTitle(if (ready) "Ready to record calls" else "Call recorder starting up…")
+            .setContentText(
+                if (ready) "The recorder is connected."
+                else "Connecting the recorder — calls won't record until this finishes.",
+            )
+            .setOngoing(!ready)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setVisibility(NotificationCompat.VISIBILITY_SECRET)
+            .build()
+        // notify() silently no-ops without POST_NOTIFICATIONS (Android 13+); acceptable here.
+        runCatching { NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification) }
+            .onFailure { AppLogger.w(TAG, "Failed to post readiness notification: ${it.message}") }
+    }
+
+    private fun createChannel(context: Context) {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Call recorder readiness",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            setShowBadge(false)
+            enableVibration(false)
+            setSound(null, null)
+        }
+        context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+}


### PR DESCRIPTION
## Why

Dispatching the v1.2.0 **Release** build produced a ~15 MB APK whose recorder **daemon was broken**: R8 prunes `RecorderServer` and its graph because the daemon is launched out-of-process by `app_process` via a **string** classpath reference, so R8 can't see it as reachable. The published v1.1.x APKs (79 MB) were never minified — minify was switched on in the "flatten" commit and never released until now.

## Changes

- **Disable R8 for release** (`isMinifyEnabled=false`, `isShrinkResources=false`). Restores the working, un-minified v1.1.x behaviour (~62 MB, daemon intact). Re-enabling minify would need comprehensive `-keep` rules for the whole daemon class graph + on-device verification — a separate effort.
- **`RecorderReadinessNotifier`**: extends the "starting up… → ready to record" signal to **any** cold daemon start (fresh install/update, post-reboot, or after the OS killed the process), driven by the existing app-start warm-up. Only appears while the daemon is cold; defers to `CallMonitorService` post-reboot to avoid a duplicate.

## Verified
- `./gradlew :app:assembleRelease` → BUILD SUCCESSFUL, ~62 MB, `RecorderServer` present in dex, no R8.
- Installed the un-minified release (debug-signed) on-device: records correctly; readiness notification shows on cold start and dismisses when ready.
- (Noted: an "auto-rotate turned on" report during testing was traced to the `monkey` launch command used by the tester, not the app — the app makes no rotation/settings writes.)