### PR TITLE
Optional dialer mode (Phase 1 + engage): InCallService recording + ADB-forced default dialer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -184,6 +184,12 @@ android {
     androidResources {
         generateLocaleConfig = true
     }
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
     lint {
         // Fail the build if any shipped locale is missing a translatable string, or has a
         // stale key that no longer exists in the default resources. This prevents the
@@ -289,4 +295,10 @@ dependencies {
     // pairing falls back to the platform Conscrypt and fails on Android 14+/OEM builds with
     // NoSuchMethodException: com.android.org.conscrypt.Conscrypt.exportKeyingMaterial.
     implementation("org.conscrypt:conscrypt-android:2.5.2")
+
+    // Test harness
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("org.robolectric:robolectric:4.14")
+    testImplementation("androidx.test:core:1.6.1")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,6 +95,21 @@
             </intent-filter>
         </activity>
 
+        <!-- Toggle-able launcher icon for the in-app dialpad; enabled only while dialer mode is on. -->
+        <activity-alias
+            android:name=".dialer.DialerLauncherAlias"
+            android:targetActivity=".MainActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:label="@string/dialer_launcher_label"
+            android:icon="@mipmap/ic_launcher">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data android:name="cv.open_dialer" android:value="true" />
+        </activity-alias>
+
         <!-- Foreground service that drives ADB wireless pairing via a notification -->
         <service
             android:name=".integrations.adb.AdbPairingService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.CallVault">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,6 +71,28 @@
                 <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" /> <!-- Show "Additional settings in the app" button in Settings App Info -> notifications -->
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!--
+                Default-dialer qualification: Android only offers ROLE_DIALER to an app that declares
+                an activity handling ACTION_DIAL (with and without a tel: number) and VIEW tel:. Without
+                these, the system role-request dialog opens but the role can never be granted. These
+                make CallVault a valid default-phone-app candidate; MainActivity routes a dial intent to
+                the in-app dialpad.
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.DIAL" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.DIAL" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="tel" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="tel" />
+            </intent-filter>
         </activity>
 
         <!-- Foreground service that drives ADB wireless pairing via a notification -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -216,7 +216,9 @@
             android:name=".ui.dialer.InCallActivity"
             android:exported="false"
             android:showOnLockScreen="true"
-            android:turnScreenOn="true" />
+            android:turnScreenOn="true"
+            android:launchMode="singleTask"
+            android:excludeFromRecents="true" />
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,18 @@
     -->
     <uses-permission android:name="android.permission.READ_CALL_LOG" tools:ignore="SmsAndCallLogPolicy" />
 
+    <!-- Default-dialer role: place calls and observe Telecom call state via InCallService. -->
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <!-- Required for the full-screen in-call UI notification (lock-screen call HUD). -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <!--
+        CALL_PHONE implies android.hardware.telephony, which is unavailable on Chrome OS / large-screen
+        devices. Mark it optional so the app remains installable on those form factors (we degrade
+        gracefully without the dialer role).
+    -->
+    <uses-feature android:name="android.hardware.telephony" android:required="false" />
+
     <!-- Recording Foreground Job -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:ignore="ForegroundServicesPolicy" />
     <!-- Android 14+ Onwards (API 34) -->
@@ -172,6 +184,39 @@
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="Call recording: listen for call state after reboot to record reliably." />
         </service>
+
+        <!--
+            InCallService: receives Telecom Call objects when CallVault holds the default-dialer
+            role. Maps call states to CallEvents (via TELECOM detection mode) and updates
+            CallStateRepository for the in-call UI. Emergency calls are never blocked — the service
+            is a pure observer.
+            android:permission guards binding so only the Telecom subsystem can bind.
+        -->
+        <service
+            android:name=".dialer.CallVaultInCallService"
+            android:exported="true"
+            android:permission="android.permission.BIND_INCALL_SERVICE"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="In-call UI and call-event observation for the default dialer role." />
+            <meta-data android:name="android.telecom.IN_CALL_SERVICE_UI" android:value="true" />
+            <meta-data android:name="android.telecom.IN_CALL_SERVICE_RINGING" android:value="true" />
+            <intent-filter>
+                <action android:name="android.telecom.InCallService" />
+            </intent-filter>
+        </service>
+
+        <!--
+            In-call UI activity — stub (Task 8 provides the full Compose implementation).
+            Launched by CallVaultInCallService when a call arrives; shown over the lock screen
+            via FLAG_SHOW_WHEN_LOCKED / FLAG_TURN_SCREEN_ON set programmatically in Task 8.
+        -->
+        <activity
+            android:name=".ui.dialer.InCallActivity"
+            android:exported="false"
+            android:showOnLockScreen="true"
+            android:turnScreenOn="true" />
 
     </application>
 

--- a/app/src/main/java/com/baba/callvault/AppNavigationScreen.kt
+++ b/app/src/main/java/com/baba/callvault/AppNavigationScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.onboarding.OnboardingStatus
 import com.baba.callvault.ui.navigation.AppScreen
+import com.baba.callvault.ui.dialer.DialpadScreen
 import com.baba.callvault.ui.screens.DisclaimerScreen
 import com.baba.callvault.ui.screens.HomeScreen
 import com.baba.callvault.ui.screens.PermissionsScreen
@@ -153,7 +154,8 @@ fun AppNavigationScreen() {
             )
 
             AppScreen.Home -> HomeScreen(
-                onOpenSettings = { appNavViewModel.navigateTo(AppScreen.Settings) }
+                onOpenSettings = { appNavViewModel.navigateTo(AppScreen.Settings) },
+                onOpenDialpad = { appNavViewModel.navigateTo(AppScreen.Dialer) }
             )
 
             AppScreen.Settings -> {
@@ -163,6 +165,11 @@ fun AppNavigationScreen() {
                     viewModel = settingsViewModel,
                     onBack = { appNavViewModel.navigateBack() }
                 )
+            }
+
+            AppScreen.Dialer -> {
+                BackHandler { appNavViewModel.navigateBack() }
+                DialpadScreen(onBack = { appNavViewModel.navigateBack() })
             }
         }
     }

--- a/app/src/main/java/com/baba/callvault/AppNavigationScreen.kt
+++ b/app/src/main/java/com/baba/callvault/AppNavigationScreen.kt
@@ -52,7 +52,7 @@ import com.baba.callvault.ui.viewmodels.SettingsViewModel
  *   granting a permission in the system Settings app).
  */
 @Composable
-fun AppNavigationScreen(openDialer: Boolean = false) {
+fun AppNavigationScreen(openDialer: Boolean = false, onDialerHandled: () -> Unit = {}) {
 
     val activityContext = LocalContext.current
 
@@ -98,10 +98,14 @@ fun AppNavigationScreen(openDialer: Boolean = false) {
         }
     }
 
-    // When the activity was launched via the DialerLauncherAlias, route directly to the dialpad.
-    // The key is a stable Boolean so this fires exactly once on first composition.
+    // When the activity was launched (or brought to front) via the DialerLauncherAlias, route
+    // directly to the dialpad. After acting, onDialerHandled() resets the flag so a subsequent
+    // alias tap can re-fire this effect via singleTop / onNewIntent.
     LaunchedEffect(openDialer) {
-        if (openDialer) appNavViewModel.navigateTo(AppScreen.Dialer)
+        if (openDialer) {
+            appNavViewModel.navigateTo(AppScreen.Dialer)
+            onDialerHandled()
+        }
     }
 
     // resolveScreen reads the flow-backed onboardingStatus - no direct preference reads here,

--- a/app/src/main/java/com/baba/callvault/AppNavigationScreen.kt
+++ b/app/src/main/java/com/baba/callvault/AppNavigationScreen.kt
@@ -126,6 +126,7 @@ fun AppNavigationScreen(openDialer: Boolean = false, onDialerHandled: () -> Unit
             if (event == Lifecycle.Event.ON_RESUME) {
                 appNavViewModel.refresh()
                 settingsViewModel.refresh()
+                settingsViewModel.reassertDialerDefaultIfNeeded()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/java/com/baba/callvault/AppNavigationScreen.kt
+++ b/app/src/main/java/com/baba/callvault/AppNavigationScreen.kt
@@ -52,7 +52,7 @@ import com.baba.callvault.ui.viewmodels.SettingsViewModel
  *   granting a permission in the system Settings app).
  */
 @Composable
-fun AppNavigationScreen() {
+fun AppNavigationScreen(openDialer: Boolean = false) {
 
     val activityContext = LocalContext.current
 
@@ -96,6 +96,12 @@ fun AppNavigationScreen() {
         if (newStatus != onboardingStatus) {
             appNavViewModel.refresh()
         }
+    }
+
+    // When the activity was launched via the DialerLauncherAlias, route directly to the dialpad.
+    // The key is a stable Boolean so this fires exactly once on first composition.
+    LaunchedEffect(openDialer) {
+        if (openDialer) appNavViewModel.navigateTo(AppScreen.Dialer)
     }
 
     // resolveScreen reads the flow-backed onboardingStatus - no direct preference reads here,

--- a/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
+++ b/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
@@ -32,8 +32,10 @@ class CallVaultApplication : Application() {
 
         // Initialise the process-wide call-event routing singleton and set detection mode from
         // the saved preference (BROADCAST = recording-only mode; TELECOM = dialer mode).
-        CallDetection.init(applicationContext)
-        CallDetection.setMode(AppPreferences(applicationContext).isDialerModeEnabled())
+        runCatching {
+            CallDetection.init(applicationContext)
+            CallDetection.setMode(AppPreferences(applicationContext).isDialerModeEnabled())
+        }.onFailure { AppLogger.e(TAG, "CallDetection init failed", it) }
 
         // Re-assert the "debug logging is on" reminder if the user left logging enabled across an
         // app restart, so the nudge to turn it back off survives process death.

--- a/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
+++ b/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
@@ -9,6 +9,7 @@
 package com.baba.callvault
 
 import android.app.Application
+import com.baba.callvault.calls.CallDetection
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.server.RecorderServerLauncher
@@ -28,6 +29,11 @@ class CallVaultApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         AppLogger.init(applicationContext)
+
+        // Initialise the process-wide call-event routing singleton and set detection mode from
+        // the saved preference (BROADCAST = recording-only mode; TELECOM = dialer mode).
+        CallDetection.init(applicationContext)
+        CallDetection.setMode(AppPreferences(applicationContext).isDialerModeEnabled())
 
         // Re-assert the "debug logging is on" reminder if the user left logging enabled across an
         // app restart, so the nudge to turn it back off survives process death.

--- a/app/src/main/java/com/baba/callvault/MainActivity.kt
+++ b/app/src/main/java/com/baba/callvault/MainActivity.kt
@@ -8,10 +8,14 @@
 
 package com.baba.callvault
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 
 /**
  * MainActivity is the single Android Activity entry point for CallVault.
@@ -20,14 +24,38 @@ import androidx.appcompat.app.AppCompatActivity
  * Its **only** responsibility is to attach the Compose content tree to the window
  * and draw edge-to-edge (the navy background extends behind the transparent system bars).
  *
+ * `android:launchMode="singleTop"` (set in the manifest) ensures that tapping the
+ * DialerLauncherAlias while the app is already open delivers the intent via [onNewIntent]
+ * rather than creating a new instance, so the dialpad routing works in both cold and warm starts.
  */
 class MainActivity : AppCompatActivity() {
+
+    /**
+     * Reactive flag: true while the app should route to the dialpad.
+     * Reset to false by [AppNavigationScreen] after it has acted on the signal,
+     * so a subsequent alias tap re-fires the effect correctly.
+     */
+    private var openDialer by mutableStateOf(false)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        val openDialer = intent?.component?.shortClassName?.endsWith("DialerLauncherAlias") == true
+        openDialer = isDialerLaunch(intent)
         setContent {
-            AppNavigationScreen(openDialer = openDialer)
+            AppNavigationScreen(
+                openDialer = openDialer,
+                onDialerHandled = { openDialer = false }
+            )
         }
     }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        if (isDialerLaunch(intent)) openDialer = true
+    }
+
+    /** Returns true when [intent] was fired from the DialerLauncherAlias component. */
+    private fun isDialerLaunch(intent: Intent?): Boolean =
+        intent?.component?.shortClassName?.endsWith("DialerLauncherAlias") == true
 }

--- a/app/src/main/java/com/baba/callvault/MainActivity.kt
+++ b/app/src/main/java/com/baba/callvault/MainActivity.kt
@@ -25,8 +25,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        val openDialer = intent?.component?.shortClassName?.endsWith("DialerLauncherAlias") == true
         setContent {
-            AppNavigationScreen()
+            AppNavigationScreen(openDialer = openDialer)
         }
     }
 }

--- a/app/src/main/java/com/baba/callvault/calls/CallDetection.kt
+++ b/app/src/main/java/com/baba/callvault/calls/CallDetection.kt
@@ -16,6 +16,8 @@ object CallDetection {
     lateinit var router: CallEventRouter
         private set
 
+    val isInitialized: Boolean get() = ::router.isInitialized
+
     fun init(context: Context) {
         if (::router.isInitialized) return
         val mgr = CallSessionManager.getInstance(context)
@@ -24,5 +26,10 @@ object CallDetection {
 
     fun setMode(dialer: Boolean) {
         router.setActiveMode(if (dialer) DetectionMode.TELECOM else DetectionMode.BROADCAST)
+    }
+
+    /** Emits a broadcast-path event into the router without allocating a source wrapper. No-op if not yet initialized. */
+    fun emitBroadcast(event: CallEvent) {
+        if (::router.isInitialized) router.submit(DetectionMode.BROADCAST, event)
     }
 }

--- a/app/src/main/java/com/baba/callvault/calls/CallDetection.kt
+++ b/app/src/main/java/com/baba/callvault/calls/CallDetection.kt
@@ -1,0 +1,28 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.calls
+
+import android.content.Context
+import com.baba.callvault.services.call.CallSessionManager
+
+/** Process-wide holder so broadcast + Telecom sources share one router and one sink. */
+object CallDetection {
+    lateinit var router: CallEventRouter
+        private set
+
+    fun init(context: Context) {
+        if (::router.isInitialized) return
+        val mgr = CallSessionManager.getInstance(context)
+        router = CallEventRouter(sink = { event -> mgr.onCallEvent(event) })
+    }
+
+    fun setMode(dialer: Boolean) {
+        router.setActiveMode(if (dialer) DetectionMode.TELECOM else DetectionMode.BROADCAST)
+    }
+}

--- a/app/src/main/java/com/baba/callvault/calls/CallEvent.kt
+++ b/app/src/main/java/com/baba/callvault/calls/CallEvent.kt
@@ -1,0 +1,13 @@
+package com.baba.callvault.calls
+
+enum class CallDirection { INCOMING, OUTGOING, UNKNOWN }
+
+/** A call-lifecycle event normalized across detection sources (broadcast vs Telecom). */
+data class CallEvent(
+    val phase: Phase,
+    val number: String?,
+    val direction: CallDirection,
+    val isEmergency: Boolean,
+) {
+    enum class Phase { RINGING, DIALING, ACTIVE, ENDED }
+}

--- a/app/src/main/java/com/baba/callvault/calls/CallEventRouter.kt
+++ b/app/src/main/java/com/baba/callvault/calls/CallEventRouter.kt
@@ -1,0 +1,19 @@
+package com.baba.callvault.calls
+
+import java.util.concurrent.atomic.AtomicReference
+
+enum class DetectionMode { BROADCAST, TELECOM }
+
+/**
+ * Single sink for normalized call events. Only events from the currently active detection mode are
+ * forwarded; the inactive source is ignored. This enforces broadcast↔Telecom mutual exclusion.
+ */
+class CallEventRouter(private val sink: (CallEvent) -> Unit) {
+    private val active = AtomicReference(DetectionMode.BROADCAST)
+
+    fun setActiveMode(mode: DetectionMode) { active.set(mode) }
+
+    fun submit(source: DetectionMode, event: CallEvent) {
+        if (source == active.get()) sink(event)
+    }
+}

--- a/app/src/main/java/com/baba/callvault/calls/CallEventSource.kt
+++ b/app/src/main/java/com/baba/callvault/calls/CallEventSource.kt
@@ -1,0 +1,12 @@
+package com.baba.callvault.calls
+
+/** Receives normalized call events from whichever source is active. */
+fun interface CallEventListener {
+    fun onCallEvent(event: CallEvent)
+}
+
+/** A source of normalized call events. Exactly one source is active at a time (see CallEventRouter). */
+interface CallEventSource {
+    fun start(listener: CallEventListener)
+    fun stop()
+}

--- a/app/src/main/java/com/baba/callvault/calls/CallStateRepository.kt
+++ b/app/src/main/java/com/baba/callvault/calls/CallStateRepository.kt
@@ -1,0 +1,25 @@
+package com.baba.callvault.calls
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class UiCall(
+    val number: String?,
+    val phase: CallEvent.Phase,
+    val direction: CallDirection,
+    val isEmergency: Boolean,
+    val isRecording: Boolean,
+)
+
+/** Process-wide current-call state, shared between the InCallService and the in-call UI. */
+object CallStateRepository {
+    private val _current = MutableStateFlow<UiCall?>(null)
+    val current: StateFlow<UiCall?> = _current.asStateFlow()
+
+    fun update(call: UiCall?) { _current.value = call }
+
+    fun setRecording(active: Boolean) {
+        _current.value = _current.value?.copy(isRecording = active)
+    }
+}

--- a/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
+++ b/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
@@ -96,6 +96,7 @@ class AppPreferences(context: Context) {
         // OFF by default: when false the existing call-detection source (TelecomManager/PhoneStateListener)
         // is used unchanged. When true the dialer-mode detection source is active instead.
         const val DIALER_MODE_ENABLED = false
+        val PRIOR_DEFAULT_DIALER: String? = null
 
         // --- Persistent recorder server (CallVault Plan 5) ---
         // OFF by default: when false the existing local recording path runs unchanged. When true the
@@ -157,6 +158,7 @@ class AppPreferences(context: Context) {
 
         // --- Dialer Mode ---
         DIALER_MODE_ENABLED("dialer_mode_enabled"),
+        PRIOR_DEFAULT_DIALER("prior_default_dialer"),
 
         // --- Persistent recorder server (CallVault Plan 5) ---
         PERSISTENT_SERVER_ENABLED("persistent_server_enabled"),
@@ -318,6 +320,16 @@ class AppPreferences(context: Context) {
 
     /** Sets whether the dialer-mode call-detection source is enabled. */
     fun setDialerModeEnabled(enabled: Boolean) = setBoolean(Key.DIALER_MODE_ENABLED, enabled)
+
+    /** Gets the package name of the prior default dialer to restore when dialer mode is disabled. */
+    fun getPriorDefaultDialer(): String? = getString(Key.PRIOR_DEFAULT_DIALER, DefaultsValue.PRIOR_DEFAULT_DIALER)
+
+    /** Sets the prior default dialer package name (or null to clear). */
+    fun setPriorDefaultDialer(pkg: String?) {
+        prefs.edit().apply {
+            if (pkg == null) remove(Key.PRIOR_DEFAULT_DIALER.id) else putString(Key.PRIOR_DEFAULT_DIALER.id, pkg)
+        }.apply()
+    }
 
     // -------- Storage & General --------
 

--- a/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
+++ b/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
@@ -92,6 +92,11 @@ class AppPreferences(context: Context) {
         // not shown again on every launch (a live connection only exists per-process).
         const val ADB_PAIRED = false
 
+        // --- Dialer Mode ---
+        // OFF by default: when false the existing call-detection source (TelecomManager/PhoneStateListener)
+        // is used unchanged. When true the dialer-mode detection source is active instead.
+        const val DIALER_MODE_ENABLED = false
+
         // --- Persistent recorder server (CallVault Plan 5) ---
         // OFF by default: when false the existing local recording path runs unchanged. When true the
         // recording layer drives the detached privileged daemon (RecorderServer) over binder instead.
@@ -149,6 +154,9 @@ class AppPreferences(context: Context) {
 
         // --- ADB ---
         ADB_PAIRED("adb_paired"),
+
+        // --- Dialer Mode ---
+        DIALER_MODE_ENABLED("dialer_mode_enabled"),
 
         // --- Persistent recorder server (CallVault Plan 5) ---
         PERSISTENT_SERVER_ENABLED("persistent_server_enabled"),
@@ -298,6 +306,18 @@ class AppPreferences(context: Context) {
 
     /** Sets the "turn Wireless debugging off when the daemon is connected" policy. */
     fun setWdDisableWhenIdle(enabled: Boolean) = setBoolean(Key.WD_DISABLE_WHEN_IDLE, enabled)
+
+    // -------- Dialer Mode --------
+
+    /**
+     * Whether the dialer-mode call-detection source is enabled. OFF by default: when false the
+     * existing detection source (TelecomManager/PhoneStateListener) is used unchanged; when true
+     * the dialer-mode source is active instead.
+     */
+    fun isDialerModeEnabled() = getBoolean(Key.DIALER_MODE_ENABLED, DefaultsValue.DIALER_MODE_ENABLED)
+
+    /** Sets whether the dialer-mode call-detection source is enabled. */
+    fun setDialerModeEnabled(enabled: Boolean) = setBoolean(Key.DIALER_MODE_ENABLED, enabled)
 
     // -------- Storage & General --------
 

--- a/app/src/main/java/com/baba/callvault/dialer/BroadcastCallEventSource.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/BroadcastCallEventSource.kt
@@ -1,0 +1,18 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.calls.CallEventRouter
+import com.baba.callvault.calls.DetectionMode
+
+/** Adapts the existing PhoneStateReceiver/CallMonitorService path to the CallEventRouter. */
+class BroadcastCallEventSource(private val router: CallEventRouter) {
+    fun emit(event: CallEvent) = router.submit(DetectionMode.BROADCAST, event)
+}

--- a/app/src/main/java/com/baba/callvault/dialer/CallActions.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/CallActions.kt
@@ -1,0 +1,71 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+import android.telecom.Call
+import android.telecom.CallAudioState
+import android.telecom.InCallService
+import android.telecom.VideoProfile
+
+/**
+ * Process-wide bridge that [CallVaultInCallService] populates with the current [Call] and a
+ * reference to itself. Audio-routing APIs (mute, speaker) live on [InCallService], not [Call],
+ * so both references are needed.
+ *
+ * [com.baba.callvault.ui.dialer.InCallViewModel] delegates every call action through this object,
+ * keeping the ViewModel free of Telecom compile-time dependencies.
+ *
+ * Thread-safety: fields are @Volatile; all writes originate from the main thread (Telecom
+ * callbacks); reads from the UI thread are therefore always consistent.
+ */
+object CallActions {
+    @Volatile var activeCall: Call? = null
+    @Volatile var serviceRef: InCallService? = null
+
+    fun answer() {
+        activeCall?.answer(VideoProfile.STATE_AUDIO_ONLY)
+    }
+
+    fun reject() {
+        activeCall?.reject(false, null)
+    }
+
+    fun end() {
+        activeCall?.disconnect()
+    }
+
+    fun toggleHold() {
+        val call = activeCall ?: return
+        when (call.state) {
+            Call.STATE_ACTIVE  -> call.hold()
+            Call.STATE_HOLDING -> call.unhold()
+        }
+    }
+
+    fun setMuted(muted: Boolean) {
+        serviceRef?.setMuted(muted)
+    }
+
+    fun setSpeaker(on: Boolean) {
+        serviceRef?.setAudioRoute(
+            if (on) CallAudioState.ROUTE_SPEAKER else CallAudioState.ROUTE_EARPIECE
+        )
+    }
+
+    fun sendDtmfTone(digit: Char) {
+        activeCall?.playDtmfTone(digit)
+        activeCall?.stopDtmfTone()
+    }
+
+    /** Called by [CallVaultInCallService.onCallRemoved] to drop stale references. */
+    fun clear() {
+        activeCall = null
+        serviceRef = null
+    }
+}

--- a/app/src/main/java/com/baba/callvault/dialer/CallPlacer.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/CallPlacer.kt
@@ -1,0 +1,37 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.telecom.TelecomManager
+import androidx.core.content.ContextCompat
+
+class CallPlacer(private val context: Context) {
+
+    fun place(number: String) {
+        if (!isDialable(number)) return
+        val tm = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
+        val uri = Uri.fromParts("tel", normalize(number), null)
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE)
+            == PackageManager.PERMISSION_GRANTED
+        ) {
+            tm.placeCall(uri, null) // emergency numbers handled by the platform
+        }
+    }
+
+    companion object {
+        fun isDialable(input: String): Boolean = normalize(input).isNotEmpty()
+
+        fun normalize(input: String): String =
+            input.trim().filter { it.isDigit() || it == '+' || it == '*' || it == '#' }
+    }
+}

--- a/app/src/main/java/com/baba/callvault/dialer/CallPlacer.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/CallPlacer.kt
@@ -10,6 +10,7 @@ package com.baba.callvault.dialer
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.telecom.TelecomManager
@@ -19,13 +20,21 @@ class CallPlacer(private val context: Context) {
 
     fun place(number: String) {
         if (!isDialable(number)) return
-        val tm = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
         val uri = Uri.fromParts("tel", normalize(number), null)
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE)
             == PackageManager.PERMISSION_GRANTED
         ) {
-            tm.placeCall(uri, null) // emergency numbers handled by the platform
+            val tm = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
+            runCatching { tm.placeCall(uri, null) }.onFailure { fallbackToDial(uri) }
+        } else {
+            fallbackToDial(uri)
         }
+    }
+
+    private fun fallbackToDial(uri: Uri) {
+        context.startActivity(
+            Intent(Intent.ACTION_DIAL, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
@@ -1,0 +1,64 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+import android.content.Intent
+import android.telecom.Call
+import android.telecom.InCallService
+import com.baba.callvault.calls.CallDetection
+import com.baba.callvault.calls.CallStateRepository
+import com.baba.callvault.calls.UiCall
+import com.baba.callvault.ui.dialer.InCallActivity
+
+/**
+ * Default-dialer [InCallService]: receives [Call] objects from Telecom, maps their states to
+ * [com.baba.callvault.calls.CallEvent]s via [TelecomCallEventSource], keeps [CallStateRepository]
+ * up to date, and launches [InCallActivity] when a call arrives.
+ *
+ * Emergency calls are never blocked or filtered — the service is a pure observer.
+ * [CallDetection.router] is guaranteed to be initialized before this service starts because
+ * [com.baba.callvault.CallVaultApplication.onCreate] initializes it before any component binds.
+ */
+class CallVaultInCallService : InCallService() {
+
+    private val callbacks = mutableMapOf<Call, Call.Callback>()
+
+    override fun onCallAdded(call: Call) {
+        val cb = object : Call.Callback() {
+            override fun onStateChanged(c: Call, state: Int) = publish(c)
+        }
+        callbacks[call] = cb
+        call.registerCallback(cb)
+        publish(call)
+        startActivity(
+            Intent(this, InCallActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+    }
+
+    override fun onCallRemoved(call: Call) {
+        callbacks.remove(call)?.let { call.unregisterCallback(it) }
+        TelecomCallEventSource.submit(CallDetection.router, call) // ENDED
+        CallStateRepository.update(null)
+    }
+
+    private fun publish(call: Call) {
+        TelecomCallEventSource.submit(CallDetection.router, call)
+        val d = call.details
+        CallStateRepository.update(
+            UiCall(
+                number = TelecomCallEventSource.numberOf(d),
+                phase = TelecomCallEventSource.phaseOf(call.state),
+                direction = TelecomCallEventSource.directionOf(d),
+                isEmergency = (d.callProperties and Call.Details.PROPERTY_EMERGENCY_CALLBACK_MODE) != 0,
+                isRecording = CallStateRepository.current.value?.isRecording ?: false,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
@@ -46,11 +46,13 @@ class CallVaultInCallService : InCallService() {
     }
 
     override fun onCallRemoved(call: Call) {
-        CallActions.clear()
+        if (call === CallActions.activeCall) {
+            CallActions.clear()
+            CallStateRepository.update(null)
+        }
         callbacks.remove(call)?.let { call.unregisterCallback(it) }
         if (!CallDetection.isInitialized) return
         TelecomCallEventSource.submit(CallDetection.router, call) // ENDED
-        CallStateRepository.update(null)
     }
 
     private fun publish(call: Call) {

--- a/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
@@ -30,6 +30,12 @@ class CallVaultInCallService : InCallService() {
 
     private val callbacks = mutableMapOf<Call, Call.Callback>()
 
+    override fun onDestroy() {
+        super.onDestroy()
+        // Prevent leaking the service reference held in CallActions after the service is unbound.
+        CallActions.clear()
+    }
+
     override fun onCallAdded(call: Call) {
         val cb = object : Call.Callback() {
             override fun onStateChanged(c: Call, state: Int) = publish(c)

--- a/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
@@ -44,11 +44,13 @@ class CallVaultInCallService : InCallService() {
 
     override fun onCallRemoved(call: Call) {
         callbacks.remove(call)?.let { call.unregisterCallback(it) }
+        if (!CallDetection.isInitialized) return
         TelecomCallEventSource.submit(CallDetection.router, call) // ENDED
         CallStateRepository.update(null)
     }
 
     private fun publish(call: Call) {
+        if (!CallDetection.isInitialized) return
         TelecomCallEventSource.submit(CallDetection.router, call)
         val d = call.details
         CallStateRepository.update(

--- a/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt
@@ -14,6 +14,7 @@ import android.telecom.InCallService
 import com.baba.callvault.calls.CallDetection
 import com.baba.callvault.calls.CallStateRepository
 import com.baba.callvault.calls.UiCall
+import com.baba.callvault.dialer.CallActions
 import com.baba.callvault.ui.dialer.InCallActivity
 
 /**
@@ -35,6 +36,8 @@ class CallVaultInCallService : InCallService() {
         }
         callbacks[call] = cb
         call.registerCallback(cb)
+        CallActions.activeCall = call
+        CallActions.serviceRef = this
         publish(call)
         startActivity(
             Intent(this, InCallActivity::class.java)
@@ -43,6 +46,7 @@ class CallVaultInCallService : InCallService() {
     }
 
     override fun onCallRemoved(call: Call) {
+        CallActions.clear()
         callbacks.remove(call)?.let { call.unregisterCallback(it) }
         if (!CallDetection.isInitialized) return
         TelecomCallEventSource.submit(CallDetection.router, call) // ENDED

--- a/app/src/main/java/com/baba/callvault/dialer/DialerDefaultEnforcer.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/DialerDefaultEnforcer.kt
@@ -29,6 +29,10 @@ class DialerDefaultEnforcer(
     /** Make CallVault the Telecom default dialer + grant CALL_PHONE. Returns true if it actually became default. */
     fun enforce(): Boolean {
         if (roleController.isDefaultDialer()) return true
+        if (!AdbShell.ensureConnected(context)) {
+            AppLogger.w(TAG, "enforce() skipped: ADB connection unavailable")
+            return false
+        }
         // Remember who held it so we can restore on relinquish (only if it wasn't already us).
         @Suppress("DEPRECATION")
         val current = telecom?.defaultDialerPackage
@@ -47,6 +51,10 @@ class DialerDefaultEnforcer(
         val prior = prefs.getPriorDefaultDialer()
             ?: @Suppress("DEPRECATION") telecom?.systemDialerPackage
         if (prior != null && prior != pkg) {
+            if (!AdbShell.ensureConnected(context)) {
+                AppLogger.w(TAG, "relinquish() skipped restore: ADB connection unavailable")
+                return
+            }
             AdbShell.runShellCommand(context, DialerCommands.restore(prior))
         }
         prefs.setPriorDefaultDialer(null)

--- a/app/src/main/java/com/baba/callvault/dialer/DialerDefaultEnforcer.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/DialerDefaultEnforcer.kt
@@ -11,6 +11,8 @@ object DialerCommands {
     fun setDefault(pkg: String) = "cmd telecom set-default-dialer $pkg"
     fun grantCallPhone(pkg: String) = "pm grant $pkg android.permission.CALL_PHONE"
     fun restore(priorPkg: String) = "cmd telecom set-default-dialer $priorPkg"
+    /** Combines set-default + grant into ONE shell invocation (avoids a second ADB stream on flaky links). */
+    fun setDefaultAndGrant(pkg: String) = "cmd telecom set-default-dialer $pkg ; pm grant $pkg android.permission.CALL_PHONE"
 }
 
 /**
@@ -39,8 +41,7 @@ class DialerDefaultEnforcer(
         if (current != null && current != pkg && prefs.getPriorDefaultDialer() == null) {
             prefs.setPriorDefaultDialer(current)
         }
-        AdbShell.runShellCommand(context, DialerCommands.setDefault(pkg))
-        AdbShell.runShellCommand(context, DialerCommands.grantCallPhone(pkg))
+        AdbShell.runShellCommand(context, DialerCommands.setDefaultAndGrant(pkg))
         val ok = roleController.isDefaultDialer()
         AppLogger.i(TAG, "enforce() default-dialer now=${if (ok) pkg else current} ok=$ok")
         return ok

--- a/app/src/main/java/com/baba/callvault/dialer/DialerDefaultEnforcer.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/DialerDefaultEnforcer.kt
@@ -1,0 +1,57 @@
+package com.baba.callvault.dialer
+
+import android.content.Context
+import android.telecom.TelecomManager
+import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.integrations.adb.AdbShell
+import com.baba.callvault.utils.AppLogger
+
+/** Pure shell-command strings (unit-testable). */
+object DialerCommands {
+    fun setDefault(pkg: String) = "cmd telecom set-default-dialer $pkg"
+    fun grantCallPhone(pkg: String) = "pm grant $pkg android.permission.CALL_PHONE"
+    fun restore(priorPkg: String) = "cmd telecom set-default-dialer $priorPkg"
+}
+
+/**
+ * Forces CallVault as the Telecom default dialer via the embedded ADB shell, because OEMs (OxygenOS)
+ * grant ROLE_DIALER but don't propagate it into Telecom's default-dialer cache. Blocking; call OFF the
+ * main thread.
+ */
+class DialerDefaultEnforcer(
+    private val context: Context,
+    private val prefs: AppPreferences,
+    private val roleController: DialerRoleController,
+) {
+    private val pkg = context.packageName
+    private val telecom = context.getSystemService(Context.TELECOM_SERVICE) as? TelecomManager
+
+    /** Make CallVault the Telecom default dialer + grant CALL_PHONE. Returns true if it actually became default. */
+    fun enforce(): Boolean {
+        if (roleController.isDefaultDialer()) return true
+        // Remember who held it so we can restore on relinquish (only if it wasn't already us).
+        @Suppress("DEPRECATION")
+        val current = telecom?.defaultDialerPackage
+        if (current != null && current != pkg && prefs.getPriorDefaultDialer() == null) {
+            prefs.setPriorDefaultDialer(current)
+        }
+        AdbShell.runShellCommand(context, DialerCommands.setDefault(pkg))
+        AdbShell.runShellCommand(context, DialerCommands.grantCallPhone(pkg))
+        val ok = roleController.isDefaultDialer()
+        AppLogger.i(TAG, "enforce() default-dialer now=${if (ok) pkg else current} ok=$ok")
+        return ok
+    }
+
+    /** Restore the previously-stored default dialer (best-effort) and clear the stored value. */
+    fun relinquish() {
+        val prior = prefs.getPriorDefaultDialer()
+            ?: @Suppress("DEPRECATION") telecom?.systemDialerPackage
+        if (prior != null && prior != pkg) {
+            AdbShell.runShellCommand(context, DialerCommands.restore(prior))
+        }
+        prefs.setPriorDefaultDialer(null)
+        AppLogger.i(TAG, "relinquish() restored default dialer to $prior")
+    }
+
+    private companion object { const val TAG = "CV:DialerEnforcer" }
+}

--- a/app/src/main/java/com/baba/callvault/dialer/DialerLauncherIcon.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/DialerLauncherIcon.kt
@@ -1,0 +1,23 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+
+/** Shows/hides the "CallVault Dialer" launcher icon (an activity-alias) with dialer mode. */
+object DialerLauncherIcon {
+    fun setEnabled(context: Context, enabled: Boolean) {
+        val alias = ComponentName(context.packageName, "com.baba.callvault.dialer.DialerLauncherAlias")
+        val state = if (enabled) PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        else PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        context.packageManager.setComponentEnabledSetting(alias, state, PackageManager.DONT_KILL_APP)
+    }
+}

--- a/app/src/main/java/com/baba/callvault/dialer/DialerModeState.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/DialerModeState.kt
@@ -1,0 +1,30 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+/**
+ * Pure reconciliation logic: derives the effective dialer-mode state from the user preference
+ * and the actual RoleManager role status. Keeping this as a plain object makes it trivially
+ * testable without Android instrumentation.
+ */
+object DialerModeState {
+
+    /**
+     * Dialer mode is only active when the user has opted in **and** the app still holds the role.
+     * If the role was revoked behind the user's back, effective() returns false even though the
+     * preference is still ON — the banner (see [shouldShowRoleLostBanner]) surfaces that gap.
+     */
+    fun effective(prefOn: Boolean, roleHeld: Boolean): Boolean = prefOn && roleHeld
+
+    /**
+     * Returns true when the user's preference is ON but the role is no longer held, signalling
+     * that a role-loss banner should be shown so the user can re-grant the role.
+     */
+    fun shouldShowRoleLostBanner(prefOn: Boolean, roleHeld: Boolean): Boolean = prefOn && !roleHeld
+}

--- a/app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt
@@ -1,0 +1,28 @@
+package com.baba.callvault.dialer
+
+import android.app.role.RoleManager
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+
+/** Wraps RoleManager for the default-dialer (ROLE_DIALER) role. Truth = isRoleHeld, never a preference. */
+class DialerRoleController(private val context: Context) {
+
+    private val roleManager: RoleManager? =
+        context.getSystemService(Context.ROLE_SERVICE) as? RoleManager
+
+    fun isDefaultDialer(): Boolean {
+        val rm = roleManager ?: return false
+        return rm.isRoleAvailable(RoleManager.ROLE_DIALER) && rm.isRoleHeld(RoleManager.ROLE_DIALER)
+    }
+
+    /** Intent to ask the user to make CallVault the default phone app, or null if already held/unavailable. */
+    fun requestRoleIntent(): Intent? {
+        val rm = roleManager ?: return null
+        if (!rm.isRoleAvailable(RoleManager.ROLE_DIALER) || rm.isRoleHeld(RoleManager.ROLE_DIALER)) return null
+        return rm.createRequestRoleIntent(RoleManager.ROLE_DIALER)
+    }
+
+    /** We cannot drop the role programmatically; send the user to default-apps settings. */
+    fun releaseRoleHint(): Intent = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+}

--- a/app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt
@@ -31,10 +31,18 @@ class DialerRoleController(private val context: Context) {
         return tm.defaultDialerPackage == context.packageName
     }
 
-    /** Intent to ask the user to make CallVault the default phone app, or null if already held/unavailable. */
+    /**
+     * Intent to ask the user to make CallVault the default phone app, or null if the role is
+     * unavailable or CallVault is *already* the real default dialer.
+     *
+     * "Already holding it" is judged by [isDefaultDialer] (Telecom), NOT by [RoleManager.isRoleHeld]:
+     * on OxygenOS isRoleHeld can be stuck `true` while Telecom binds another dialer, which previously
+     * made this return null forever — so the role-lost banner and the enable toggle did nothing.
+     */
     fun requestRoleIntent(): Intent? {
         val rm = roleManager ?: return null
-        if (!rm.isRoleAvailable(RoleManager.ROLE_DIALER) || rm.isRoleHeld(RoleManager.ROLE_DIALER)) return null
+        if (!rm.isRoleAvailable(RoleManager.ROLE_DIALER)) return null
+        if (isDefaultDialer()) return null
         return rm.createRequestRoleIntent(RoleManager.ROLE_DIALER)
     }
 

--- a/app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt
@@ -4,16 +4,31 @@ import android.app.role.RoleManager
 import android.content.Context
 import android.content.Intent
 import android.provider.Settings
+import android.telecom.TelecomManager
 
-/** Wraps RoleManager for the default-dialer (ROLE_DIALER) role. Truth = isRoleHeld, never a preference. */
+/**
+ * Wraps the default-dialer (ROLE_DIALER) role.
+ *
+ * - "Am I the default dialer?" is answered by [TelecomManager.getDefaultDialerPackage], NOT by
+ *   [RoleManager.isRoleHeld]. The Telecom default-dialer package is what actually determines whether
+ *   CallVault's InCallService is bound and receives calls; on some OEMs (observed on OxygenOS)
+ *   `isRoleHeld` can report `true` while Telecom still binds another app's dialer, which would make
+ *   us wrongly defer call detection to a Telecom path that never fires.
+ * - Requesting the role still uses [RoleManager.createRequestRoleIntent] (the supported request API).
+ */
 class DialerRoleController(private val context: Context) {
 
     private val roleManager: RoleManager? =
         context.getSystemService(Context.ROLE_SERVICE) as? RoleManager
 
+    private val telecomManager: TelecomManager? =
+        context.getSystemService(Context.TELECOM_SERVICE) as? TelecomManager
+
+    /** True only when CallVault is the *actual* Telecom default dialer (so our InCallService is bound). */
     fun isDefaultDialer(): Boolean {
-        val rm = roleManager ?: return false
-        return rm.isRoleAvailable(RoleManager.ROLE_DIALER) && rm.isRoleHeld(RoleManager.ROLE_DIALER)
+        val tm = telecomManager ?: return false
+        @Suppress("DEPRECATION") // getDefaultDialerPackage is the authoritative source for InCallService binding.
+        return tm.defaultDialerPackage == context.packageName
     }
 
     /** Intent to ask the user to make CallVault the default phone app, or null if already held/unavailable. */

--- a/app/src/main/java/com/baba/callvault/dialer/TelecomCallEventSource.kt
+++ b/app/src/main/java/com/baba/callvault/dialer/TelecomCallEventSource.kt
@@ -1,0 +1,57 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+import android.telecom.Call
+import com.baba.callvault.calls.CallDirection
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.calls.CallEventRouter
+import com.baba.callvault.calls.DetectionMode
+
+/**
+ * Pure mapping helpers: translate Telecom [Call] state/details into normalized [CallEvent]s and
+ * forward them to the shared [CallEventRouter]. Kept as a separate object so the mapping functions
+ * could be unit-tested without an [android.telecom.InCallService] in a future task.
+ *
+ * API-level notes (minSdk 30):
+ *  - [Call.Details.callDirection] was added in API 29 — safe at minSdk 30.
+ *  - [Call.Details.PROPERTY_EMERGENCY_CALLBACK_MODE] was added in API 28 — safe.
+ */
+object TelecomCallEventSource {
+
+    fun phaseOf(state: Int): CallEvent.Phase = when (state) {
+        Call.STATE_RINGING -> CallEvent.Phase.RINGING
+        Call.STATE_DIALING, Call.STATE_CONNECTING -> CallEvent.Phase.DIALING
+        Call.STATE_ACTIVE -> CallEvent.Phase.ACTIVE
+        Call.STATE_DISCONNECTED, Call.STATE_DISCONNECTING -> CallEvent.Phase.ENDED
+        else -> CallEvent.Phase.ACTIVE
+    }
+
+    fun directionOf(details: Call.Details): CallDirection = when (details.callDirection) {
+        Call.Details.DIRECTION_INCOMING -> CallDirection.INCOMING
+        Call.Details.DIRECTION_OUTGOING -> CallDirection.OUTGOING
+        else -> CallDirection.UNKNOWN
+    }
+
+    fun numberOf(details: Call.Details): String? =
+        details.handle?.schemeSpecificPart
+
+    fun submit(router: CallEventRouter, call: Call) {
+        val d = call.details
+        router.submit(
+            DetectionMode.TELECOM,
+            CallEvent(
+                phaseOf(call.state),
+                numberOf(d),
+                directionOf(d),
+                isEmergency = (d.callProperties and Call.Details.PROPERTY_EMERGENCY_CALLBACK_MODE) != 0,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
@@ -165,4 +165,17 @@ object AdbShell {
             AppLogger.i(TAG, "Requested self-grant of WRITE_SECURE_SETTINGS via ADB shell")
         }.onFailure { AppLogger.w(TAG, "Self-grant of WRITE_SECURE_SETTINGS failed: ${it.message}") }
     }
+
+    /**
+     * Runs an arbitrary shell command over the embedded ADB connection (uid 2000 shell), draining its
+     * output so the command completes. Returns true if it ran without throwing. Caller must be OFF the
+     * main thread. Used for privileged dialer setup (cmd telecom set-default-dialer, pm grant CALL_PHONE).
+     */
+    fun runShellCommand(context: Context, command: String): Boolean =
+        runCatching {
+            openShell(context, command).use { s -> s.openInputStream().use { it.readBytes() } }
+            AppLogger.i(TAG, "ADB shell command ran: $command")
+            true
+        }.onFailure { AppLogger.w(TAG, "ADB shell command failed ($command): ${it.message}") }
+            .getOrDefault(false)
 }

--- a/app/src/main/java/com/baba/callvault/services/boot/AdbConnectionService.kt
+++ b/app/src/main/java/com/baba/callvault/services/boot/AdbConnectionService.kt
@@ -68,6 +68,15 @@ class AdbConnectionService : Service() {
                 .getOrDefault(false)
             AppLogger.i(TAG, "Boot: recorder daemon connected=$started")
 
+            // Re-assert default dialer after boot if the role was lost while the device was off.
+            val prefs = com.baba.callvault.data.AppPreferences(this@AdbConnectionService)
+            if (prefs.isDialerModeEnabled()) {
+                val rc = com.baba.callvault.dialer.DialerRoleController(this@AdbConnectionService)
+                if (!rc.isDefaultDialer()) {
+                    com.baba.callvault.dialer.DialerDefaultEnforcer(this@AdbConnectionService, prefs, rc).enforce()
+                }
+            }
+
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
         }

--- a/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
@@ -24,6 +24,7 @@ import android.telephony.TelephonyCallback
 import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
 import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.dialer.DialerRoleController
 import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.utils.AppLogger
 
@@ -195,10 +196,11 @@ class CallMonitorService : Service() {
 
     /** Maps a [TelephonyManager] call-state int to the broadcast's EXTRA_STATE string and feeds the session manager. */
     private fun forwardState(state: Int) {
-        // In dialer mode the InCallService (Telecom) is the authoritative call-state source.
-        // Mirrors the identical guard in PhoneStateReceiver to prevent double-feeding.
-        if (AppPreferences(this).isDialerModeEnabled()) {
-            AppLogger.v(TAG, "Dialer mode active; live listener deferring to Telecom (state forwarding skipped)")
+        // Defer to Telecom ONLY when dialer mode is *effective* (pref on AND the default-dialer role is
+        // actually held). Mirrors PhoneStateReceiver: if the role isn't held, the live-listener path must
+        // stay active so recording keeps working instead of going dark.
+        if (AppPreferences(this).isDialerModeEnabled() && DialerRoleController(this).isDefaultDialer()) {
+            AppLogger.v(TAG, "Dialer mode effective (role held); live listener deferring to Telecom")
             return
         }
         val stateString = when (state) {

--- a/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
@@ -23,6 +23,7 @@ import android.telephony.PhoneStateListener
 import android.telephony.TelephonyCallback
 import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
+import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.utils.AppLogger
 
@@ -194,6 +195,12 @@ class CallMonitorService : Service() {
 
     /** Maps a [TelephonyManager] call-state int to the broadcast's EXTRA_STATE string and feeds the session manager. */
     private fun forwardState(state: Int) {
+        // In dialer mode the InCallService (Telecom) is the authoritative call-state source.
+        // Mirrors the identical guard in PhoneStateReceiver to prevent double-feeding.
+        if (AppPreferences(this).isDialerModeEnabled()) {
+            AppLogger.v(TAG, "Dialer mode active; live listener deferring to Telecom (state forwarding skipped)")
+            return
+        }
         val stateString = when (state) {
             TelephonyManager.CALL_STATE_RINGING  -> TelephonyManager.EXTRA_STATE_RINGING
             TelephonyManager.CALL_STATE_OFFHOOK  -> TelephonyManager.EXTRA_STATE_OFFHOOK

--- a/app/src/main/java/com/baba/callvault/services/call/CallSessionManager.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/CallSessionManager.kt
@@ -283,6 +283,27 @@ class CallSessionManager private constructor(context: Context) {
         session.wasRecordingServiceStartIntentSend = true
     }
 
+    /**
+     * Entry point for the [com.baba.callvault.calls.CallEventRouter] sink.
+     * Maps a normalized [com.baba.callvault.calls.CallEvent] onto the existing [handlePhoneState]
+     * pipeline without touching any recording-decision logic.
+     *
+     * Phase → TelephonyManager EXTRA_STATE mapping:
+     *  RINGING  → EXTRA_STATE_RINGING  (incoming ring)
+     *  DIALING  → EXTRA_STATE_OFFHOOK  (outgoing dial, treated as OFFHOOK by the pipeline)
+     *  ACTIVE   → EXTRA_STATE_OFFHOOK  (call answered / active)
+     *  ENDED    → EXTRA_STATE_IDLE     (call finished)
+     */
+    fun onCallEvent(event: com.baba.callvault.calls.CallEvent) {
+        val stateString = when (event.phase) {
+            com.baba.callvault.calls.CallEvent.Phase.RINGING -> TelephonyManager.EXTRA_STATE_RINGING
+            com.baba.callvault.calls.CallEvent.Phase.DIALING -> TelephonyManager.EXTRA_STATE_OFFHOOK
+            com.baba.callvault.calls.CallEvent.Phase.ACTIVE  -> TelephonyManager.EXTRA_STATE_OFFHOOK
+            com.baba.callvault.calls.CallEvent.Phase.ENDED   -> TelephonyManager.EXTRA_STATE_IDLE
+        }
+        handlePhoneState(stateString, event.number)
+    }
+
     @Synchronized
     fun handleDebugAction(action: String) {
         if (!preferences.isDebugEnabled()) {

--- a/app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt
@@ -12,6 +12,11 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.telephony.TelephonyManager
+import com.baba.callvault.calls.CallDetection
+import com.baba.callvault.calls.CallDirection
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.dialer.BroadcastCallEventSource
 import com.baba.callvault.utils.AppLogger
 
 /**
@@ -59,6 +64,13 @@ class PhoneStateReceiver : BroadcastReceiver() {
 
         AppLogger.v(TAG, "Raw broadcast received: state=$state number=$number")
 
+        // In dialer mode the InCallService (Telecom) is the authoritative call-state source.
+        // Let it own detection entirely; ignore this broadcast.
+        if (AppPreferences(context).isDialerModeEnabled()) {
+            AppLogger.v(TAG, "Dialer mode active; broadcast detection deferred to Telecom (broadcast ignored)")
+            return
+        }
+
         // During the post-boot window, CallMonitorService holds a LIVE telephony listener and is the
         // authoritative call-state source. The PHONE_STATE broadcast can be delivered seconds late on a
         // freshly-booted system (after the call has already ended), which would otherwise spawn a stale
@@ -68,8 +80,23 @@ class PhoneStateReceiver : BroadcastReceiver() {
             return
         }
 
-        // Forward the phone state and number to the session manager.
-        // We now forward everything (including null) to let the CallSessionManager handle the Verification Window.
-        CallSessionManager.getInstance(context).handlePhoneState(state, number)
+        // Map the raw telephony state string to a normalized CallEvent and route it through the
+        // CallEventRouter. The router forwards only events from the currently active source
+        // (BROADCAST in recording-only mode), ensuring mutual exclusion with the Telecom path.
+        val phase = when (state) {
+            TelephonyManager.EXTRA_STATE_RINGING -> CallEvent.Phase.RINGING
+            TelephonyManager.EXTRA_STATE_OFFHOOK -> CallEvent.Phase.ACTIVE
+            TelephonyManager.EXTRA_STATE_IDLE    -> CallEvent.Phase.ENDED
+            else -> return  // unknown state; handlePhoneState would also ignore it
+        }
+        // Direction is only unambiguous at RINGING (always incoming). OFFHOOK/IDLE direction is
+        // derived inside CallSessionManager from the session state sequence, so UNKNOWN is safe here.
+        val direction = if (state == TelephonyManager.EXTRA_STATE_RINGING) {
+            CallDirection.INCOMING
+        } else {
+            CallDirection.UNKNOWN
+        }
+        val event = CallEvent(phase, number, direction, isEmergency = false)
+        BroadcastCallEventSource(CallDetection.router).emit(event)
     }
 }

--- a/app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt
@@ -16,6 +16,7 @@ import com.baba.callvault.calls.CallDetection
 import com.baba.callvault.calls.CallDirection
 import com.baba.callvault.calls.CallEvent
 import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.dialer.DialerRoleController
 import com.baba.callvault.utils.AppLogger
 
 /**
@@ -63,10 +64,17 @@ class PhoneStateReceiver : BroadcastReceiver() {
 
         AppLogger.v(TAG, "Raw broadcast received: state=$state number=$number")
 
-        // In dialer mode the InCallService (Telecom) is the authoritative call-state source.
-        // Let it own detection entirely; ignore this broadcast.
-        if (AppPreferences(context).isDialerModeEnabled()) {
-            AppLogger.v(TAG, "Dialer mode active; broadcast detection deferred to Telecom (broadcast ignored)")
+        // Dialer mode is *effective* only when the preference is on AND CallVault actually holds the
+        // default-dialer role (so its InCallService is bound and receiving calls). Resync the router's
+        // active source to reality on every call: this self-heals a lost/never-granted role back to
+        // broadcast detection (and hands ownership to Telecom only while the role is truly held).
+        // Without this, pref-on + role-not-held would leave the router stuck on TELECOM and silently
+        // drop the broadcast while Telecom never fires → total detection blackout (no recording).
+        val effectiveDialerMode =
+            AppPreferences(context).isDialerModeEnabled() && DialerRoleController(context).isDefaultDialer()
+        if (CallDetection.isInitialized) CallDetection.setMode(effectiveDialerMode)
+        if (effectiveDialerMode) {
+            AppLogger.v(TAG, "Dialer mode effective (role held); broadcast detection deferred to Telecom")
             return
         }
 

--- a/app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt
@@ -16,7 +16,6 @@ import com.baba.callvault.calls.CallDetection
 import com.baba.callvault.calls.CallDirection
 import com.baba.callvault.calls.CallEvent
 import com.baba.callvault.data.AppPreferences
-import com.baba.callvault.dialer.BroadcastCallEventSource
 import com.baba.callvault.utils.AppLogger
 
 /**
@@ -97,6 +96,6 @@ class PhoneStateReceiver : BroadcastReceiver() {
             CallDirection.UNKNOWN
         }
         val event = CallEvent(phase, number, direction, isEmergency = false)
-        BroadcastCallEventSource(CallDetection.router).emit(event)
+        CallDetection.emitBroadcast(event)
     }
 }

--- a/app/src/main/java/com/baba/callvault/ui/dialer/DialpadScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/dialer/DialpadScreen.kt
@@ -1,0 +1,167 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.ui.dialer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Backspace
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.baba.callvault.R
+import com.baba.callvault.dialer.CallPlacer
+import com.baba.callvault.ui.common.CvScaffold
+
+private val DIALPAD_ROWS = listOf(
+    listOf("1", "2", "3"),
+    listOf("4", "5", "6"),
+    listOf("7", "8", "9"),
+    listOf("*", "0", "#"),
+)
+
+@Composable
+fun DialpadScreen(onBack: () -> Unit) {
+    var digits by remember { mutableStateOf("") }
+    val context = LocalContext.current
+
+    CvScaffold(
+        title = stringResource(R.string.dialer_keypad),
+        onBack = onBack,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Number display
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, MaterialTheme.shapes.medium)
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = digits.ifEmpty { "—" },
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = if (digits.isEmpty()) MaterialTheme.colorScheme.onSurfaceVariant
+                                else MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                        textAlign = TextAlign.End
+                    )
+                    if (digits.isNotEmpty()) {
+                        IconButton(onClick = { digits = digits.dropLast(1) }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.Backspace,
+                                contentDescription = stringResource(R.string.dialer_backspace),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            // Digit grid
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                DIALPAD_ROWS.forEach { row ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceEvenly
+                    ) {
+                        row.forEach { label ->
+                            DialKey(label = label, onClick = { digits += label })
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            // Call button
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center
+            ) {
+                IconButton(
+                    onClick = { CallPlacer(context).place(digits) },
+                    enabled = CallPlacer.isDialable(digits),
+                    modifier = Modifier.size(72.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Call,
+                        contentDescription = stringResource(R.string.dialer_place_call),
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(32.dp)
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun DialKey(label: String, onClick: () -> Unit) {
+    FilledTonalButton(
+        onClick = onClick,
+        modifier = Modifier.size(72.dp),
+        shape = CircleShape,
+        contentPadding = PaddingValues(0.dp)
+    ) {
+        Text(
+            text = label,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}

--- a/app/src/main/java/com/baba/callvault/ui/dialer/InCallActivity.kt
+++ b/app/src/main/java/com/baba/callvault/ui/dialer/InCallActivity.kt
@@ -12,6 +12,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.baba.callvault.calls.CallEvent
@@ -41,10 +42,9 @@ class InCallActivity : ComponentActivity() {
             CallVaultTheme {
                 val call by vm.current.collectAsStateWithLifecycle()
 
-                if (call == null || call?.phase == CallEvent.Phase.ENDED) {
-                    finish()
-                    return@CallVaultTheme
-                }
+                val shouldFinish = call == null || call?.phase == CallEvent.Phase.ENDED
+                LaunchedEffect(shouldFinish) { if (shouldFinish) finish() }
+                if (shouldFinish) return@CallVaultTheme
 
                 InCallScreen(
                     call = call,

--- a/app/src/main/java/com/baba/callvault/ui/dialer/InCallActivity.kt
+++ b/app/src/main/java/com/baba/callvault/ui/dialer/InCallActivity.kt
@@ -1,0 +1,17 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.ui.dialer
+
+import androidx.activity.ComponentActivity
+
+/**
+ * In-call UI activity — stub only.
+ * Full implementation is provided by Task 8 (in-call screen + Compose UI).
+ */
+class InCallActivity : ComponentActivity()

--- a/app/src/main/java/com/baba/callvault/ui/dialer/InCallActivity.kt
+++ b/app/src/main/java/com/baba/callvault/ui/dialer/InCallActivity.kt
@@ -8,10 +8,56 @@
 
 package com.baba.callvault.ui.dialer
 
+import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.ui.theme.CallVaultTheme
 
 /**
- * In-call UI activity — stub only.
- * Full implementation is provided by Task 8 (in-call screen + Compose UI).
+ * Full-screen in-call Activity.
+ *
+ * Shown over the lock screen ([setShowWhenLocked]) and wakes the display ([setTurnScreenOn])
+ * so an incoming call is immediately visible. The Activity auto-finishes when the call ends
+ * ([CallEvent.Phase.ENDED]) or when [com.baba.callvault.calls.CallStateRepository.current] drops
+ * to null (call removed by the system).
+ *
+ * All call actions are delegated to [InCallViewModel], which routes them through
+ * [com.baba.callvault.dialer.CallActions].
  */
-class InCallActivity : ComponentActivity()
+class InCallActivity : ComponentActivity() {
+
+    private val vm: InCallViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setShowWhenLocked(true)
+        setTurnScreenOn(true)
+
+        setContent {
+            CallVaultTheme {
+                val call by vm.current.collectAsStateWithLifecycle()
+
+                if (call == null || call?.phase == CallEvent.Phase.ENDED) {
+                    finish()
+                    return@CallVaultTheme
+                }
+
+                InCallScreen(
+                    call = call,
+                    onAnswer = { vm.answer() },
+                    onReject = { vm.reject() },
+                    onEnd = { vm.end() },
+                    onHold = { vm.hold() },
+                    onMute = { muted -> vm.setMuted(muted) },
+                    onSpeaker = { on -> vm.setSpeaker(on) },
+                    onToggleRecord = { vm.toggleRecord() },
+                    onDtmf = { digit -> vm.sendDtmf(digit) },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/baba/callvault/ui/dialer/InCallScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/dialer/InCallScreen.kt
@@ -104,9 +104,9 @@ fun InCallScreen(
             Text(
                 text = when (call.phase) {
                     CallEvent.Phase.RINGING -> stringResource(R.string.dialer_incoming_title)
-                    CallEvent.Phase.DIALING -> "Calling…"
-                    CallEvent.Phase.ACTIVE  -> "Active"
-                    CallEvent.Phase.ENDED   -> "Call ended"
+                    CallEvent.Phase.DIALING -> stringResource(R.string.dialer_status_dialing)
+                    CallEvent.Phase.ACTIVE  -> stringResource(R.string.dialer_status_active)
+                    CallEvent.Phase.ENDED   -> stringResource(R.string.dialer_status_ended)
                 },
                 color = Color.White.copy(alpha = 0.7f),
                 style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/com/baba/callvault/ui/dialer/InCallScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/dialer/InCallScreen.kt
@@ -1,0 +1,338 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.ui.dialer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.CallEnd
+import androidx.compose.material.icons.filled.Dialpad
+import androidx.compose.material.icons.filled.FiberManualRecord
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.MicOff
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledIconToggleButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.baba.callvault.R
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.calls.UiCall
+
+private val NavyCallBg = Color(0xFF0A1628)
+private val GreenAnswer = Color(0xFF1B7F4B)
+private val RedEnd = Color(0xFFB00020)
+
+/**
+ * Stateless in-call screen. The Activity owns the ViewModel; this composable is purely
+ * presentation and delegates every action through lambdas.
+ *
+ * Renders three layouts driven by [call.phase]:
+ *  - [CallEvent.Phase.RINGING]: large answer + reject buttons for an incoming call.
+ *  - [CallEvent.Phase.DIALING] / [CallEvent.Phase.ACTIVE]: full control row (mute, speaker, hold,
+ *    keypad, end, record toggle).
+ *  - [CallEvent.Phase.ENDED]: blank (the Activity finishes itself before reaching here).
+ */
+@Composable
+fun InCallScreen(
+    call: UiCall?,
+    onAnswer: () -> Unit,
+    onReject: () -> Unit,
+    onEnd: () -> Unit,
+    onHold: () -> Unit,
+    onMute: (Boolean) -> Unit,
+    onSpeaker: (Boolean) -> Unit,
+    onToggleRecord: () -> Unit,
+    onDtmf: (Char) -> Unit = {},
+) {
+    if (call == null) return
+
+    val unknownLabel = stringResource(R.string.dialer_unknown_caller)
+    val displayNumber = InCallLabels.displayNumber(call, unknownLabel)
+
+    var isMuted by rememberSaveable { mutableStateOf(false) }
+    var isSpeaker by rememberSaveable { mutableStateOf(false) }
+    var showKeypad by rememberSaveable { mutableStateOf(false) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(NavyCallBg),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(Modifier.height(56.dp))
+
+            Text(
+                text = when (call.phase) {
+                    CallEvent.Phase.RINGING -> stringResource(R.string.dialer_incoming_title)
+                    CallEvent.Phase.DIALING -> "Calling…"
+                    CallEvent.Phase.ACTIVE  -> "Active"
+                    CallEvent.Phase.ENDED   -> "Call ended"
+                },
+                color = Color.White.copy(alpha = 0.7f),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            Text(
+                text = displayNumber,
+                color = Color.White,
+                fontSize = 34.sp,
+                fontWeight = FontWeight.Bold,
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            when (call.phase) {
+                CallEvent.Phase.RINGING -> IncomingControls(
+                    onAnswer = onAnswer,
+                    onReject = onReject,
+                )
+                CallEvent.Phase.DIALING,
+                CallEvent.Phase.ACTIVE -> ActiveControls(
+                    isRecording = call.isRecording,
+                    isMuted = isMuted,
+                    isSpeaker = isSpeaker,
+                    showKeypad = showKeypad,
+                    onEnd = onEnd,
+                    onHold = onHold,
+                    onMuteToggle = { muted ->
+                        isMuted = muted
+                        onMute(muted)
+                    },
+                    onSpeakerToggle = { speaker ->
+                        isSpeaker = speaker
+                        onSpeaker(speaker)
+                    },
+                    onKeypadToggle = { showKeypad = !showKeypad },
+                    onToggleRecord = onToggleRecord,
+                    onDtmf = onDtmf,
+                )
+                CallEvent.Phase.ENDED -> Unit
+            }
+
+            Spacer(Modifier.height(40.dp))
+        }
+    }
+}
+
+@Composable
+private fun IncomingControls(
+    onAnswer: () -> Unit,
+    onReject: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ActionButton(
+            icon = Icons.Filled.Call,
+            label = stringResource(R.string.dialer_answer),
+            containerColor = GreenAnswer,
+            onClick = onAnswer,
+        )
+        ActionButton(
+            icon = Icons.Filled.CallEnd,
+            label = stringResource(R.string.dialer_reject),
+            containerColor = RedEnd,
+            onClick = onReject,
+        )
+    }
+}
+
+@Composable
+private fun ActiveControls(
+    isRecording: Boolean,
+    isMuted: Boolean,
+    isSpeaker: Boolean,
+    showKeypad: Boolean,
+    onEnd: () -> Unit,
+    onHold: () -> Unit,
+    onMuteToggle: (Boolean) -> Unit,
+    onSpeakerToggle: (Boolean) -> Unit,
+    onKeypadToggle: () -> Unit,
+    onToggleRecord: () -> Unit,
+    onDtmf: (Char) -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        if (showKeypad) {
+            DtmfKeypad(onDigit = onDtmf)
+            Spacer(Modifier.height(16.dp))
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            ToggleButton(
+                icon = if (isMuted) Icons.Filled.MicOff else Icons.Filled.Mic,
+                label = stringResource(R.string.dialer_mute),
+                checked = isMuted,
+                onCheckedChange = onMuteToggle,
+            )
+            ToggleButton(
+                icon = Icons.Filled.VolumeUp,
+                label = stringResource(R.string.dialer_speaker),
+                checked = isSpeaker,
+                onCheckedChange = onSpeakerToggle,
+            )
+            ToggleButton(
+                icon = Icons.Filled.Pause,
+                label = stringResource(R.string.dialer_hold),
+                checked = false,
+                onCheckedChange = { onHold() },
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ToggleButton(
+                icon = Icons.Filled.Dialpad,
+                label = stringResource(R.string.dialer_keypad),
+                checked = showKeypad,
+                onCheckedChange = { onKeypadToggle() },
+            )
+            ActionButton(
+                icon = Icons.Filled.CallEnd,
+                label = stringResource(R.string.dialer_end_call),
+                containerColor = RedEnd,
+                onClick = onEnd,
+            )
+            ToggleButton(
+                icon = if (isRecording) Icons.Filled.Stop else Icons.Filled.FiberManualRecord,
+                label = if (isRecording) stringResource(R.string.dialer_stop_recording)
+                        else stringResource(R.string.dialer_record),
+                checked = isRecording,
+                onCheckedChange = { onToggleRecord() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DtmfKeypad(onDigit: (Char) -> Unit) {
+    val rows = listOf(
+        listOf('1', '2', '3'),
+        listOf('4', '5', '6'),
+        listOf('7', '8', '9'),
+        listOf('*', '0', '#'),
+    )
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        rows.forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                row.forEach { digit ->
+                    FilledIconButton(
+                        onClick = { onDigit(digit) },
+                        modifier = Modifier.size(56.dp),
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = Color.White.copy(alpha = 0.15f),
+                            contentColor = Color.White,
+                        ),
+                        shape = CircleShape,
+                    ) {
+                        Text(text = digit.toString(), color = Color.White, fontSize = 20.sp)
+                    }
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun ActionButton(
+    icon: ImageVector,
+    label: String,
+    containerColor: Color,
+    onClick: () -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        FilledIconButton(
+            onClick = onClick,
+            modifier = Modifier.size(72.dp),
+            colors = IconButtonDefaults.filledIconButtonColors(containerColor = containerColor),
+            shape = CircleShape,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                modifier = Modifier.size(36.dp),
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Text(text = label, color = Color.White.copy(alpha = 0.8f), fontSize = 12.sp)
+    }
+}
+
+@Composable
+private fun ToggleButton(
+    icon: ImageVector,
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        FilledIconToggleButton(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier.size(56.dp),
+            colors = IconButtonDefaults.filledIconToggleButtonColors(
+                containerColor = Color.White.copy(alpha = 0.12f),
+                contentColor = Color.White,
+                checkedContainerColor = Color.White.copy(alpha = 0.35f),
+                checkedContentColor = Color.White,
+            ),
+            shape = CircleShape,
+        ) {
+            Icon(imageVector = icon, contentDescription = label)
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(text = label, color = Color.White.copy(alpha = 0.7f), fontSize = 11.sp)
+    }
+}

--- a/app/src/main/java/com/baba/callvault/ui/dialer/InCallViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/dialer/InCallViewModel.kt
@@ -1,0 +1,91 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.ui.dialer
+
+import android.app.Application
+import android.content.Intent
+import androidx.lifecycle.AndroidViewModel
+import com.baba.callvault.calls.CallDirection
+import com.baba.callvault.calls.CallStateRepository
+import com.baba.callvault.calls.UiCall
+import com.baba.callvault.data.recordings.RecordingDirection
+import com.baba.callvault.data.recordings.RecordingMetadata
+import com.baba.callvault.dialer.CallActions
+import com.baba.callvault.services.recording.RecordingForegroundService
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Pure, JVM-testable helper for in-call display labels.
+ * Lives next to [InCallViewModel] so the unit test can access it without Android context.
+ */
+object InCallLabels {
+    /**
+     * Returns the phone number to display for [call], falling back to [unknown] when the number
+     * is null or blank.
+     */
+    fun displayNumber(call: UiCall?, unknown: String): String =
+        call?.number?.takeIf { it.isNotBlank() } ?: unknown
+}
+
+/**
+ * ViewModel for the in-call screen.
+ *
+ * Exposes [current] from [CallStateRepository] and delegates all call actions to [CallActions],
+ * keeping Telecom internals out of the Compose layer.
+ *
+ * Recording toggle concern (on-device-unverified): the manual start sends
+ * [RecordingForegroundService.ACTION_MANUAL_START] with metadata derived from the current [UiCall].
+ * This bypasses the 500ms verification window in CallSessionManager and skips contact-filter
+ * evaluation — correct for an explicit user action. The metadata is un-enriched (no E.164
+ * standardisation); enrichment happens asynchronously after call end regardless.
+ */
+class InCallViewModel(application: Application) : AndroidViewModel(application) {
+
+    /** Mirrors [CallStateRepository.current]; observed by the Compose layer. */
+    val current: StateFlow<UiCall?> = CallStateRepository.current
+
+    fun answer() = CallActions.answer()
+    fun reject() = CallActions.reject()
+    fun end() = CallActions.end()
+    fun hold() = CallActions.toggleHold()
+    fun setMuted(muted: Boolean) = CallActions.setMuted(muted)
+    fun setSpeaker(on: Boolean) = CallActions.setSpeaker(on)
+    fun sendDtmf(digit: Char) = CallActions.sendDtmfTone(digit)
+
+    /**
+     * Starts or stops recording for the current call.
+     *
+     * Start path: fires [RecordingForegroundService.ACTION_MANUAL_START] with minimal
+     * [RecordingMetadata] built from the current [UiCall].
+     *
+     * Stop path: fires [RecordingForegroundService.ACTION_STOP_RECORDING], matching what
+     * CallSessionManager sends on call end.
+     */
+    fun toggleRecord() {
+        val call = current.value ?: return
+        val ctx = getApplication<Application>().applicationContext
+        if (call.isRecording) {
+            ctx.startService(
+                Intent(ctx, RecordingForegroundService::class.java)
+                    .setAction(RecordingForegroundService.ACTION_STOP_RECORDING),
+            )
+        } else {
+            val direction = when (call.direction) {
+                CallDirection.INCOMING -> RecordingDirection.INCOMING
+                else -> RecordingDirection.OUTGOING
+            }
+            val metadata = RecordingMetadata(rawPhoneNumber = call.number, direction = direction)
+            ctx.startForegroundService(
+                Intent(ctx, RecordingForegroundService::class.java)
+                    .setAction(RecordingForegroundService.ACTION_MANUAL_START)
+                    .putExtra(RecordingMetadata.EXTRA_METADATA, metadata),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/baba/callvault/ui/dialer/InCallViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/dialer/InCallViewModel.kt
@@ -70,11 +70,13 @@ class InCallViewModel(application: Application) : AndroidViewModel(application) 
     fun toggleRecord() {
         val call = current.value ?: return
         val ctx = getApplication<Application>().applicationContext
+        // Known Phase-1 limitation: an auto-started recording will show "Record" until the first tap.
         if (call.isRecording) {
             ctx.startService(
                 Intent(ctx, RecordingForegroundService::class.java)
                     .setAction(RecordingForegroundService.ACTION_STOP_RECORDING),
             )
+            CallStateRepository.setRecording(false)
         } else {
             val direction = when (call.direction) {
                 CallDirection.INCOMING -> RecordingDirection.INCOMING
@@ -86,6 +88,7 @@ class InCallViewModel(application: Application) : AndroidViewModel(application) 
                     .setAction(RecordingForegroundService.ACTION_MANUAL_START)
                     .putExtra(RecordingMetadata.EXTRA_METADATA, metadata),
             )
+            CallStateRepository.setRecording(true)
         }
     }
 }

--- a/app/src/main/java/com/baba/callvault/ui/navigation/AppScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/navigation/AppScreen.kt
@@ -30,5 +30,8 @@ enum class AppScreen {
     Home,
 
     /** Settings. Reachable only via manual navigation from [Home]. */
-    Settings
+    Settings,
+
+    /** Outgoing-call dialpad. Reachable only from [Home] when dialer mode is enabled. */
+    Dialer
 }

--- a/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Smartphone
+import androidx.compose.material.icons.filled.Dialpad
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material3.AlertDialog
@@ -72,6 +73,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -82,6 +84,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.baba.callvault.R
+import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.data.recordings.RecordingDirection
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingItem
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingSource
@@ -116,6 +119,7 @@ import java.util.Locale
 @Composable
 fun HomeScreen(
     onOpenSettings: () -> Unit,
+    onOpenDialpad: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = viewModel()
 ) {
@@ -140,10 +144,22 @@ fun HomeScreen(
         }
     }
 
+    val context = LocalContext.current
+    val isDialerMode = remember { AppPreferences(context).isDialerModeEnabled() }
+
     CvScaffold(
         modifier = modifier.fillMaxSize(),
         title = stringResource(R.string.app_name),
         actions = {
+            if (isDialerMode) {
+                IconButton(onClick = onOpenDialpad) {
+                    Icon(
+                        imageVector = Icons.Filled.Dialpad,
+                        contentDescription = stringResource(R.string.dialer_keypad),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
             IconButton(onClick = onOpenSettings) {
                 Icon(
                     imageVector = Icons.Filled.Tune,

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -9,10 +9,8 @@
 package com.baba.callvault.ui.screens
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.expandVertically
@@ -146,24 +144,12 @@ fun SettingsScreen(
         viewModel.refresh()
     }
 
-    // Dialer-role launcher: fires the system "set as default phone app" dialog. On success we
-    // verify that the role is actually held (the system may still deny despite RESULT_OK on some
-    // OEMs) before persisting the preference. On denial we just refresh so the switch snaps back.
-    val dialerRoleLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-        if (result.resultCode == Activity.RESULT_OK && viewModel.dialerRoleController.isDefaultDialer()) {
-            viewModel.setDialerModeEnabled(true)
-        }
-        // Always refresh — if denied, the preference was not persisted so the switch reverts.
-        viewModel.refresh()
-    }
-
     SettingsContent(
         preferences = viewModel.preferences,
         updateTrigger = updateTrigger,
         actions = viewModel,
         contactPickerState = contactPickerState,
         dialerRoleController = viewModel.dialerRoleController,
-        onRequestDialerRole = { intent -> dialerRoleLauncher.launch(intent) },
         onBack = onBack,
         // Seed each picker with its OWN current folder so it opens there, instead of letting
         // Android's DocumentsUI reopen at the last-browsed location (which, after setting Drive,
@@ -230,7 +216,6 @@ fun SettingsContent(
     onDismissContacts: () -> Unit,
     onShareLogs: () -> Unit,
     dialerRoleController: DialerRoleController? = null,
-    onRequestDialerRole: (android.content.Intent) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var showLicensesDialog by remember { mutableStateOf(false) }
@@ -310,7 +295,6 @@ fun SettingsContent(
                     updateTrigger = updateTrigger,
                     actions = actions,
                     dialerRoleController = dialerRoleController,
-                    onRequestDialerRole = onRequestDialerRole,
                     expanded = openSection == SECTION_DIALER,
                     onToggle = { onToggleSection(SECTION_DIALER) }
                 )
@@ -932,9 +916,11 @@ private fun VisualSection(preferences: AppPreferences, updateTrigger: Int, actio
 
 /**
  * Dialer mode: lets the user make CallVault the default phone app (ROLE_DIALER) so Telecom-path
- * call events can be captured without root. The switch defaults to OFF; on enable, the system
- * role-request dialog is fired via [onRequestDialerRole]. On success the preference is persisted
- * by the caller ([SettingsScreen]) once [DialerRoleController.isDefaultDialer] confirms the role.
+ * call events can be captured without root. The switch defaults to OFF; enabling always routes
+ * through [SettingsActions.setDialerModeEnabled], which calls the enforcer to force Telecom's
+ * default-dialer assignment via ADB. The RoleManager prompt is retired — on OEMs like OxygenOS
+ * it grants the role without moving Telecom's default-dialer cache, so [DialerRoleController.isDefaultDialer]
+ * would stay false and the pref would never turn on.
  * On disable, the preference is cleared and a hint to open Default Apps settings is shown.
  * A role-loss banner is shown whenever the preference is ON but the role was revoked externally.
  *
@@ -942,8 +928,6 @@ private fun VisualSection(preferences: AppPreferences, updateTrigger: Int, actio
  * @param updateTrigger        Trigger value to force recomposition when settings change.
  * @param actions              Implementation of [SettingsActions] to handle user interaction.
  * @param dialerRoleController Optional controller; null in Compose Previews and non-dialer builds.
- * @param onRequestDialerRole  Called with the role-request [android.content.Intent] when the user
- *                             enables the switch; the stateful [SettingsScreen] fires the launcher.
  * @param expanded             Whether this accordion section is currently open.
  * @param onToggle             Invoked when the section header is tapped.
  */
@@ -953,7 +937,6 @@ private fun DialerModeSection(
     updateTrigger: Int,
     actions: SettingsActions,
     dialerRoleController: DialerRoleController?,
-    onRequestDialerRole: (android.content.Intent) -> Unit,
     expanded: Boolean,
     onToggle: () -> Unit
 ) {
@@ -971,7 +954,7 @@ private fun DialerModeSection(
         expanded = expanded,
         onToggle = onToggle
     ) {
-        // Role-loss banner — tapping it fires a fresh role-request dialog.
+        // Role-loss banner — tapping it re-asserts the default dialer via the enforcer.
         if (showRoleLostBanner) {
             Row(
                 modifier = Modifier
@@ -1006,20 +989,10 @@ private fun DialerModeSection(
             onCheckedChange = { enabled ->
                 if (enabled) {
                     showReleaseGuidance = false
-                    if (isRoleHeld) {
-                        // Already the default dialer — just persist and propagate the mode.
-                        actions.setDialerModeEnabled(true)
-                    } else {
-                        val intent = dialerRoleController?.requestRoleIntent()
-                        if (intent != null) {
-                            // Preference NOT persisted here; persisted in the launcher callback
-                            // only when the system confirms the role was granted.
-                            onRequestDialerRole(intent)
-                        } else {
-                            // Role unavailable on this device; refresh so the switch reverts deterministically.
-                            actions.refresh()
-                        }
-                    }
+                    // Enabling routes through the enforcer: setDialerModeEnabled(true) runs enforce(),
+                    // which forces the Telecom default dialer via ADB. The RoleManager prompt is retired —
+                    // on OEMs like OxygenOS it grants the role without moving Telecom's default-dialer cache.
+                    actions.setDialerModeEnabled(true)
                 } else {
                     actions.setDialerModeEnabled(false)
                     showReleaseGuidance = true

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -9,8 +9,10 @@
 package com.baba.callvault.ui.screens
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.expandVertically
@@ -45,6 +47,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import android.widget.Toast
 import com.baba.callvault.R
+import com.baba.callvault.dialer.DialerModeState
+import com.baba.callvault.dialer.DialerRoleController
 import com.baba.callvault.system.PersistentFolderPickerContract
 import com.baba.callvault.system.copyToClipboard
 import com.baba.callvault.system.openOriginalProjectRepo
@@ -91,8 +95,10 @@ import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Vibration
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalResources
 import org.xmlpull.v1.XmlPullParser
@@ -140,11 +146,24 @@ fun SettingsScreen(
         viewModel.refresh()
     }
 
+    // Dialer-role launcher: fires the system "set as default phone app" dialog. On success we
+    // verify that the role is actually held (the system may still deny despite RESULT_OK on some
+    // OEMs) before persisting the preference. On denial we just refresh so the switch snaps back.
+    val dialerRoleLauncher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == Activity.RESULT_OK && viewModel.dialerRoleController.isDefaultDialer()) {
+            viewModel.setDialerModeEnabled(true)
+        }
+        // Always refresh — if denied, the preference was not persisted so the switch reverts.
+        viewModel.refresh()
+    }
+
     SettingsContent(
         preferences = viewModel.preferences,
         updateTrigger = updateTrigger,
         actions = viewModel,
         contactPickerState = contactPickerState,
+        dialerRoleController = viewModel.dialerRoleController,
+        onRequestDialerRole = { intent -> dialerRoleLauncher.launch(intent) },
         onBack = onBack,
         // Seed each picker with its OWN current folder so it opens there, instead of letting
         // Android's DocumentsUI reopen at the last-browsed location (which, after setting Drive,
@@ -210,6 +229,8 @@ fun SettingsContent(
     onConfirmContacts: (Set<String>) -> Unit,
     onDismissContacts: () -> Unit,
     onShareLogs: () -> Unit,
+    dialerRoleController: DialerRoleController? = null,
+    onRequestDialerRole: (android.content.Intent) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var showLicensesDialog by remember { mutableStateOf(false) }
@@ -281,6 +302,17 @@ fun SettingsContent(
                     preferences, updateTrigger, actions,
                     expanded = openSection == SECTION_VISUAL,
                     onToggle = { onToggleSection(SECTION_VISUAL) }
+                )
+            }
+            item {
+                DialerModeSection(
+                    preferences = preferences,
+                    updateTrigger = updateTrigger,
+                    actions = actions,
+                    dialerRoleController = dialerRoleController,
+                    onRequestDialerRole = onRequestDialerRole,
+                    expanded = openSection == SECTION_DIALER,
+                    onToggle = { onToggleSection(SECTION_DIALER) }
                 )
             }
             // Debug section: always visible so anyone can enable logging and share logs to report an issue.
@@ -362,6 +394,7 @@ private const val SECTION_STORAGE = "storage"
 private const val SECTION_RETENTION = "retention"
 private const val SECTION_AUDIO = "audio"
 private const val SECTION_VISUAL = "visual"
+private const val SECTION_DIALER = "dialer"
 private const val SECTION_BUG_REPORT = "bug_report"
 private const val SECTION_ABOUT = "about"
 
@@ -898,6 +931,128 @@ private fun VisualSection(preferences: AppPreferences, updateTrigger: Int, actio
 }
 
 /**
+ * Dialer mode: lets the user make CallVault the default phone app (ROLE_DIALER) so Telecom-path
+ * call events can be captured without root. The switch defaults to OFF; on enable, the system
+ * role-request dialog is fired via [onRequestDialerRole]. On success the preference is persisted
+ * by the caller ([SettingsScreen]) once [DialerRoleController.isDefaultDialer] confirms the role.
+ * On disable, the preference is cleared and a hint to open Default Apps settings is shown.
+ * A role-loss banner is shown whenever the preference is ON but the role was revoked externally.
+ *
+ * @param preferences          The [AppPreferences] instance to read data from.
+ * @param updateTrigger        Trigger value to force recomposition when settings change.
+ * @param actions              Implementation of [SettingsActions] to handle user interaction.
+ * @param dialerRoleController Optional controller; null in Compose Previews and non-dialer builds.
+ * @param onRequestDialerRole  Called with the role-request [android.content.Intent] when the user
+ *                             enables the switch; the stateful [SettingsScreen] fires the launcher.
+ * @param expanded             Whether this accordion section is currently open.
+ * @param onToggle             Invoked when the section header is tapped.
+ */
+@Composable
+private fun DialerModeSection(
+    preferences: AppPreferences,
+    updateTrigger: Int,
+    actions: SettingsActions,
+    dialerRoleController: DialerRoleController?,
+    onRequestDialerRole: (android.content.Intent) -> Unit,
+    expanded: Boolean,
+    onToggle: () -> Unit
+) {
+    val context = LocalContext.current
+    val prefOn = remember(updateTrigger) { preferences.isDialerModeEnabled() }
+    val isRoleHeld = remember(updateTrigger) { dialerRoleController?.isDefaultDialer() ?: false }
+    val showRoleLostBanner = DialerModeState.shouldShowRoleLostBanner(prefOn = prefOn, roleHeld = isRoleHeld)
+
+    // Shown below the switch after the user disables dialer mode so they know how to
+    // release the role in system settings (we cannot drop it programmatically).
+    var showReleaseGuidance by remember(prefOn) { mutableStateOf(false) }
+
+    SettingsSection(
+        title = stringResource(R.string.settings_dialer_mode_label),
+        expanded = expanded,
+        onToggle = onToggle
+    ) {
+        // Role-loss banner — tapping it fires a fresh role-request dialog.
+        if (showRoleLostBanner) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 6.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .clickable {
+                        val intent = dialerRoleController?.requestRoleIntent()
+                        if (intent != null) onRequestDialerRole(intent)
+                    }
+                    .padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Warning,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier.size(18.dp)
+                )
+                Text(
+                    text = stringResource(R.string.settings_dialer_mode_role_lost_banner),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+            }
+        }
+
+        SettingsToggleRow(
+            icon = Icons.Filled.Phone,
+            label = stringResource(R.string.settings_dialer_mode_label),
+            description = stringResource(R.string.settings_dialer_mode_description),
+            checked = prefOn,
+            onCheckedChange = { enabled ->
+                if (enabled) {
+                    showReleaseGuidance = false
+                    if (isRoleHeld) {
+                        // Already the default dialer — just persist and propagate the mode.
+                        actions.setDialerModeEnabled(true)
+                    } else {
+                        val intent = dialerRoleController?.requestRoleIntent()
+                        if (intent != null) {
+                            // Preference NOT persisted here; persisted in the launcher callback
+                            // only when the system confirms the role was granted.
+                            onRequestDialerRole(intent)
+                        }
+                        // If intent is null the role is unavailable on this device; do nothing.
+                    }
+                } else {
+                    actions.setDialerModeEnabled(false)
+                    showReleaseGuidance = true
+                }
+            }
+        )
+
+        // Release guidance: shown after the user disables dialer mode.
+        if (showReleaseGuidance) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp)) {
+                Text(
+                    text = stringResource(R.string.settings_dialer_mode_release_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = {
+                        val intent = dialerRoleController?.releaseRoleHint()
+                        if (intent != null) context.startActivity(intent)
+                        showReleaseGuidance = false
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(R.string.general_settings))
+                }
+            }
+        }
+    }
+}
+
+/**
  * Debug section (always visible). The flow is: turn logging on, reproduce the issue, turn logging
  * off, then share the captured log.
  *
@@ -1338,6 +1493,7 @@ private fun SettingsScreenPreview() {
             override fun setRetentionDriveDays(days: Int) {}
             override fun setRetentionTimeHour(hour: Int) {}
             override fun setRetentionTimeMinute(minute: Int) {}
+            override fun setDialerModeEnabled(enabled: Boolean) {}
         }
 
         SettingsContent(

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -979,10 +979,7 @@ private fun DialerModeSection(
                     .padding(horizontal = 16.dp, vertical = 6.dp)
                     .clip(RoundedCornerShape(8.dp))
                     .background(MaterialTheme.colorScheme.errorContainer)
-                    .clickable {
-                        val intent = dialerRoleController?.requestRoleIntent()
-                        if (intent != null) onRequestDialerRole(intent)
-                    }
+                    .clickable { actions.reassertDialerDefault() }
                     .padding(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -1496,6 +1493,7 @@ private fun SettingsScreenPreview() {
             override fun setRetentionTimeHour(hour: Int) {}
             override fun setRetentionTimeMinute(minute: Int) {}
             override fun setDialerModeEnabled(enabled: Boolean) {}
+            override fun reassertDialerDefault() {}
             override fun refresh() {}
         }
 

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -964,7 +964,7 @@ private fun DialerModeSection(
 
     // Shown below the switch after the user disables dialer mode so they know how to
     // release the role in system settings (we cannot drop it programmatically).
-    var showReleaseGuidance by remember(prefOn) { mutableStateOf(false) }
+    var showReleaseGuidance by remember { mutableStateOf(false) }
 
     SettingsSection(
         title = stringResource(R.string.settings_dialer_mode_label),
@@ -1018,8 +1018,10 @@ private fun DialerModeSection(
                             // Preference NOT persisted here; persisted in the launcher callback
                             // only when the system confirms the role was granted.
                             onRequestDialerRole(intent)
+                        } else {
+                            // Role unavailable on this device; refresh so the switch reverts deterministically.
+                            actions.refresh()
                         }
-                        // If intent is null the role is unavailable on this device; do nothing.
                     }
                 } else {
                     actions.setDialerModeEnabled(false)
@@ -1494,6 +1496,7 @@ private fun SettingsScreenPreview() {
             override fun setRetentionTimeHour(hour: Int) {}
             override fun setRetentionTimeMinute(minute: Int) {}
             override fun setDialerModeEnabled(enabled: Boolean) {}
+            override fun refresh() {}
         }
 
         SettingsContent(

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
@@ -13,6 +13,9 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.AndroidViewModel
 import com.baba.callvault.BuildConfig
+import com.baba.callvault.calls.CallDetection
+import com.baba.callvault.dialer.DialerModeState
+import com.baba.callvault.dialer.DialerRoleController
 import com.baba.callvault.services.debug.DebugNotificationHelper
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.data.StorageTarget
@@ -56,6 +59,7 @@ interface SettingsActions {
     fun setRetentionDriveDays(days: Int)
     fun setRetentionTimeHour(hour: Int)
     fun setRetentionTimeMinute(minute: Int)
+    fun setDialerModeEnabled(enabled: Boolean)
 }
 
 /**
@@ -75,6 +79,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
      * Read and Manager AppPreference settings
      */
     val preferences = AppPreferences(appContext)
+
+    /** Manages the default-dialer (ROLE_DIALER) role request and release. */
+    val dialerRoleController = DialerRoleController(appContext)
 
     // -------- Internal mutable state
     // Private so only this ViewModel can mutate it.
@@ -349,6 +356,31 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     }
 
     // -------- Debug settings
+
+    // -------- Dialer mode settings
+
+    /**
+     * Persists the dialer-mode preference and propagates the effective mode to [CallDetection].
+     *
+     * The *effective* mode requires both the preference and the role being held
+     * (see [DialerModeState.effective]). [CallDetection.setMode] is only called when the
+     * detection engine has been initialised; if the daemon hasn't started yet, the correct mode
+     * will be applied at daemon start time.
+     *
+     * @param enabled `true` to opt in to dialer mode; `false` to revert to broadcast capture.
+     */
+    override fun setDialerModeEnabled(enabled: Boolean) {
+        preferences.setDialerModeEnabled(enabled)
+        if (CallDetection.isInitialized) {
+            CallDetection.setMode(
+                DialerModeState.effective(
+                    prefOn = enabled,
+                    roleHeld = dialerRoleController.isDefaultDialer()
+                )
+            )
+        }
+        refresh()
+    }
 
     /** Turns diagnostic logging on or off.
      *

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
@@ -65,6 +65,7 @@ interface SettingsActions {
     fun setRetentionTimeHour(hour: Int)
     fun setRetentionTimeMinute(minute: Int)
     fun setDialerModeEnabled(enabled: Boolean)
+    fun reassertDialerDefault()
     fun refresh()
 }
 
@@ -395,6 +396,29 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 )
             }
             refresh() // re-read state so the toggle/banner reflect reality
+        }
+    }
+
+    /**
+     * Re-asserts the default dialer role if dialer mode is enabled but the role was lost.
+     * No-op when dialer mode is disabled. Runs off the main thread; calls [refresh] when done.
+     */
+    fun reassertDialerDefaultIfNeeded() {
+        if (!preferences.isDialerModeEnabled()) return
+        viewModelScope.launch(Dispatchers.IO) {
+            if (!dialerRoleController.isDefaultDialer()) dialerEnforcer.enforce()
+            refresh()
+        }
+    }
+
+    /**
+     * Unconditionally re-asserts the default dialer role (used when the user taps the role-lost
+     * banner). Runs off the main thread; calls [refresh] when done.
+     */
+    override fun reassertDialerDefault() {
+        viewModelScope.launch(Dispatchers.IO) {
+            dialerEnforcer.enforce()
+            refresh()
         }
     }
 

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
@@ -13,9 +13,14 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.AndroidViewModel
 import com.baba.callvault.BuildConfig
+import androidx.lifecycle.viewModelScope
 import com.baba.callvault.calls.CallDetection
+import com.baba.callvault.dialer.DialerDefaultEnforcer
+import com.baba.callvault.dialer.DialerLauncherIcon
 import com.baba.callvault.dialer.DialerModeState
 import com.baba.callvault.dialer.DialerRoleController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import com.baba.callvault.services.debug.DebugNotificationHelper
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.data.StorageTarget
@@ -83,6 +88,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     /** Manages the default-dialer (ROLE_DIALER) role request and release. */
     val dialerRoleController = DialerRoleController(appContext)
+
+    /** Lazily-created enforcer; constructed on first use so tests that never call
+     *  [setDialerModeEnabled] pay no construction cost. */
+    private val dialerEnforcer by lazy {
+        DialerDefaultEnforcer(appContext, preferences, dialerRoleController)
+    }
 
     // -------- Internal mutable state
     // Private so only this ViewModel can mutate it.
@@ -372,15 +383,19 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
      */
     override fun setDialerModeEnabled(enabled: Boolean) {
         preferences.setDialerModeEnabled(enabled)
-        if (CallDetection.isInitialized) {
-            CallDetection.setMode(
-                DialerModeState.effective(
-                    prefOn = enabled,
-                    roleHeld = dialerRoleController.isDefaultDialer()
+        DialerLauncherIcon.setEnabled(appContext, enabled)
+        viewModelScope.launch(Dispatchers.IO) {
+            if (enabled) dialerEnforcer.enforce() else dialerEnforcer.relinquish()
+            if (CallDetection.isInitialized) {
+                CallDetection.setMode(
+                    DialerModeState.effective(
+                        prefOn = enabled,
+                        roleHeld = dialerRoleController.isDefaultDialer(),
+                    )
                 )
-            )
+            }
+            refresh() // re-read state so the toggle/banner reflect reality
         }
-        refresh()
     }
 
     /** Turns diagnostic logging on or off.

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
@@ -60,6 +60,7 @@ interface SettingsActions {
     fun setRetentionTimeHour(hour: Int)
     fun setRetentionTimeMinute(minute: Int)
     fun setDialerModeEnabled(enabled: Boolean)
+    fun refresh()
 }
 
 /**
@@ -134,7 +135,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
      * val autoRecord = remember(updateTrigger) { preferences.isAutoRecordIncomingEnabled() }
      * ```
      */
-    fun refresh() {
+    override fun refresh() {
         _updateTrigger.update { it + 1 }
     }
 

--- a/app/src/main/res/values-de/strings_dialer.xml
+++ b/app/src/main/res/values-de/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Anruf läuft…</string>
     <string name="dialer_status_active">Aktiv</string>
     <string name="dialer_status_ended">Anruf beendet</string>
+    <string name="dialer_place_call">Anrufen</string>
+    <string name="dialer_backspace">Löschen</string>
 </resources>

--- a/app/src/main/res/values-de/strings_dialer.xml
+++ b/app/src/main/res/values-de/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Eingehender Anruf</string>
+    <string name="dialer_answer">Annehmen</string>
+    <string name="dialer_reject">Ablehnen</string>
+    <string name="dialer_end_call">Auflegen</string>
+    <string name="dialer_mute">Stummschalten</string>
+    <string name="dialer_speaker">Lautsprecher</string>
+    <string name="dialer_hold">Halten</string>
+    <string name="dialer_keypad">Tastenfeld</string>
+    <string name="dialer_record">Aufnehmen</string>
+    <string name="dialer_stop_recording">Aufnahme stoppen</string>
+    <string name="dialer_unknown_caller">Unbekannt</string>
+</resources>

--- a/app/src/main/res/values-de/strings_dialer.xml
+++ b/app/src/main/res/values-de/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Aufnehmen</string>
     <string name="dialer_stop_recording">Aufnahme stoppen</string>
     <string name="dialer_unknown_caller">Unbekannt</string>
+    <string name="dialer_status_dialing">Anruf läuft…</string>
+    <string name="dialer_status_active">Aktiv</string>
+    <string name="dialer_status_ended">Anruf beendet</string>
 </resources>

--- a/app/src/main/res/values-de/strings_dialer.xml
+++ b/app/src/main/res/values-de/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Ersetzt die System-Telefon-App. Ermöglicht Anrufaufzeichnung ohne Root.</string>
     <string name="settings_dialer_mode_role_lost_banner">Standard-Wähler-Rolle verloren. Tippen zum Wiederherstellen und Aufzeichnung fortsetzen.</string>
     <string name="settings_dialer_mode_release_hint">Um nicht mehr als Standard-Telefon-App zu fungieren, öffnen Sie die Standard-Apps-Einstellungen.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-de/strings_dialer.xml
+++ b/app/src/main/res/values-de/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Anruf beendet</string>
     <string name="dialer_place_call">Anrufen</string>
     <string name="dialer_backspace">Löschen</string>
+    <string name="settings_dialer_mode_label">Standard-Wähler-Modus</string>
+    <string name="settings_dialer_mode_description">Ersetzt die System-Telefon-App. Ermöglicht Anrufaufzeichnung ohne Root.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Standard-Wähler-Rolle verloren. Tippen zum Wiederherstellen und Aufzeichnung fortsetzen.</string>
+    <string name="settings_dialer_mode_release_hint">Um nicht mehr als Standard-Telefon-App zu fungieren, öffnen Sie die Standard-Apps-Einstellungen.</string>
 </resources>

--- a/app/src/main/res/values-es/strings_dialer.xml
+++ b/app/src/main/res/values-es/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Grabar</string>
     <string name="dialer_stop_recording">Detener grabación</string>
     <string name="dialer_unknown_caller">Desconocido</string>
+    <string name="dialer_status_dialing">Llamando…</string>
+    <string name="dialer_status_active">Activo</string>
+    <string name="dialer_status_ended">Llamada finalizada</string>
 </resources>

--- a/app/src/main/res/values-es/strings_dialer.xml
+++ b/app/src/main/res/values-es/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Llamando…</string>
     <string name="dialer_status_active">Activo</string>
     <string name="dialer_status_ended">Llamada finalizada</string>
+    <string name="dialer_place_call">Llamar</string>
+    <string name="dialer_backspace">Borrar</string>
 </resources>

--- a/app/src/main/res/values-es/strings_dialer.xml
+++ b/app/src/main/res/values-es/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Reemplaza la app de teléfono del sistema. Permite grabar llamadas sin root.</string>
     <string name="settings_dialer_mode_role_lost_banner">Se perdió el rol de marcador. Toca para restaurar y reanudar la grabación.</string>
     <string name="settings_dialer_mode_release_hint">Para dejar de ser la app de teléfono predeterminada, abre la configuración de apps predeterminadas.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-es/strings_dialer.xml
+++ b/app/src/main/res/values-es/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Llamada finalizada</string>
     <string name="dialer_place_call">Llamar</string>
     <string name="dialer_backspace">Borrar</string>
+    <string name="settings_dialer_mode_label">Modo marcador predeterminado</string>
+    <string name="settings_dialer_mode_description">Reemplaza la app de teléfono del sistema. Permite grabar llamadas sin root.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Se perdió el rol de marcador. Toca para restaurar y reanudar la grabación.</string>
+    <string name="settings_dialer_mode_release_hint">Para dejar de ser la app de teléfono predeterminada, abre la configuración de apps predeterminadas.</string>
 </resources>

--- a/app/src/main/res/values-es/strings_dialer.xml
+++ b/app/src/main/res/values-es/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Llamada entrante</string>
+    <string name="dialer_answer">Contestar</string>
+    <string name="dialer_reject">Rechazar</string>
+    <string name="dialer_end_call">Colgar</string>
+    <string name="dialer_mute">Silencio</string>
+    <string name="dialer_speaker">Altavoz</string>
+    <string name="dialer_hold">Espera</string>
+    <string name="dialer_keypad">Teclado</string>
+    <string name="dialer_record">Grabar</string>
+    <string name="dialer_stop_recording">Detener grabación</string>
+    <string name="dialer_unknown_caller">Desconocido</string>
+</resources>

--- a/app/src/main/res/values-fr/strings_dialer.xml
+++ b/app/src/main/res/values-fr/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Appel terminé</string>
     <string name="dialer_place_call">Appeler</string>
     <string name="dialer_backspace">Effacer</string>
+    <string name="settings_dialer_mode_label">Mode téléphone par défaut</string>
+    <string name="settings_dialer_mode_description">Remplace l\'application téléphone du système. Permet l\'enregistrement des appels sans root.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Le rôle de téléphone par défaut a été perdu. Appuyez pour restaurer et reprendre l\'enregistrement.</string>
+    <string name="settings_dialer_mode_release_hint">Pour ne plus être l\'application téléphone par défaut, ouvrez les paramètres des applications par défaut.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_dialer.xml
+++ b/app/src/main/res/values-fr/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Remplace l\'application téléphone du système. Permet l\'enregistrement des appels sans root.</string>
     <string name="settings_dialer_mode_role_lost_banner">Le rôle de téléphone par défaut a été perdu. Appuyez pour restaurer et reprendre l\'enregistrement.</string>
     <string name="settings_dialer_mode_release_hint">Pour ne plus être l\'application téléphone par défaut, ouvrez les paramètres des applications par défaut.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_dialer.xml
+++ b/app/src/main/res/values-fr/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Appel entrant</string>
+    <string name="dialer_answer">Répondre</string>
+    <string name="dialer_reject">Refuser</string>
+    <string name="dialer_end_call">Raccrocher</string>
+    <string name="dialer_mute">Muet</string>
+    <string name="dialer_speaker">Haut-parleur</string>
+    <string name="dialer_hold">Attente</string>
+    <string name="dialer_keypad">Clavier</string>
+    <string name="dialer_record">Enregistrer</string>
+    <string name="dialer_stop_recording">Arrêter l\'enregistrement</string>
+    <string name="dialer_unknown_caller">Inconnu</string>
+</resources>

--- a/app/src/main/res/values-fr/strings_dialer.xml
+++ b/app/src/main/res/values-fr/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Enregistrer</string>
     <string name="dialer_stop_recording">Arrêter l\'enregistrement</string>
     <string name="dialer_unknown_caller">Inconnu</string>
+    <string name="dialer_status_dialing">Appel en cours…</string>
+    <string name="dialer_status_active">Actif</string>
+    <string name="dialer_status_ended">Appel terminé</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_dialer.xml
+++ b/app/src/main/res/values-fr/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Appel en cours…</string>
     <string name="dialer_status_active">Actif</string>
     <string name="dialer_status_ended">Appel terminé</string>
+    <string name="dialer_place_call">Appeler</string>
+    <string name="dialer_backspace">Effacer</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_dialer.xml
+++ b/app/src/main/res/values-hu/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Rögzítés</string>
     <string name="dialer_stop_recording">Rögzítés leállítása</string>
     <string name="dialer_unknown_caller">Ismeretlen</string>
+    <string name="dialer_status_dialing">Hívás folyamatban…</string>
+    <string name="dialer_status_active">Aktív</string>
+    <string name="dialer_status_ended">Hívás befejezve</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_dialer.xml
+++ b/app/src/main/res/values-hu/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Hívás befejezve</string>
     <string name="dialer_place_call">Hívás</string>
     <string name="dialer_backspace">Töröl</string>
+    <string name="settings_dialer_mode_label">Alapértelmezett tárcsázó mód</string>
+    <string name="settings_dialer_mode_description">Felváltja a rendszer telefonalkalmazását. Lehetővé teszi a hívások rögzítését root nélkül.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Az alapértelmezett tárcsázó szerepkör elveszett. Koppintson a visszaállításhoz és a rögzítés folytatásához.</string>
+    <string name="settings_dialer_mode_release_hint">Ha nem szeretne alapértelmezett telefonalkalmazás lenni, nyissa meg az alapértelmezett alkalmazások beállításait.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_dialer.xml
+++ b/app/src/main/res/values-hu/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Felváltja a rendszer telefonalkalmazását. Lehetővé teszi a hívások rögzítését root nélkül.</string>
     <string name="settings_dialer_mode_role_lost_banner">Az alapértelmezett tárcsázó szerepkör elveszett. Koppintson a visszaállításhoz és a rögzítés folytatásához.</string>
     <string name="settings_dialer_mode_release_hint">Ha nem szeretne alapértelmezett telefonalkalmazás lenni, nyissa meg az alapértelmezett alkalmazások beállításait.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_dialer.xml
+++ b/app/src/main/res/values-hu/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Hívás folyamatban…</string>
     <string name="dialer_status_active">Aktív</string>
     <string name="dialer_status_ended">Hívás befejezve</string>
+    <string name="dialer_place_call">Hívás</string>
+    <string name="dialer_backspace">Töröl</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_dialer.xml
+++ b/app/src/main/res/values-hu/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Bejövő hívás</string>
+    <string name="dialer_answer">Fogadás</string>
+    <string name="dialer_reject">Elutasítás</string>
+    <string name="dialer_end_call">Hívás befejezése</string>
+    <string name="dialer_mute">Némítás</string>
+    <string name="dialer_speaker">Hangszóró</string>
+    <string name="dialer_hold">Tartás</string>
+    <string name="dialer_keypad">Billentyűzet</string>
+    <string name="dialer_record">Rögzítés</string>
+    <string name="dialer_stop_recording">Rögzítés leállítása</string>
+    <string name="dialer_unknown_caller">Ismeretlen</string>
+</resources>

--- a/app/src/main/res/values-it/strings_dialer.xml
+++ b/app/src/main/res/values-it/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Chiamata terminata</string>
     <string name="dialer_place_call">Chiama</string>
     <string name="dialer_backspace">Cancella</string>
+    <string name="settings_dialer_mode_label">Modalità telefono predefinita</string>
+    <string name="settings_dialer_mode_description">Sostituisce l\'app telefono di sistema. Consente la registrazione delle chiamate senza root.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Il ruolo di telefono predefinito è stato perso. Tocca per ripristinare e riprendere la registrazione.</string>
+    <string name="settings_dialer_mode_release_hint">Per smettere di essere l\'app telefono predefinita, apri le impostazioni delle app predefinite.</string>
 </resources>

--- a/app/src/main/res/values-it/strings_dialer.xml
+++ b/app/src/main/res/values-it/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Chiamata in arrivo</string>
+    <string name="dialer_answer">Rispondi</string>
+    <string name="dialer_reject">Rifiuta</string>
+    <string name="dialer_end_call">Termina chiamata</string>
+    <string name="dialer_mute">Muto</string>
+    <string name="dialer_speaker">Altoparlante</string>
+    <string name="dialer_hold">In attesa</string>
+    <string name="dialer_keypad">Tastiera</string>
+    <string name="dialer_record">Registra</string>
+    <string name="dialer_stop_recording">Interrompi registrazione</string>
+    <string name="dialer_unknown_caller">Sconosciuto</string>
+</resources>

--- a/app/src/main/res/values-it/strings_dialer.xml
+++ b/app/src/main/res/values-it/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Sostituisce l\'app telefono di sistema. Consente la registrazione delle chiamate senza root.</string>
     <string name="settings_dialer_mode_role_lost_banner">Il ruolo di telefono predefinito è stato perso. Tocca per ripristinare e riprendere la registrazione.</string>
     <string name="settings_dialer_mode_release_hint">Per smettere di essere l\'app telefono predefinita, apri le impostazioni delle app predefinite.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-it/strings_dialer.xml
+++ b/app/src/main/res/values-it/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Chiamata in corso…</string>
     <string name="dialer_status_active">Attivo</string>
     <string name="dialer_status_ended">Chiamata terminata</string>
+    <string name="dialer_place_call">Chiama</string>
+    <string name="dialer_backspace">Cancella</string>
 </resources>

--- a/app/src/main/res/values-it/strings_dialer.xml
+++ b/app/src/main/res/values-it/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Registra</string>
     <string name="dialer_stop_recording">Interrompi registrazione</string>
     <string name="dialer_unknown_caller">Sconosciuto</string>
+    <string name="dialer_status_dialing">Chiamata in corso…</string>
+    <string name="dialer_status_active">Attivo</string>
+    <string name="dialer_status_ended">Chiamata terminata</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_dialer.xml
+++ b/app/src/main/res/values-pl/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Zastępuje systemową aplikację telefonu. Umożliwia nagrywanie rozmów bez roota.</string>
     <string name="settings_dialer_mode_role_lost_banner">Utracono rolę domyślnego dialera. Dotknij, aby przywrócić i wznowić nagrywanie.</string>
     <string name="settings_dialer_mode_release_hint">Aby przestać być domyślną aplikacją telefoniczną, otwórz ustawienia domyślnych aplikacji.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_dialer.xml
+++ b/app/src/main/res/values-pl/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Połączenie przychodzące</string>
+    <string name="dialer_answer">Odbierz</string>
+    <string name="dialer_reject">Odrzuć</string>
+    <string name="dialer_end_call">Zakończ połączenie</string>
+    <string name="dialer_mute">Wycisz</string>
+    <string name="dialer_speaker">Głośnik</string>
+    <string name="dialer_hold">Wstrzymaj</string>
+    <string name="dialer_keypad">Klawiatura</string>
+    <string name="dialer_record">Nagraj</string>
+    <string name="dialer_stop_recording">Zatrzymaj nagrywanie</string>
+    <string name="dialer_unknown_caller">Nieznany</string>
+</resources>

--- a/app/src/main/res/values-pl/strings_dialer.xml
+++ b/app/src/main/res/values-pl/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Połączenie zakończone</string>
     <string name="dialer_place_call">Zadzwoń</string>
     <string name="dialer_backspace">Usuń</string>
+    <string name="settings_dialer_mode_label">Tryb domyślnego dialera</string>
+    <string name="settings_dialer_mode_description">Zastępuje systemową aplikację telefonu. Umożliwia nagrywanie rozmów bez roota.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Utracono rolę domyślnego dialera. Dotknij, aby przywrócić i wznowić nagrywanie.</string>
+    <string name="settings_dialer_mode_release_hint">Aby przestać być domyślną aplikacją telefoniczną, otwórz ustawienia domyślnych aplikacji.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_dialer.xml
+++ b/app/src/main/res/values-pl/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Połączenie trwa…</string>
     <string name="dialer_status_active">Aktywne</string>
     <string name="dialer_status_ended">Połączenie zakończone</string>
+    <string name="dialer_place_call">Zadzwoń</string>
+    <string name="dialer_backspace">Usuń</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_dialer.xml
+++ b/app/src/main/res/values-pl/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Nagraj</string>
     <string name="dialer_stop_recording">Zatrzymaj nagrywanie</string>
     <string name="dialer_unknown_caller">Nieznany</string>
+    <string name="dialer_status_dialing">Połączenie trwa…</string>
+    <string name="dialer_status_active">Aktywne</string>
+    <string name="dialer_status_ended">Połączenie zakończone</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_dialer.xml
+++ b/app/src/main/res/values-ru/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Звонок…</string>
     <string name="dialer_status_active">Активный</string>
     <string name="dialer_status_ended">Звонок завершён</string>
+    <string name="dialer_place_call">Позвонить</string>
+    <string name="dialer_backspace">Удалить</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_dialer.xml
+++ b/app/src/main/res/values-ru/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Запись</string>
     <string name="dialer_stop_recording">Остановить запись</string>
     <string name="dialer_unknown_caller">Неизвестный</string>
+    <string name="dialer_status_dialing">Звонок…</string>
+    <string name="dialer_status_active">Активный</string>
+    <string name="dialer_status_ended">Звонок завершён</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_dialer.xml
+++ b/app/src/main/res/values-ru/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Заменяет системное приложение телефона. Позволяет записывать звонки без root-прав.</string>
     <string name="settings_dialer_mode_role_lost_banner">Роль стандартного приложения телефона утеряна. Нажмите для восстановления и возобновления записи.</string>
     <string name="settings_dialer_mode_release_hint">Чтобы перестать быть стандартным приложением телефона, откройте настройки приложений по умолчанию.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_dialer.xml
+++ b/app/src/main/res/values-ru/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Входящий звонок</string>
+    <string name="dialer_answer">Принять</string>
+    <string name="dialer_reject">Отклонить</string>
+    <string name="dialer_end_call">Завершить звонок</string>
+    <string name="dialer_mute">Без звука</string>
+    <string name="dialer_speaker">Громкоговоритель</string>
+    <string name="dialer_hold">Удержание</string>
+    <string name="dialer_keypad">Клавиатура</string>
+    <string name="dialer_record">Запись</string>
+    <string name="dialer_stop_recording">Остановить запись</string>
+    <string name="dialer_unknown_caller">Неизвестный</string>
+</resources>

--- a/app/src/main/res/values-ru/strings_dialer.xml
+++ b/app/src/main/res/values-ru/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Звонок завершён</string>
     <string name="dialer_place_call">Позвонить</string>
     <string name="dialer_backspace">Удалить</string>
+    <string name="settings_dialer_mode_label">Режим телефонного приложения</string>
+    <string name="settings_dialer_mode_description">Заменяет системное приложение телефона. Позволяет записывать звонки без root-прав.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Роль стандартного приложения телефона утеряна. Нажмите для восстановления и возобновления записи.</string>
+    <string name="settings_dialer_mode_release_hint">Чтобы перестать быть стандартным приложением телефона, откройте настройки приложений по умолчанию.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_dialer.xml
+++ b/app/src/main/res/values-vi/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Ghi âm</string>
     <string name="dialer_stop_recording">Dừng ghi âm</string>
     <string name="dialer_unknown_caller">Không xác định</string>
+    <string name="dialer_status_dialing">Đang gọi…</string>
+    <string name="dialer_status_active">Đang hoạt động</string>
+    <string name="dialer_status_ended">Cuộc gọi đã kết thúc</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_dialer.xml
+++ b/app/src/main/res/values-vi/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Cuộc gọi đã kết thúc</string>
     <string name="dialer_place_call">Gọi</string>
     <string name="dialer_backspace">Xóa</string>
+    <string name="settings_dialer_mode_label">Chế độ ứng dụng gọi mặc định</string>
+    <string name="settings_dialer_mode_description">Thay thế ứng dụng điện thoại hệ thống. Cho phép ghi âm cuộc gọi mà không cần root.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Đã mất vai trò ứng dụng gọi mặc định. Nhấn để khôi phục và tiếp tục ghi âm.</string>
+    <string name="settings_dialer_mode_release_hint">Để ngừng là ứng dụng điện thoại mặc định, hãy mở cài đặt ứng dụng mặc định.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_dialer.xml
+++ b/app/src/main/res/values-vi/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Cuộc gọi đến</string>
+    <string name="dialer_answer">Trả lời</string>
+    <string name="dialer_reject">Từ chối</string>
+    <string name="dialer_end_call">Kết thúc cuộc gọi</string>
+    <string name="dialer_mute">Tắt tiếng</string>
+    <string name="dialer_speaker">Loa ngoài</string>
+    <string name="dialer_hold">Giữ máy</string>
+    <string name="dialer_keypad">Bàn phím</string>
+    <string name="dialer_record">Ghi âm</string>
+    <string name="dialer_stop_recording">Dừng ghi âm</string>
+    <string name="dialer_unknown_caller">Không xác định</string>
+</resources>

--- a/app/src/main/res/values-vi/strings_dialer.xml
+++ b/app/src/main/res/values-vi/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Đang gọi…</string>
     <string name="dialer_status_active">Đang hoạt động</string>
     <string name="dialer_status_ended">Cuộc gọi đã kết thúc</string>
+    <string name="dialer_place_call">Gọi</string>
+    <string name="dialer_backspace">Xóa</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_dialer.xml
+++ b/app/src/main/res/values-vi/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Thay thế ứng dụng điện thoại hệ thống. Cho phép ghi âm cuộc gọi mà không cần root.</string>
     <string name="settings_dialer_mode_role_lost_banner">Đã mất vai trò ứng dụng gọi mặc định. Nhấn để khôi phục và tiếp tục ghi âm.</string>
     <string name="settings_dialer_mode_release_hint">Để ngừng là ứng dụng điện thoại mặc định, hãy mở cài đặt ứng dụng mặc định.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_dialer.xml
+++ b/app/src/main/res/values-zh-rCN/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">正在拨打…</string>
     <string name="dialer_status_active">通话中</string>
     <string name="dialer_status_ended">通话已结束</string>
+    <string name="dialer_place_call">拨号</string>
+    <string name="dialer_backspace">删除</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_dialer.xml
+++ b/app/src/main/res/values-zh-rCN/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">替换系统电话应用。无需 root 即可录制通话。</string>
     <string name="settings_dialer_mode_role_lost_banner">默认拨号器角色已丢失。点击以恢复并继续录音。</string>
     <string name="settings_dialer_mode_release_hint">若要停止作为默认电话应用，请打开默认应用设置。</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_dialer.xml
+++ b/app/src/main/res/values-zh-rCN/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">来电</string>
+    <string name="dialer_answer">接听</string>
+    <string name="dialer_reject">拒接</string>
+    <string name="dialer_end_call">挂断</string>
+    <string name="dialer_mute">静音</string>
+    <string name="dialer_speaker">扬声器</string>
+    <string name="dialer_hold">保留</string>
+    <string name="dialer_keypad">键盘</string>
+    <string name="dialer_record">录音</string>
+    <string name="dialer_stop_recording">停止录音</string>
+    <string name="dialer_unknown_caller">未知</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings_dialer.xml
+++ b/app/src/main/res/values-zh-rCN/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">通话已结束</string>
     <string name="dialer_place_call">拨号</string>
     <string name="dialer_backspace">删除</string>
+    <string name="settings_dialer_mode_label">默认拨号器模式</string>
+    <string name="settings_dialer_mode_description">替换系统电话应用。无需 root 即可录制通话。</string>
+    <string name="settings_dialer_mode_role_lost_banner">默认拨号器角色已丢失。点击以恢复并继续录音。</string>
+    <string name="settings_dialer_mode_release_hint">若要停止作为默认电话应用，请打开默认应用设置。</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_dialer.xml
+++ b/app/src/main/res/values-zh-rCN/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">录音</string>
     <string name="dialer_stop_recording">停止录音</string>
     <string name="dialer_unknown_caller">未知</string>
+    <string name="dialer_status_dialing">正在拨打…</string>
+    <string name="dialer_status_active">通话中</string>
+    <string name="dialer_status_ended">通话已结束</string>
 </resources>

--- a/app/src/main/res/values/strings_dialer.xml
+++ b/app/src/main/res/values/strings_dialer.xml
@@ -20,4 +20,5 @@
     <string name="settings_dialer_mode_description">Replace the system phone app. Enables call recording without root.</string>
     <string name="settings_dialer_mode_role_lost_banner">Dialer role was lost. Tap to restore and resume recording.</string>
     <string name="settings_dialer_mode_release_hint">To stop acting as the default phone app, open Default apps settings.</string>
+    <string name="dialer_launcher_label">CallVault Dialer</string>
 </resources>

--- a/app/src/main/res/values/strings_dialer.xml
+++ b/app/src/main/res/values/strings_dialer.xml
@@ -16,4 +16,8 @@
     <string name="dialer_status_ended">Call ended</string>
     <string name="dialer_place_call">Call</string>
     <string name="dialer_backspace">Backspace</string>
+    <string name="settings_dialer_mode_label">Dialer mode</string>
+    <string name="settings_dialer_mode_description">Replace the system phone app. Enables call recording without root.</string>
+    <string name="settings_dialer_mode_role_lost_banner">Dialer role was lost. Tap to restore and resume recording.</string>
+    <string name="settings_dialer_mode_release_hint">To stop acting as the default phone app, open Default apps settings.</string>
 </resources>

--- a/app/src/main/res/values/strings_dialer.xml
+++ b/app/src/main/res/values/strings_dialer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Incoming call</string>
+    <string name="dialer_answer">Answer</string>
+    <string name="dialer_reject">Reject</string>
+    <string name="dialer_end_call">End call</string>
+    <string name="dialer_mute">Mute</string>
+    <string name="dialer_speaker">Speaker</string>
+    <string name="dialer_hold">Hold</string>
+    <string name="dialer_keypad">Keypad</string>
+    <string name="dialer_record">Record</string>
+    <string name="dialer_stop_recording">Stop recording</string>
+    <string name="dialer_unknown_caller">Unknown</string>
+</resources>

--- a/app/src/main/res/values/strings_dialer.xml
+++ b/app/src/main/res/values/strings_dialer.xml
@@ -11,4 +11,7 @@
     <string name="dialer_record">Record</string>
     <string name="dialer_stop_recording">Stop recording</string>
     <string name="dialer_unknown_caller">Unknown</string>
+    <string name="dialer_status_dialing">Calling…</string>
+    <string name="dialer_status_active">Active</string>
+    <string name="dialer_status_ended">Call ended</string>
 </resources>

--- a/app/src/main/res/values/strings_dialer.xml
+++ b/app/src/main/res/values/strings_dialer.xml
@@ -14,4 +14,6 @@
     <string name="dialer_status_dialing">Calling…</string>
     <string name="dialer_status_active">Active</string>
     <string name="dialer_status_ended">Call ended</string>
+    <string name="dialer_place_call">Call</string>
+    <string name="dialer_backspace">Backspace</string>
 </resources>

--- a/app/src/test/java/com/baba/callvault/SanityTest.kt
+++ b/app/src/test/java/com/baba/callvault/SanityTest.kt
@@ -1,0 +1,8 @@
+package com.baba.callvault
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SanityTest {
+    @Test fun harness_runs() { assertEquals(4, 2 + 2) }
+}

--- a/app/src/test/java/com/baba/callvault/calls/CallDetectionSinkTest.kt
+++ b/app/src/test/java/com/baba/callvault/calls/CallDetectionSinkTest.kt
@@ -9,7 +9,7 @@ class CallDetectionSinkTest {
         val router = CallEventRouter(sink = { seen.add(it) })
         router.setActiveMode(DetectionMode.BROADCAST)
         val src = com.baba.callvault.dialer.BroadcastCallEventSource(router)
-        src.emit(CallEvent(CallEvent.Phase.ACTIVE, "1", CallDirection.OUTGOING, false))
+        src.emit(CallEvent(CallEvent.Phase.ACTIVE, "1", CallDirection.UNKNOWN, false))
         assertEquals(1, seen.size)
     }
 }

--- a/app/src/test/java/com/baba/callvault/calls/CallDetectionSinkTest.kt
+++ b/app/src/test/java/com/baba/callvault/calls/CallDetectionSinkTest.kt
@@ -1,0 +1,15 @@
+package com.baba.callvault.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CallDetectionSinkTest {
+    @Test fun broadcast_source_reaches_sink_in_broadcast_mode() {
+        val seen = mutableListOf<CallEvent>()
+        val router = CallEventRouter(sink = { seen.add(it) })
+        router.setActiveMode(DetectionMode.BROADCAST)
+        val src = com.baba.callvault.dialer.BroadcastCallEventSource(router)
+        src.emit(CallEvent(CallEvent.Phase.ACTIVE, "1", CallDirection.OUTGOING, false))
+        assertEquals(1, seen.size)
+    }
+}

--- a/app/src/test/java/com/baba/callvault/calls/CallEventRouterTest.kt
+++ b/app/src/test/java/com/baba/callvault/calls/CallEventRouterTest.kt
@@ -1,0 +1,29 @@
+package com.baba.callvault.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CallEventRouterTest {
+    private fun event() = CallEvent(CallEvent.Phase.ACTIVE, "1", CallDirection.INCOMING, false)
+
+    @Test fun forwards_events_from_active_source_only() {
+        val seen = mutableListOf<CallEvent>()
+        val router = CallEventRouter(sink = { seen.add(it) })
+        router.setActiveMode(DetectionMode.TELECOM)
+
+        router.submit(DetectionMode.TELECOM, event())   // active → forwarded
+        router.submit(DetectionMode.BROADCAST, event())  // inactive → dropped
+
+        assertEquals(1, seen.size)
+    }
+
+    @Test fun switching_mode_changes_which_source_is_forwarded() {
+        val seen = mutableListOf<CallEvent>()
+        val router = CallEventRouter(sink = { seen.add(it) })
+        router.setActiveMode(DetectionMode.BROADCAST)
+        router.submit(DetectionMode.BROADCAST, event())
+        router.setActiveMode(DetectionMode.TELECOM)
+        router.submit(DetectionMode.BROADCAST, event())  // now inactive → dropped
+        assertEquals(1, seen.size)
+    }
+}

--- a/app/src/test/java/com/baba/callvault/calls/CallEventTest.kt
+++ b/app/src/test/java/com/baba/callvault/calls/CallEventTest.kt
@@ -1,0 +1,20 @@
+package com.baba.callvault.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CallEventTest {
+    @Test fun builds_incoming_ringing_event() {
+        val e = CallEvent(CallEvent.Phase.RINGING, "+15551234", CallDirection.INCOMING, isEmergency = false)
+        assertEquals(CallEvent.Phase.RINGING, e.phase)
+        assertEquals(CallDirection.INCOMING, e.direction)
+        assertEquals("+15551234", e.number)
+        assertTrue(!e.isEmergency)
+    }
+
+    @Test fun emergency_flag_is_carried() {
+        val e = CallEvent(CallEvent.Phase.DIALING, "911", CallDirection.OUTGOING, isEmergency = true)
+        assertTrue(e.isEmergency)
+    }
+}

--- a/app/src/test/java/com/baba/callvault/calls/CallStateRepositoryTest.kt
+++ b/app/src/test/java/com/baba/callvault/calls/CallStateRepositoryTest.kt
@@ -1,0 +1,22 @@
+package com.baba.callvault.calls
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CallStateRepositoryTest {
+    @Test fun update_and_clear_current_call() = runBlocking {
+        CallStateRepository.update(UiCall("1", CallEvent.Phase.ACTIVE, CallDirection.INCOMING, false, false))
+        assertEquals("1", CallStateRepository.current.first()!!.number)
+        CallStateRepository.update(null)
+        assertNull(CallStateRepository.current.first())
+    }
+
+    @Test fun set_recording_updates_flag() = runBlocking {
+        CallStateRepository.update(UiCall("1", CallEvent.Phase.ACTIVE, CallDirection.INCOMING, false, false))
+        CallStateRepository.setRecording(true)
+        assertEquals(true, CallStateRepository.current.first()!!.isRecording)
+    }
+}

--- a/app/src/test/java/com/baba/callvault/data/DialerModePrefTest.kt
+++ b/app/src/test/java/com/baba/callvault/data/DialerModePrefTest.kt
@@ -1,0 +1,22 @@
+package com.baba.callvault.data
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35]) // Robolectric 4.14 max; project targets SDK 36
+class DialerModePrefTest {
+    private val prefs = AppPreferences(ApplicationProvider.getApplicationContext())
+
+    @Test fun defaults_to_false() { assertFalse(prefs.isDialerModeEnabled()) }
+
+    @Test fun persists_true() {
+        prefs.setDialerModeEnabled(true)
+        assertTrue(prefs.isDialerModeEnabled())
+    }
+}

--- a/app/src/test/java/com/baba/callvault/data/PriorDefaultDialerPrefTest.kt
+++ b/app/src/test/java/com/baba/callvault/data/PriorDefaultDialerPrefTest.kt
@@ -1,0 +1,24 @@
+package com.baba.callvault.data
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class PriorDefaultDialerPrefTest {
+    private val prefs = AppPreferences(ApplicationProvider.getApplicationContext())
+
+    @Test fun defaults_to_null() { assertNull(prefs.getPriorDefaultDialer()) }
+
+    @Test fun stores_and_clears() {
+        prefs.setPriorDefaultDialer("com.google.android.dialer")
+        assertEquals("com.google.android.dialer", prefs.getPriorDefaultDialer())
+        prefs.setPriorDefaultDialer(null)
+        assertNull(prefs.getPriorDefaultDialer())
+    }
+}

--- a/app/src/test/java/com/baba/callvault/dialer/CallPlacerTest.kt
+++ b/app/src/test/java/com/baba/callvault/dialer/CallPlacerTest.kt
@@ -1,0 +1,22 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CallPlacerTest {
+    @Test fun blank_is_not_dialable() { assertFalse(CallPlacer.isDialable("")) }
+    @Test fun digits_are_dialable() { assertTrue(CallPlacer.isDialable("112")) }
+    @Test fun sanitizes_display_to_dial_string() {
+        assertEquals("+15551234", CallPlacer.normalize(" +1 (555) 1234 "))
+    }
+}

--- a/app/src/test/java/com/baba/callvault/dialer/DialerDefaultEnforcerTest.kt
+++ b/app/src/test/java/com/baba/callvault/dialer/DialerDefaultEnforcerTest.kt
@@ -16,4 +16,9 @@ class DialerDefaultEnforcerTest {
         assertEquals("cmd telecom set-default-dialer com.google.android.dialer",
             DialerCommands.restore("com.google.android.dialer"))
     }
+    @Test fun set_default_and_grant_is_one_command() {
+        assertEquals(
+            "cmd telecom set-default-dialer com.baba.callvault ; pm grant com.baba.callvault android.permission.CALL_PHONE",
+            DialerCommands.setDefaultAndGrant("com.baba.callvault"))
+    }
 }

--- a/app/src/test/java/com/baba/callvault/dialer/DialerDefaultEnforcerTest.kt
+++ b/app/src/test/java/com/baba/callvault/dialer/DialerDefaultEnforcerTest.kt
@@ -1,0 +1,19 @@
+package com.baba.callvault.dialer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DialerDefaultEnforcerTest {
+    @Test fun set_default_command() {
+        assertEquals("cmd telecom set-default-dialer com.baba.callvault",
+            DialerCommands.setDefault("com.baba.callvault"))
+    }
+    @Test fun grant_call_phone_command() {
+        assertEquals("pm grant com.baba.callvault android.permission.CALL_PHONE",
+            DialerCommands.grantCallPhone("com.baba.callvault"))
+    }
+    @Test fun restore_command() {
+        assertEquals("cmd telecom set-default-dialer com.google.android.dialer",
+            DialerCommands.restore("com.google.android.dialer"))
+    }
+}

--- a/app/src/test/java/com/baba/callvault/dialer/DialerModeStateTest.kt
+++ b/app/src/test/java/com/baba/callvault/dialer/DialerModeStateTest.kt
@@ -1,0 +1,25 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.dialer
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DialerModeStateTest {
+    @Test fun effective_requires_pref_and_role() {
+        assertTrue(DialerModeState.effective(prefOn = true, roleHeld = true))
+        assertFalse(DialerModeState.effective(prefOn = true, roleHeld = false))
+        assertFalse(DialerModeState.effective(prefOn = false, roleHeld = true))
+    }
+    @Test fun banner_shown_when_pref_on_but_role_lost() {
+        assertTrue(DialerModeState.shouldShowRoleLostBanner(prefOn = true, roleHeld = false))
+        assertFalse(DialerModeState.shouldShowRoleLostBanner(prefOn = false, roleHeld = false))
+    }
+}

--- a/app/src/test/java/com/baba/callvault/dialer/DialerModeStateTest.kt
+++ b/app/src/test/java/com/baba/callvault/dialer/DialerModeStateTest.kt
@@ -17,6 +17,7 @@ class DialerModeStateTest {
         assertTrue(DialerModeState.effective(prefOn = true, roleHeld = true))
         assertFalse(DialerModeState.effective(prefOn = true, roleHeld = false))
         assertFalse(DialerModeState.effective(prefOn = false, roleHeld = true))
+        assertFalse(DialerModeState.effective(prefOn = false, roleHeld = false))
     }
     @Test fun banner_shown_when_pref_on_but_role_lost() {
         assertTrue(DialerModeState.shouldShowRoleLostBanner(prefOn = true, roleHeld = false))

--- a/app/src/test/java/com/baba/callvault/dialer/DialerRoleControllerTest.kt
+++ b/app/src/test/java/com/baba/callvault/dialer/DialerRoleControllerTest.kt
@@ -1,0 +1,38 @@
+package com.baba.callvault.dialer
+
+import android.app.role.RoleManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric 4.14 ShadowRoleManager note:
+ * - isRoleAvailable() returns false for all roles by default (none pre-registered).
+ * - Tests that exercise requestRoleIntent() must first add the role as available via
+ *   shadowOf(rm).addAvailableRole(...) so that the implementation's isRoleAvailable guard passes.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35]) // Robolectric 4.14 max; project targets SDK 36
+class DialerRoleControllerTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val controller = DialerRoleController(context)
+
+    @Test fun reports_not_default_when_role_not_held() {
+        // Shadow default: role not available/held → isDefaultDialer() must return false
+        assertFalse(controller.isDefaultDialer())
+    }
+
+    @Test fun request_intent_is_available_when_not_held() {
+        // Shadow needs explicit role registration; make ROLE_DIALER available but not held
+        val rm = context.getSystemService(RoleManager::class.java)
+        shadowOf(rm).addAvailableRole(RoleManager.ROLE_DIALER)
+
+        assertNotNull(controller.requestRoleIntent())
+    }
+}

--- a/app/src/test/java/com/baba/callvault/ui/dialer/InCallViewModelTest.kt
+++ b/app/src/test/java/com/baba/callvault/ui/dialer/InCallViewModelTest.kt
@@ -1,0 +1,16 @@
+package com.baba.callvault.ui.dialer
+
+import com.baba.callvault.calls.CallDirection
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.calls.UiCall
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InCallViewModelTest {
+    @Test fun shows_unknown_when_number_null() {
+        assertEquals("Unknown", InCallLabels.displayNumber(UiCall(null, CallEvent.Phase.RINGING, CallDirection.INCOMING, false, false), unknown = "Unknown"))
+    }
+    @Test fun shows_number_when_present() {
+        assertEquals("+15551234", InCallLabels.displayNumber(UiCall("+15551234", CallEvent.Phase.ACTIVE, CallDirection.OUTGOING, false, false), unknown = "Unknown"))
+    }
+}

--- a/docs/dialer-mode-engage-design.md
+++ b/docs/dialer-mode-engage-design.md
@@ -1,0 +1,123 @@
+# Dialer Mode — "Engage + Reachable" Increment (A+B) Design
+
+**Date:** 2026-06-28
+**Status:** Approved design (pre-plan)
+**Branch:** feat/dialer-mode-phase1 (builds on the Phase 1 dialer work + on-device fixes)
+
+## Motivation
+
+On-device testing (OnePlus / OxygenOS) proved that the standard `RoleManager` default-dialer
+prompt is granted at the role level but **not propagated into Telecom's default-dialer cache** by
+the OEM, so CallVault's `InCallService` never binds and dialer mode never engages. We verified that
+the **privileged shell path the app already uses** (over its ADB/daemon channel) *does* move
+Telecom's default:
+
+- `cmd telecom set-default-dialer com.baba.callvault` → `mDefaultDialerCache = com.baba.callvault`,
+  CallVault's `InCallService` binds (`dumpsys telecom`: `type: 1 is crashed: false`, call CREATED).
+- The override does **not** auto-grant role permissions, so `pm grant … CALL_PHONE` is also needed
+  for the in-app dialpad to place calls (otherwise it falls back to `ACTION_DIAL` → Google Phone).
+
+This increment makes dialer mode **actually engage** via that ADB privilege (A) and adds a
+**toggle-linked launcher icon** so the dialpad is reachable (B). The larger "proper dialer" UX
+(history/contacts/autocomplete) is a separate, later increment (C).
+
+## Goals / Non-Goals
+
+**Goals**
+- Enabling dialer mode reliably makes CallVault the *functional* Telecom default dialer on locked-down
+  OEMs, using the existing ADB/daemon channel.
+- Grant the role-implied `CALL_PHONE` so the in-app dialpad places calls directly (no Google bounce).
+- Re-assert sensibly (enable + boot + app-resume); surface the existing banner otherwise.
+- On disable, relinquish cleanly (restore the prior default dialer).
+- A "CallVault Dialer" launcher icon that appears/disappears with the toggle and opens the dialpad.
+
+**Non-Goals (this increment)**
+- Proper dialer UX: autocomplete, call history, contacts browser, favorites, search (increment C).
+- Overwriting the OEM's hardcoded "Phone" launcher icon (not possible; we add our own icon).
+- Winning a continuous tug-of-war with Google Phone (we re-assert at defined points, not in background).
+- Surviving on devices without the app's ADB/daemon setup (already a hard app dependency).
+
+## Architecture
+
+### A. `DialerDefaultEnforcer` (new) — forces/relinquishes the Telecom default via ADB
+
+Uses the existing `AdbShell` (the same uid-2000 shell channel that grants `WRITE_SECURE_SETTINGS`,
+toggles Wireless Debugging, and launches the daemon).
+
+- `fun isDefault(): Boolean` — delegates to `DialerRoleController.isDefaultDialer()`
+  (`TelecomManager.getDefaultDialerPackage() == packageName`).
+- `suspend fun enforce(): Result` — capture+store the current default (if not already us), then run
+  over `AdbShell`:
+  - `cmd telecom set-default-dialer com.baba.callvault`
+  - `pm grant com.baba.callvault android.permission.CALL_PHONE`
+  then verify `isDefault()`. Returns success/failure (failure → recording-only + banner).
+- `suspend fun relinquish()` — restore the stored prior default dialer:
+  `cmd telecom set-default-dialer <priorPackage>` (fallback to
+  `TelecomManager.getSystemDialerPackage()` if none stored). Clears the stored value.
+- Prior-default storage: `AppPreferences.PRIOR_DEFAULT_DIALER` (string).
+- Command strings are pure/testable; the AdbShell invocation is the only Android dependency.
+
+### B. Toggle-able launcher icon — manifest `activity-alias`
+
+- New `activity-alias` (e.g. `.dialer.DialerLauncherAlias`) targeting a thin entry that routes to
+  the dialpad (`AppScreen.Dialer`) — either `MainActivity` with an extra (`open=dialer`) or a small
+  `DialerEntryActivity`. `LAUNCHER` category, `android:enabled="false"`, `android:exported="true"`,
+  label `@string/dialer_launcher_label` ("CallVault Dialer"), app icon.
+- `DialerLauncherIcon` helper: `setEnabled(context, on)` →
+  `PackageManager.setComponentEnabledSetting(aliasComponent, ENABLED|DISABLED, DONT_KILL_APP)`.
+- The dialpad entry must read the routing extra and navigate to `AppScreen.Dialer` on launch.
+
+### Integration — orchestrated in `SettingsViewModel.setDialerModeEnabled(on)`
+
+```
+on == true:
+  store prior default (if not us); preferences.setDialerModeEnabled(true)
+  DialerDefaultEnforcer.enforce()            // ADB: set-default-dialer + grant CALL_PHONE
+  DialerLauncherIcon.setEnabled(true)
+  CallDetection.setMode(DialerModeState.effective(prefOn=true, roleHeld=isDefault()))
+on == false:
+  preferences.setDialerModeEnabled(false)
+  DialerLauncherIcon.setEnabled(false)
+  DialerDefaultEnforcer.relinquish()         // restore prior default
+  CallDetection.setMode(false)
+```
+
+Re-assert points (only when pref on and `!isDefault()`):
+- **Boot:** existing post-boot path (`AdbConnectionService` after the daemon connects) calls `enforce()`.
+- **App resume:** existing `ON_RESUME` in `AppNavigationScreen` (or `MainActivity`) calls `enforce()`.
+- **Banner tap:** the existing role-lost banner now calls `enforce()` instead of `requestRoleIntent()`.
+
+The RoleManager prompt path is retired for enabling on these builds; `DialerRoleController` keeps
+`isDefaultDialer()` (used everywhere) and may drop `requestRoleIntent()` once the banner/toggle no
+longer call it.
+
+## Error handling
+
+- `enforce()` failure (ADB/daemon unavailable, or Telecom didn't move): do **not** flip effective
+  mode; keep recording-only (broadcast detection) and show the role-lost banner with guidance that
+  dialer mode needs the ADB setup. Never crash; log via `AppLogger`.
+- `relinquish()` best-effort; if it fails, log and proceed (worst case the banner reflects state).
+- All ADB commands run on a background thread (suspend); never on main.
+
+## Testing
+
+- **Unit (JVM):** exact command strings produced by `DialerDefaultEnforcer` (set-default-dialer,
+  pm grant, relinquish with stored/ fallback package); prior-default capture/restore logic;
+  `DialerLauncherIcon` enabled/disabled decision mapping; orchestration order in a fake VM.
+- **On-device (manual):** enable → `get-default-dialer == self`, `CALL_PHONE granted`, alias icon
+  appears, dialpad places a call, CallVault in-call UI + recording via Telecom; disable → prior
+  default restored, icon gone, recording-only via fallback; reboot → re-assert; resume after Google
+  Phone steals it → re-assert; ADB-down → graceful banner.
+
+## Constraints / caveats
+
+- Requires the app's ADB/daemon channel (already mandatory for recording).
+- Launcher alias icon appears in the **app drawer**, not auto-placed on the home screen.
+- Tug-of-war with Google Phone is handled only at enable/boot/resume + banner (no background loop).
+- The `set-default-dialer` override likely does not survive reboot → boot re-assert covers it.
+- Emergency calls always use the preloaded dialer (AOSP guarantee) — unaffected.
+- Recording-only mode remains byte-for-byte unchanged when dialer mode is off.
+
+## Open Questions
+
+None blocking. Increment C (proper dialer UX) will get its own design.

--- a/docs/dialer-mode-engage-plan.md
+++ b/docs/dialer-mode-engage-plan.md
@@ -1,0 +1,482 @@
+# Dialer Mode "Engage + Reachable" (A+B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make dialer mode actually engage on locked-down OEMs by forcing CallVault as the Telecom default dialer over the existing ADB/shell channel, and add a toggle-linked "CallVault Dialer" launcher icon.
+
+**Architecture:** A `DialerDefaultEnforcer` runs `cmd telecom set-default-dialer` + `pm grant CALL_PHONE` via the existing `AdbShell`, storing/restoring the prior default for clean relinquish. `SettingsViewModel.setDialerModeEnabled` orchestrates enforce/relinquish + a `PackageManager`-toggled `activity-alias` launcher icon. Re-assert on enable/boot/resume; the existing role-lost banner re-asserts on tap.
+
+**Tech Stack:** Kotlin, Android (minSdk 30/targetSdk 36), `TelecomManager`, `RoleManager`, the app's `AdbShell` (embedded ADB), Jetpack Compose. Tests: JUnit4 + MockK + Robolectric (`@Config(sdk=[35])` for Robolectric tests).
+
+## Global Constraints
+
+- minSdk 30, targetSdk 36; guard APIs accordingly.
+- Recording-only mode (dialer pref OFF) stays byte-for-byte identical to v1.2.1.
+- `isDefaultDialer()` truth = `TelecomManager.getDefaultDialerPackage() == packageName` (already implemented).
+- All ADB/shell commands run **off the main thread** (suspend / `Dispatchers.IO`).
+- New user-facing strings MUST be added to `values/` AND all 9 locales (fr,de,es,it,hu,pl,ru,vi,zh-rCN) or `lintDebug` fails.
+- Emergency calls always use the preloaded dialer (AOSP) — never gate/block them.
+- Robolectric 4.14 caps at SDK 35 → annotate Robolectric tests `@Config(sdk = [35])`.
+- Build env: `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home`; run on device serial `6011b07e`.
+- Branch: `feat/dialer-mode-phase1`. Conventional commits; commit per task.
+
+---
+
+## File Structure
+
+- **New:** `dialer/DialerDefaultEnforcer.kt` — force/relinquish Telecom default via AdbShell (+ pure command strings).
+- **New:** `dialer/DialerLauncherIcon.kt` — enable/disable the launcher `activity-alias`.
+- **Modify:** `integrations/adb/AdbShell.kt` — add generic `runShellCommand`.
+- **Modify:** `data/AppPreferences.kt` — `PRIOR_DEFAULT_DIALER` string pref.
+- **Modify:** `AndroidManifest.xml` — `activity-alias` (disabled by default) + routing extra on MainActivity.
+- **Modify:** `MainActivity.kt` — route the launcher-alias intent to the dialpad (`AppScreen.Dialer`).
+- **Modify:** `ui/viewmodels/SettingsViewModel.kt` — orchestrate enforce/relinquish + icon toggle.
+- **Modify:** `ui/screens/SettingsScreen.kt` — role-lost banner + toggle call the enforcer.
+- **Modify:** `services/boot/AdbConnectionService.kt` — re-assert on boot when pref on.
+- **Modify:** `AppNavigationScreen.kt` — re-assert on ON_RESUME when pref on.
+- **New strings:** `res/values/strings_dialer.xml` (+ 9 locales): `dialer_launcher_label`.
+
+---
+
+## Task 1: `AdbShell.runShellCommand` (generic command runner)
+
+**Files:**
+- Modify: `app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt`
+
+**Interfaces:**
+- Produces: `fun AdbShell.runShellCommand(context: Context, command: String): Boolean` — runs a shell command over ADB, drains output, returns true on success (no exception), false otherwise.
+
+- [ ] **Step 1: Implement** — add to `AdbShell` (model on the existing `grantSecureSettingsIfNeeded` pattern, lines ~158-167):
+
+```kotlin
+    /**
+     * Runs an arbitrary shell command over the embedded ADB connection (uid 2000 shell), draining its
+     * output so the command completes. Returns true if it ran without throwing. Caller must be OFF the
+     * main thread. Used for privileged dialer setup (cmd telecom set-default-dialer, pm grant CALL_PHONE).
+     */
+    fun runShellCommand(context: Context, command: String): Boolean =
+        runCatching {
+            openShell(context, command).use { s -> s.openInputStream().use { it.readBytes() } }
+            AppLogger.i(TAG, "ADB shell command ran: $command")
+            true
+        }.onFailure { AppLogger.w(TAG, "ADB shell command failed ($command): ${it.message}") }
+            .getOrDefault(false)
+```
+
+- [ ] **Step 2: Build**
+
+Run: `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
+git commit -m "feat(adb): generic AdbShell.runShellCommand for privileged setup commands"
+```
+
+---
+
+## Task 2: `PRIOR_DEFAULT_DIALER` preference
+
+**Files:**
+- Modify: `app/src/main/java/com/baba/callvault/data/AppPreferences.kt`
+- Test: `app/src/test/java/com/baba/callvault/data/PriorDefaultDialerPrefTest.kt`
+
+**Interfaces:**
+- Produces: `fun getPriorDefaultDialer(): String?` (default null), `fun setPriorDefaultDialer(pkg: String?)` (null clears the key).
+
+- [ ] **Step 1: Inspect** the existing `Key` enum + a String accessor pair in `AppPreferences.kt` (e.g. `getRecordingFolderUri`/setter) and mirror the style.
+
+- [ ] **Step 2: Write the failing test** at `PriorDefaultDialerPrefTest.kt`:
+
+```kotlin
+package com.baba.callvault.data
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class PriorDefaultDialerPrefTest {
+    private val prefs = AppPreferences(ApplicationProvider.getApplicationContext())
+
+    @Test fun defaults_to_null() { assertNull(prefs.getPriorDefaultDialer()) }
+
+    @Test fun stores_and_clears() {
+        prefs.setPriorDefaultDialer("com.google.android.dialer")
+        assertEquals("com.google.android.dialer", prefs.getPriorDefaultDialer())
+        prefs.setPriorDefaultDialer(null)
+        assertNull(prefs.getPriorDefaultDialer())
+    }
+}
+```
+
+- [ ] **Step 3: Run — verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.data.PriorDefaultDialerPrefTest"`
+Expected: FAIL (unresolved `getPriorDefaultDialer`).
+
+- [ ] **Step 4: Implement** — add a `PRIOR_DEFAULT_DIALER("prior_default_dialer")` key and accessors (adapt field names to the real file):
+
+```kotlin
+    fun getPriorDefaultDialer(): String? =
+        sharedPreferences.getString(Key.PRIOR_DEFAULT_DIALER.id, null)
+
+    fun setPriorDefaultDialer(pkg: String?) {
+        sharedPreferences.edit().apply {
+            if (pkg == null) remove(Key.PRIOR_DEFAULT_DIALER.id) else putString(Key.PRIOR_DEFAULT_DIALER.id, pkg)
+        }.apply()
+    }
+```
+
+- [ ] **Step 5: Run — verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.data.PriorDefaultDialerPrefTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/data/AppPreferences.kt app/src/test/java/com/baba/callvault/data/PriorDefaultDialerPrefTest.kt
+git commit -m "feat(prefs): PRIOR_DEFAULT_DIALER for clean dialer-mode relinquish"
+```
+
+---
+
+## Task 3: `DialerDefaultEnforcer`
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/dialer/DialerDefaultEnforcer.kt`
+- Test: `app/src/test/java/com/baba/callvault/dialer/DialerDefaultEnforcerTest.kt`
+
+**Interfaces:**
+- Consumes: `AdbShell.runShellCommand` (Task 1), `AppPreferences.get/setPriorDefaultDialer` (Task 2), `DialerRoleController.isDefaultDialer()`, `TelecomManager.getDefaultDialerPackage()`.
+- Produces:
+  - pure: `object DialerCommands { fun setDefault(pkg: String): String; fun grantCallPhone(pkg: String): String; fun restore(priorPkg: String): String }`
+  - `class DialerDefaultEnforcer(context, prefs, roleController)` with `fun enforce(): Boolean` and `fun relinquish()` (both blocking; callers dispatch to IO).
+
+- [ ] **Step 1: Write the failing test** (pure command strings) at `DialerDefaultEnforcerTest.kt`:
+
+```kotlin
+package com.baba.callvault.dialer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DialerDefaultEnforcerTest {
+    @Test fun set_default_command() {
+        assertEquals("cmd telecom set-default-dialer com.baba.callvault",
+            DialerCommands.setDefault("com.baba.callvault"))
+    }
+    @Test fun grant_call_phone_command() {
+        assertEquals("pm grant com.baba.callvault android.permission.CALL_PHONE",
+            DialerCommands.grantCallPhone("com.baba.callvault"))
+    }
+    @Test fun restore_command() {
+        assertEquals("cmd telecom set-default-dialer com.google.android.dialer",
+            DialerCommands.restore("com.google.android.dialer"))
+    }
+}
+```
+
+- [ ] **Step 2: Run — verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.dialer.DialerDefaultEnforcerTest"`
+Expected: FAIL (unresolved `DialerCommands`).
+
+- [ ] **Step 3: Implement** `DialerDefaultEnforcer.kt`:
+
+```kotlin
+package com.baba.callvault.dialer
+
+import android.content.Context
+import android.telecom.TelecomManager
+import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.integrations.adb.AdbShell
+import com.baba.callvault.utils.AppLogger
+
+/** Pure shell-command strings (unit-testable). */
+object DialerCommands {
+    fun setDefault(pkg: String) = "cmd telecom set-default-dialer $pkg"
+    fun grantCallPhone(pkg: String) = "pm grant $pkg android.permission.CALL_PHONE"
+    fun restore(priorPkg: String) = "cmd telecom set-default-dialer $priorPkg"
+}
+
+/**
+ * Forces CallVault as the Telecom default dialer via the embedded ADB shell, because OEMs (OxygenOS)
+ * grant ROLE_DIALER but don't propagate it into Telecom's default-dialer cache. Blocking; call OFF the
+ * main thread.
+ */
+class DialerDefaultEnforcer(
+    private val context: Context,
+    private val prefs: AppPreferences,
+    private val roleController: DialerRoleController,
+) {
+    private val pkg = context.packageName
+    private val telecom = context.getSystemService(Context.TELECOM_SERVICE) as? TelecomManager
+
+    /** Make CallVault the Telecom default dialer + grant CALL_PHONE. Returns true if it actually became default. */
+    fun enforce(): Boolean {
+        if (roleController.isDefaultDialer()) return true
+        // Remember who held it so we can restore on relinquish (only if it wasn't already us).
+        @Suppress("DEPRECATION")
+        val current = telecom?.defaultDialerPackage
+        if (current != null && current != pkg && prefs.getPriorDefaultDialer() == null) {
+            prefs.setPriorDefaultDialer(current)
+        }
+        AdbShell.runShellCommand(context, DialerCommands.setDefault(pkg))
+        AdbShell.runShellCommand(context, DialerCommands.grantCallPhone(pkg))
+        val ok = roleController.isDefaultDialer()
+        AppLogger.i(TAG, "enforce() default-dialer now=${'$'}{if (ok) pkg else current} ok=$ok")
+        return ok
+    }
+
+    /** Restore the previously-stored default dialer (best-effort) and clear the stored value. */
+    fun relinquish() {
+        val prior = prefs.getPriorDefaultDialer()
+            ?: @Suppress("DEPRECATION") telecom?.systemDialerPackage
+        if (prior != null && prior != pkg) {
+            AdbShell.runShellCommand(context, DialerCommands.restore(prior))
+        }
+        prefs.setPriorDefaultDialer(null)
+        AppLogger.i(TAG, "relinquish() restored default dialer to ${'$'}prior")
+    }
+
+    private companion object { const val TAG = "CV:DialerEnforcer" }
+}
+```
+
+- [ ] **Step 4: Run — verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.dialer.DialerDefaultEnforcerTest" :app:assembleDebug`
+Expected: PASS + BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/dialer/DialerDefaultEnforcer.kt app/src/test/java/com/baba/callvault/dialer/DialerDefaultEnforcerTest.kt
+git commit -m "feat(dialer): DialerDefaultEnforcer forces/relinquishes Telecom default via ADB"
+```
+
+---
+
+## Task 4: Launcher `activity-alias` + `DialerLauncherIcon` + routing
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/dialer/DialerLauncherIcon.kt`
+- Modify: `app/src/main/AndroidManifest.xml`
+- Modify: `app/src/main/java/com/baba/callvault/MainActivity.kt`
+- Modify: `app/src/main/res/values/strings_dialer.xml` (+ 9 locales)
+
+**Interfaces:**
+- Produces: `object DialerLauncherIcon { fun setEnabled(context: Context, enabled: Boolean) }`.
+- The alias routes to the dialpad: MainActivity reads intent extra `open_dialer=true` and navigates to `AppScreen.Dialer`.
+
+- [ ] **Step 1: Add the alias** to `AndroidManifest.xml` (inside `<application>`, after the MainActivity `</activity>`):
+
+```xml
+        <!-- Toggle-able launcher icon for the in-app dialpad; enabled only while dialer mode is on. -->
+        <activity-alias
+            android:name=".dialer.DialerLauncherAlias"
+            android:targetActivity=".MainActivity"
+            android:enabled="false"
+            android:exported="true"
+            android:label="@string/dialer_launcher_label"
+            android:icon="@mipmap/ic_launcher">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data android:name="cv.open_dialer" android:value="true" />
+        </activity-alias>
+```
+
+- [ ] **Step 2: Add strings** — `res/values/strings_dialer.xml` add `<string name="dialer_launcher_label">CallVault Dialer</string>`, and add the SAME key, translated, to all 9 `values-*/strings_dialer.xml` (fr,de,es,it,hu,pl,ru,vi,zh-rCN). Keep "CallVault" verbatim. Required or `lintDebug` fails.
+
+- [ ] **Step 3: Implement** `DialerLauncherIcon.kt`:
+
+```kotlin
+package com.baba.callvault.dialer
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+
+/** Shows/hides the "CallVault Dialer" launcher icon (an activity-alias) with dialer mode. */
+object DialerLauncherIcon {
+    fun setEnabled(context: Context, enabled: Boolean) {
+        val alias = ComponentName(context.packageName, "com.baba.callvault.dialer.DialerLauncherAlias")
+        val state = if (enabled) PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        else PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        context.packageManager.setComponentEnabledSetting(alias, state, PackageManager.DONT_KILL_APP)
+    }
+}
+```
+
+- [ ] **Step 4: Route the alias to the dialpad** in `MainActivity.kt` — when launched via the alias, the intent's component is the alias; detect it and signal the nav layer to open the dialpad. Read the existing nav entry (`AppNavigationViewModel.navigateTo(AppScreen.Dialer)`). In `MainActivity.onCreate`/`onNewIntent`, after the content is set, if `intent?.component?.className == "com.baba.callvault.dialer.DialerLauncherAlias"` (or the alias was the launching component), request the dialpad route. Concretely, set a flag the composable reads once:
+
+```kotlin
+        val openDialer = intent?.component?.shortClassName?.endsWith("DialerLauncherAlias") == true
+        // Pass openDialer into AppNavigationScreen(...) so it calls appNavViewModel.navigateTo(AppScreen.Dialer)
+        // once on first composition when true (only meaningful if dialer mode is on).
+```
+Wire `AppNavigationScreen(openDialer = openDialer)`; in it, `LaunchedEffect(openDialer) { if (openDialer) appNavViewModel.navigateTo(AppScreen.Dialer) }`. (Match the actual `AppNavigationScreen` signature/params.)
+
+- [ ] **Step 5: Build + lint**
+
+Run: `JAVA_HOME=... ./gradlew :app:assembleDebug :app:lintDebug`
+Expected: BUILD SUCCESSFUL + lint clean (all 10 strings_dialer.xml carry `dialer_launcher_label`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/dialer/DialerLauncherIcon.kt app/src/main/AndroidManifest.xml app/src/main/java/com/baba/callvault/MainActivity.kt app/src/main/java/com/baba/callvault/AppNavigationScreen.kt app/src/main/res/values*/strings_dialer.xml
+git commit -m "feat(dialer): toggle-able CallVault Dialer launcher icon routing to the dialpad"
+```
+
+---
+
+## Task 5: Orchestrate in `SettingsViewModel.setDialerModeEnabled`
+
+**Files:**
+- Modify: `app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt`
+
+**Interfaces:**
+- Consumes: `DialerDefaultEnforcer` (Task 3), `DialerLauncherIcon` (Task 4), `CallDetection.setMode`, `DialerModeState.effective`, existing `dialerRoleController`.
+
+- [ ] **Step 1: Inspect** the current `setDialerModeEnabled` (around line 373) and the VM's coroutine scope (`viewModelScope`) + `appContext`.
+
+- [ ] **Step 2: Implement** — replace the body so enable enforces + shows the icon, disable relinquishes + hides it; ADB work on `Dispatchers.IO`:
+
+```kotlin
+    private val dialerEnforcer by lazy {
+        com.baba.callvault.dialer.DialerDefaultEnforcer(appContext, preferences, dialerRoleController)
+    }
+
+    override fun setDialerModeEnabled(enabled: Boolean) {
+        preferences.setDialerModeEnabled(enabled)
+        com.baba.callvault.dialer.DialerLauncherIcon.setEnabled(appContext, enabled)
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            if (enabled) dialerEnforcer.enforce() else dialerEnforcer.relinquish()
+            if (com.baba.callvault.calls.CallDetection.isInitialized) {
+                com.baba.callvault.calls.CallDetection.setMode(
+                    com.baba.callvault.dialer.DialerModeState.effective(
+                        prefOn = enabled,
+                        roleHeld = dialerRoleController.isDefaultDialer(),
+                    )
+                )
+            }
+            refresh() // re-read state so the toggle/banner reflect reality
+        }
+    }
+```
+(Use the existing `refresh()` and imports already present; add `viewModelScope`/`launch`/`Dispatchers` imports if missing.)
+
+- [ ] **Step 3: Build**
+
+Run: `JAVA_HOME=... ./gradlew :app:assembleDebug :app:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL + existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
+git commit -m "feat(dialer): enable=enforce+show icon, disable=relinquish+hide icon"
+```
+
+---
+
+## Task 6: Re-assert on boot, resume, and banner tap
+
+**Files:**
+- Modify: `app/src/main/java/com/baba/callvault/services/boot/AdbConnectionService.kt`
+- Modify: `app/src/main/java/com/baba/callvault/AppNavigationScreen.kt`
+- Modify: `app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt`
+
+**Interfaces:**
+- Consumes: `DialerDefaultEnforcer.enforce()`, `AppPreferences.isDialerModeEnabled()`, `DialerRoleController.isDefaultDialer()`.
+
+- [ ] **Step 1: Boot re-assert** — in `AdbConnectionService.kt`, at the point the log prints "Boot: recorder daemon connected=true" (daemon connected), add (off main thread, where it already runs background work):
+
+```kotlin
+        val prefs = com.baba.callvault.data.AppPreferences(this)
+        if (prefs.isDialerModeEnabled()) {
+            val rc = com.baba.callvault.dialer.DialerRoleController(this)
+            if (!rc.isDefaultDialer()) {
+                com.baba.callvault.dialer.DialerDefaultEnforcer(this, prefs, rc).enforce()
+            }
+        }
+```
+
+- [ ] **Step 2: Resume re-assert** — in `AppNavigationScreen.kt`'s existing `LifecycleEventObserver` ON_RESUME branch (where it already calls `appNavViewModel.refresh()`), add a background re-assert:
+
+```kotlin
+            if (event == Lifecycle.Event.ON_RESUME) {
+                appNavViewModel.refresh()
+                settingsViewModel.refresh()
+                settingsViewModel.reassertDialerDefaultIfNeeded()  // new VM method (below)
+            }
+```
+And add to `SettingsViewModel`:
+```kotlin
+    fun reassertDialerDefaultIfNeeded() {
+        if (!preferences.isDialerModeEnabled()) return
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            if (!dialerRoleController.isDefaultDialer()) dialerEnforcer.enforce()
+            refresh()
+        }
+    }
+```
+
+- [ ] **Step 3: Banner tap re-asserts** — in `SettingsScreen.kt`, the role-lost banner `.clickable { ... }` (currently `dialerRoleController?.requestRoleIntent()`) should instead trigger the enforcer. Replace its body with a call into the VM:
+```kotlin
+                    .clickable { actions.reassertDialerDefault() }
+```
+Add `reassertDialerDefault()` to `SettingsActions`/VM (same as `reassertDialerDefaultIfNeeded` but unconditional enforce):
+```kotlin
+    fun reassertDialerDefault() {
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) { dialerEnforcer.enforce(); refresh() }
+    }
+```
+(Provide a no-op default in the preview/fake `SettingsActions` impl so previews compile.)
+
+- [ ] **Step 4: Build + lint + tests**
+
+Run: `JAVA_HOME=... ./gradlew :app:assembleDebug :app:lintDebug :app:testDebugUnitTest`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/services/boot/AdbConnectionService.kt app/src/main/java/com/baba/callvault/AppNavigationScreen.kt app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt
+git commit -m "feat(dialer): re-assert default dialer on boot, resume, and banner tap"
+```
+
+---
+
+## Task 7: On-device verification (user-driven)
+
+**Files:** none.
+
+- [ ] **Step 1:** Install debug build (`adb -s 6011b07e install -r app/build/outputs/apk/debug/app-debug.apk`), re-grant `WRITE_SECURE_SETTINGS`.
+- [ ] **Step 2:** Enable dialer mode → verify `cmd telecom get-default-dialer` == `com.baba.callvault`, `CALL_PHONE` granted, and a "CallVault Dialer" icon appears in the app drawer.
+- [ ] **Step 3:** Open that icon → lands on the dialpad. Place a call → CallVault in-call UI + recording via Telecom (confirm in `dumpsys telecom` InCallService bound + a recording saved).
+- [ ] **Step 4:** Disable dialer mode → icon disappears, `get-default-dialer` restored to the prior dialer, recording-only still works.
+- [ ] **Step 5:** Reboot → re-asserted (pref still on). Open Google Phone to steal it, return to CallVault → resume re-asserts (or banner → tap re-asserts).
+- [ ] **Step 6:** Regression: dialer mode OFF behaves exactly as v1.2.1.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** enforce/relinquish (T3) · CALL_PHONE grant (T3) · prior-default capture/restore (T2,T3) · launcher icon toggle (T4) · orchestration (T5) · re-assert enable/boot/resume/banner (T5,T6) · recording-only unchanged (no detection code touched) · on-device verify (T7). All spec sections mapped.
+- **Translation gate:** T4 adds `dialer_launcher_label` to all 10 locale files.
+- **Type consistency:** `DialerCommands.setDefault/grantCallPhone/restore`, `DialerDefaultEnforcer.enforce()/relinquish()`, `DialerLauncherIcon.setEnabled`, `get/setPriorDefaultDialer`, `reassertDialerDefault()/reassertDialerDefaultIfNeeded()` used consistently across tasks.
+- **Threading:** all ADB/shell calls dispatched to `Dispatchers.IO` (T5,T6) or already-background boot path (T6).
+- **Ordering note:** T5/T6 reference `DialerDefaultEnforcer` (T3) and `DialerLauncherIcon` (T4) — implement T1–T4 before T5–T6.

--- a/docs/dialer-mode-phase1-design.md
+++ b/docs/dialer-mode-phase1-design.md
@@ -1,0 +1,168 @@
+# Optional Dialer Mode — Phase 1 Design
+
+**Date:** 2026-06-26
+**Status:** Approved design (pre-implementation-plan)
+**Baseline:** v1.2.1
+
+## 1. Motivation
+
+Today CallVault detects calls via the `PHONE_STATE` broadcast (with a post-boot live
+`TelephonyCallback` in `CallMonitorService`). That detection is inherently laggy and has been the
+source of repeated bugs (e.g. the 1.2.0 "first call after reboot records ~9s late" fix).
+
+Becoming the **default phone app** gives CallVault an `InCallService`, which delivers precise,
+real-time per-call state from Telecom (`DIALING`/`RINGING`/`ACTIVE`/`DISCONNECTED`). This both
+**fixes the detection-timing class of bugs** and enables a **cleaner, integrated calling UX**.
+
+Crucially, being the default dialer does **not** grant any additional access to call *audio* — that
+remains the job of the existing privileged `app_process` daemon (scrcpy `VOICE_CALL` capture over
+embedded ADB). The dialer *wraps* the recording system; it does not replace or simplify it.
+
+## 2. Goals / Non-Goals
+
+**Goals (Phase 1)**
+- Make the dialer **optional**: existing users stay on today's behavior unless they opt in.
+- Let users switch between **recording-only** and **dialer + recording** anytime in Settings.
+- Ship a **minimal-but-complete** default phone app: place/receive/emergency calls, incoming-call
+  screen, in-call screen, minimal dialpad.
+- Migrate call detection to **Telecom** while in dialer mode, feeding the **unchanged** recording
+  pipeline.
+
+**Non-Goals (Phase 1 — deferred to later phases)**
+- Rich call-log/history UI (Phase 2).
+- Contacts browser/search, favorites/speed-dial (Phase 3).
+- Call blocking/screening, search, post-call screen, conference UI (Phase 4).
+- Play Store eligibility (call recording remains banned regardless of dialer role).
+- Video/VoIP calls (route to system; out of scope).
+
+## 3. Phased Roadmap
+
+| Phase | Scope | Value |
+|---|---|---|
+| **1 (this spec)** | Mode infra + Settings toggle (reversible) · become/release default-dialer role · `InCallService` · incoming-call screen · in-call screen (mute/speaker/hold/DTMF/end) · minimal dialpad (place + emergency) · Telecom-based detection in dialer mode · wire existing recording pipeline to Telecom events | Reliability + a real phone |
+| **2** | Rich call log/history UI; link each call to its recording | Everyday usability |
+| **3** | Contacts browser/search, contact detail, favorites/speed-dial | Everyday usability |
+| **4** | Polish: search, blocking/screening, post-call screen, conference | Nice-to-have |
+
+Recording-only mode remains byte-for-byte the current app throughout. Dialer features only activate
+when the user opts in **and** the `ROLE_DIALER` role is actually held.
+
+## 4. Architecture
+
+### 4.1 The `CallEventSource` seam (core refactor)
+
+Introduce a thin interface between *"a call happened"* and *"decide whether to record"*:
+
+```
+CallEventSource (interface)
+   emits normalized CallEvent: Ringing / Dialing / Active / Ended  (+ number, direction, sim)
+        │
+        ├── BroadcastCallEventSource  ← existing PhoneStateReceiver + CallMonitorService  (recording-only)
+        └── TelecomCallEventSource     ← new CallVaultInCallService                         (dialer)
+                                  │
+                                  ▼
+   CallSessionManager.processSessionUpdate → shouldAutoRecord → RecordingForegroundService → daemon
+                         (UNCHANGED: recording decision + pipeline identical in both modes)
+```
+
+- Only the **source** of call events swaps based on mode. The recording decision logic
+  (`shouldAutoRecord`, contact/anonymous/cross-country filters, storage) is untouched.
+- In dialer mode the Telecom source fires on `STATE_DIALING`/`STATE_RINGING` — earlier and more
+  precise than the broadcast — enabling capture at dial tone (subject to daemon warmth; see §6).
+- **Mutual exclusion:** in dialer mode, `BroadcastCallEventSource` defers to Telecom, reusing the
+  existing pattern where `PhoneStateReceiver` already defers when `CallMonitorService.isListening`.
+
+### 4.2 Components (new unless noted)
+
+1. **Mode + role infrastructure**
+   - `AppPreferences.DIALER_MODE_ENABLED` (default `false`) + accessors.
+   - `DialerRoleController` wrapping `RoleManager`: requests `ROLE_DIALER`, handles the system
+     result, releases on toggle-off, and treats **`RoleManager.isRoleHeld` as the source of truth**
+     (detects external changes to the default phone app). The Settings toggle drives the role
+     request and reflects real role state, not just the stored preference.
+
+2. **`CallVaultInCallService`** — manifest-registered with `BIND_INCALL_SERVICE`. Tracks `Call`
+   objects, registers `Call.Callback`s, maps Telecom states → normalized `CallEvent`s (feeding the
+   pipeline in §4.1), and exposes current-call state to the UI. Pulls number/direction directly off
+   the `Call` object (no `READ_CALL_LOG` double-broadcast hack needed in this mode).
+
+3. **Calling UI** (Compose) — reachable only in dialer mode:
+   - **`InCallActivity`** — a *standalone* Activity launched by the InCallService via full-screen
+     intent (it must appear over the lock screen / when the app is closed). Therefore it is
+     deliberately **not** part of the onboarding `AppNavigationScreen` router. States: incoming
+     (answer/reject), active (mute/speaker/hold/DTMF/end), dialing/connecting.
+   - **Minimal dialpad** — digits, call, backspace; places via `TelecomManager.placeCall`.
+     **Emergency numbers always pass through** unfiltered (hard requirement).
+
+4. **Recording control in dialer mode** — existing auto-record toggles still apply (incoming/
+   outgoing/contact filters unchanged), **plus** a manual record/stop button on the in-call screen.
+
+### 4.3 Mode/role lifecycle
+
+```
+Settings toggle ON  → DialerRoleController.requestRole() → system role dialog
+   granted  → isRoleHeld=true  → InCallService active → TelecomCallEventSource drives detection
+   denied   → revert toggle, stay recording-only
+Settings toggle OFF → release role → fall back to BroadcastCallEventSource
+External change (user picks another default phone app) → detected on resume via isRoleHeld
+   → auto-fall back to BroadcastCallEventSource + show "dialer features off" banner
+```
+
+## 5. Data Flow (dialer mode, a call)
+
+1. Telecom adds a `Call` → `CallVaultInCallService.onCallAdded` → register `Call.Callback`.
+2. State transitions (`DIALING`/`RINGING`/`ACTIVE`/`DISCONNECTED`) map to normalized `CallEvent`s.
+3. `TelecomCallEventSource` forwards events to `CallSessionManager.processSessionUpdate` (the same
+   entry the broadcast path uses today).
+4. `shouldAutoRecord` decides; `RecordingForegroundService` starts/stops the daemon capture — all
+   unchanged.
+5. `InCallActivity` renders call state and exposes answer/reject/end + manual record toggle.
+
+## 6. Risks & Edge Cases
+
+- **Emergency calls (hard requirement):** emergency dialing must always work; emergency numbers
+  bypass all filtering/standby and are never blocked or record-gated. Explicit test coverage.
+- **Role loss / external change:** `RoleManager.isRoleHeld` is checked on every resume; on loss we
+  auto-fall back to the broadcast source so recording never dies silently, plus a UI banner.
+- **Daemon cold-start is separate:** Telecom detection is instant, but *capture* still needs the
+  privileged daemon warm. Being the dialer fixes detection timing, not daemon warm-up — the existing
+  "starting up… / ready" notification still applies. We will not over-promise "record from dial
+  tone" when the daemon is cold.
+- **Concurrent calls / call waiting:** Phase 1 handles the primary active call with basic hold/swap;
+  full conference UI deferred. Recording follows the active call.
+- **Multi-SIM, VoLTE/VoWiFi, video calls:** Phase 1 records voice calls as today; video/VoIP route
+  to the system and are out of scope.
+- **Lock-screen incoming UI:** requires `USE_FULL_SCREEN_INTENT` (dialers are exempt from the
+  Android 14 restriction).
+- **Distribution:** still F-Droid/GitHub only; the dialer role does not change the recording ban.
+- **Permissions:** holding `ROLE_DIALER` implicitly grants `CALL_PHONE`/`READ_CALL_LOG` while held;
+  no `MANAGE_OWN_CALLS` (we ride system telephony via InCallService, not a self-managed
+  ConnectionService). When the role is released, those revert.
+- **OEM quirks (OxygenOS/OnePlus):** default-dialer behavior on heavily-skinned OEMs needs on-device
+  verification (consistent with existing battery/autostart friction).
+
+## 7. Testing
+
+- **Unit:** `CallEventSource` normalization (Telecom states → events); `DialerRoleController` state
+  machine; **regression** that `shouldAutoRecord` / recording-decision logic is unchanged.
+- **On-device (manual/instrumented):** place + receive calls; emergency-number dial; reject/miss;
+  role grant→revoke mid-session; recording start timing (warm vs cold daemon); lock-screen incoming;
+  multi-SIM if available.
+- **Regression:** recording-only mode behaves byte-for-byte as 1.2.1 (default `DIALER_MODE_ENABLED`
+  is `false`).
+
+## 8. Integration Seams (from codebase map)
+
+| Concern | File | Note |
+|---|---|---|
+| Mode pref | `data/AppPreferences.kt` | Add `DIALER_MODE_ENABLED` key + default + accessors |
+| Detection entry | `services/call/CallSessionManager.kt` | `processSessionUpdate` is the shared sink for both sources |
+| Existing broadcast source | `services/call/PhoneStateReceiver.kt`, `services/call/CallMonitorService.kt` | Becomes `BroadcastCallEventSource`; defers in dialer mode |
+| Recording start | `services/recording/RecordingForegroundService.kt`, `server/RecorderServerLauncher.kt` | Unchanged |
+| Settings UI | `ui/screens/SettingsScreen.kt`, `ui/viewmodels/SettingsViewModel.kt` | Mode toggle + role request |
+| Manifest | `AndroidManifest.xml` | Add `InCallService` (`BIND_INCALL_SERVICE`), full-screen-intent perm |
+| New UI | `ui/dialer/` (InCallActivity, dialpad, viewmodels) | Standalone calling surfaces |
+
+## 9. Open Questions
+
+None blocking Phase 1. Later phases (call log, contacts) will get their own specs.

--- a/docs/dialer-mode-phase1-plan.md
+++ b/docs/dialer-mode-phase1-plan.md
@@ -1,0 +1,1099 @@
+# Dialer Mode — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional "dialer + recording" mode: make CallVault selectable as the default phone app, render its own incoming/in-call/dialpad UI, and detect calls via Telecom (`InCallService`) instead of broadcasts — feeding the **unchanged** recording pipeline.
+
+**Architecture:** A `CallEventSource` seam sits between call detection and the existing recording decision. Two implementations (`BroadcastCallEventSource` = today's path; `TelecomCallEventSource` = new `InCallService`) emit identical normalized `CallEvent`s into a single `CallEventRouter`, which forwards to the existing `CallSessionManager`. Mode is a reversible preference gated on the real `ROLE_DIALER` role.
+
+**Tech Stack:** Kotlin, Android (minSdk 30 / targetSdk 36), Jetpack Compose, Android Telecom (`InCallService`, `TelecomManager`, `RoleManager`). Tests: JUnit4 + MockK + Robolectric (added in Task 0).
+
+## Global Constraints
+
+- **minSdk 30, targetSdk 36** — all APIs must be guarded for API 30 where they require ≥31.
+- **Recording-only mode must remain byte-for-byte identical to v1.2.1.** `DIALER_MODE_ENABLED` defaults to `false`; with it off, no behavior changes.
+- **Recording pipeline is UNCHANGED.** Do not modify `shouldAutoRecord`, the daemon, `RecorderServerLauncher`, or `RecordingForegroundService`'s recording logic. Only the *source* of call events changes.
+- **Translation gate:** lint treats `MissingTranslation`/`ExtraTranslation` as errors. Every new user-facing string added to `values/` MUST be added to all 9 locale folders (`values-fr,de,es,it,hu,pl,ru,vi,zh-rCN`) or `lintDebug` fails.
+- **Emergency calls always work** and are never filtered, blocked, or record-gated.
+- **Role truth = `RoleManager.isRoleHeld(ROLE_DIALER)`**, never the stored preference alone.
+- **No new signing/release changes.** Builds stay debug-signed per current release process.
+- **Build env:** `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home` for local Gradle.
+- Conventional commits; commit after each task.
+
+---
+
+## File Structure
+
+**New (pure logic — JVM unit-tested):**
+- `app/src/main/java/com/baba/callvault/calls/CallEvent.kt` — normalized event model.
+- `app/src/main/java/com/baba/callvault/calls/CallEventSource.kt` — source interface + listener type.
+- `app/src/main/java/com/baba/callvault/calls/CallEventRouter.kt` — mode-aware single sink → `CallSessionManager`.
+- `app/src/main/java/com/baba/callvault/calls/CallStateRepository.kt` — process-wide current-call state for the UI.
+
+**New (Android glue — thin, on-device verified):**
+- `app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt` — `RoleManager` wrapper.
+- `app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt` — `InCallService`.
+- `app/src/main/java/com/baba/callvault/dialer/TelecomCallEventSource.kt` — Telecom `Call` → `CallEvent`.
+- `app/src/main/java/com/baba/callvault/dialer/BroadcastCallEventSource.kt` — wraps existing detection.
+
+**New (Compose UI — on-device verified):**
+- `app/src/main/java/com/baba/callvault/ui/dialer/InCallActivity.kt`
+- `app/src/main/java/com/baba/callvault/ui/dialer/InCallScreen.kt`
+- `app/src/main/java/com/baba/callvault/ui/dialer/DialpadScreen.kt`
+- `app/src/main/java/com/baba/callvault/ui/dialer/InCallViewModel.kt`
+
+**Modified:**
+- `app/build.gradle.kts` — test deps (Task 0).
+- `app/src/main/java/com/baba/callvault/data/AppPreferences.kt` — `DIALER_MODE_ENABLED`.
+- `app/src/main/java/com/baba/callvault/services/call/CallSessionManager.kt` — expose a clean entry for `CallEventRouter`; add dialer-mode deferral.
+- `app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt` — defer when dialer mode active.
+- `app/src/main/AndroidManifest.xml` — `InCallService`, `InCallActivity`, permissions.
+- `app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt` + `ui/viewmodels/SettingsViewModel.kt` — mode toggle + role flow + banner.
+- `app/src/main/res/values/strings_dialer.xml` (new) + all 9 locale copies — new strings.
+
+---
+
+## Task 0: Add JVM unit-test harness
+
+**Files:**
+- Modify: `app/build.gradle.kts`
+- Create: `app/src/test/java/com/baba/callvault/SanityTest.kt`
+
+**Interfaces:**
+- Produces: a working `./gradlew :app:testDebugUnitTest` task for all later logic tasks.
+
+- [ ] **Step 1: Add test dependencies** to `app/build.gradle.kts` dependencies block:
+
+```kotlin
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("org.robolectric:robolectric:4.14")
+    testImplementation("androidx.test:core:1.6.1")
+```
+
+- [ ] **Step 2: Enable Android resources in unit tests** — inside the `android { ... }` block:
+
+```kotlin
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
+```
+
+- [ ] **Step 3: Write the sanity test** at `app/src/test/java/com/baba/callvault/SanityTest.kt`:
+
+```kotlin
+package com.baba.callvault
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SanityTest {
+    @Test fun harness_runs() { assertEquals(4, 2 + 2) }
+}
+```
+
+- [ ] **Step 4: Run it**
+
+Run: `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.SanityTest"`
+Expected: PASS (BUILD SUCCESSFUL).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/build.gradle.kts app/src/test/java/com/baba/callvault/SanityTest.kt
+git commit -m "test: add JVM unit-test harness (JUnit/MockK/Robolectric)"
+```
+
+---
+
+## Task 1: Normalized `CallEvent` model + `CallEventSource` interface
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/calls/CallEvent.kt`
+- Create: `app/src/main/java/com/baba/callvault/calls/CallEventSource.kt`
+- Test: `app/src/test/java/com/baba/callvault/calls/CallEventTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `enum class CallDirection { INCOMING, OUTGOING, UNKNOWN }`
+  - `data class CallEvent(val phase: Phase, val number: String?, val direction: CallDirection, val isEmergency: Boolean)` with `enum class Phase { RINGING, DIALING, ACTIVE, ENDED }`
+  - `fun interface CallEventListener { fun onCallEvent(event: CallEvent) }`
+  - `interface CallEventSource { fun start(listener: CallEventListener); fun stop() }`
+
+- [ ] **Step 1: Write the failing test** at `CallEventTest.kt`:
+
+```kotlin
+package com.baba.callvault.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CallEventTest {
+    @Test fun builds_incoming_ringing_event() {
+        val e = CallEvent(CallEvent.Phase.RINGING, "+15551234", CallDirection.INCOMING, isEmergency = false)
+        assertEquals(CallEvent.Phase.RINGING, e.phase)
+        assertEquals(CallDirection.INCOMING, e.direction)
+        assertEquals("+15551234", e.number)
+        assertTrue(!e.isEmergency)
+    }
+
+    @Test fun emergency_flag_is_carried() {
+        val e = CallEvent(CallEvent.Phase.DIALING, "911", CallDirection.OUTGOING, isEmergency = true)
+        assertTrue(e.isEmergency)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.calls.CallEventTest"`
+Expected: FAIL (unresolved reference `CallEvent`).
+
+- [ ] **Step 3: Implement** `CallEvent.kt`:
+
+```kotlin
+package com.baba.callvault.calls
+
+enum class CallDirection { INCOMING, OUTGOING, UNKNOWN }
+
+/** A call-lifecycle event normalized across detection sources (broadcast vs Telecom). */
+data class CallEvent(
+    val phase: Phase,
+    val number: String?,
+    val direction: CallDirection,
+    val isEmergency: Boolean,
+) {
+    enum class Phase { RINGING, DIALING, ACTIVE, ENDED }
+}
+```
+
+- [ ] **Step 4: Implement** `CallEventSource.kt`:
+
+```kotlin
+package com.baba.callvault.calls
+
+/** Receives normalized call events from whichever source is active. */
+fun interface CallEventListener {
+    fun onCallEvent(event: CallEvent)
+}
+
+/** A source of normalized call events. Exactly one source is active at a time (see CallEventRouter). */
+interface CallEventSource {
+    fun start(listener: CallEventListener)
+    fun stop()
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.calls.CallEventTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/calls/CallEvent.kt app/src/main/java/com/baba/callvault/calls/CallEventSource.kt app/src/test/java/com/baba/callvault/calls/CallEventTest.kt
+git commit -m "feat(calls): normalized CallEvent model + CallEventSource interface"
+```
+
+---
+
+## Task 2: `CallEventRouter` — mode-aware single sink
+
+The router is the one place that knows the current mode. It forwards events to a sink callback
+(wired to `CallSessionManager` in Task 5/6). It ignores events from the non-active source.
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/calls/CallEventRouter.kt`
+- Test: `app/src/test/java/com/baba/callvault/calls/CallEventRouterTest.kt`
+
+**Interfaces:**
+- Consumes: `CallEvent`, `CallDirection` (Task 1).
+- Produces:
+  - `enum class DetectionMode { BROADCAST, TELECOM }`
+  - `class CallEventRouter(private val sink: (CallEvent) -> Unit)` with:
+    - `fun setActiveMode(mode: DetectionMode)`
+    - `fun submit(source: DetectionMode, event: CallEvent)` — forwards to `sink` only if `source == active mode`.
+
+- [ ] **Step 1: Write the failing test** at `CallEventRouterTest.kt`:
+
+```kotlin
+package com.baba.callvault.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CallEventRouterTest {
+    private fun event() = CallEvent(CallEvent.Phase.ACTIVE, "1", CallDirection.INCOMING, false)
+
+    @Test fun forwards_events_from_active_source_only() {
+        val seen = mutableListOf<CallEvent>()
+        val router = CallEventRouter(sink = { seen.add(it) })
+        router.setActiveMode(DetectionMode.TELECOM)
+
+        router.submit(DetectionMode.TELECOM, event())   // active → forwarded
+        router.submit(DetectionMode.BROADCAST, event())  // inactive → dropped
+
+        assertEquals(1, seen.size)
+    }
+
+    @Test fun switching_mode_changes_which_source_is_forwarded() {
+        val seen = mutableListOf<CallEvent>()
+        val router = CallEventRouter(sink = { seen.add(it) })
+        router.setActiveMode(DetectionMode.BROADCAST)
+        router.submit(DetectionMode.BROADCAST, event())
+        router.setActiveMode(DetectionMode.TELECOM)
+        router.submit(DetectionMode.BROADCAST, event())  // now inactive → dropped
+        assertEquals(1, seen.size)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.calls.CallEventRouterTest"`
+Expected: FAIL (unresolved `CallEventRouter`).
+
+- [ ] **Step 3: Implement** `CallEventRouter.kt`:
+
+```kotlin
+package com.baba.callvault.calls
+
+import java.util.concurrent.atomic.AtomicReference
+
+enum class DetectionMode { BROADCAST, TELECOM }
+
+/**
+ * Single sink for normalized call events. Only events from the currently active detection mode are
+ * forwarded; the inactive source is ignored. This enforces broadcast↔Telecom mutual exclusion.
+ */
+class CallEventRouter(private val sink: (CallEvent) -> Unit) {
+    private val active = AtomicReference(DetectionMode.BROADCAST)
+
+    fun setActiveMode(mode: DetectionMode) { active.set(mode) }
+
+    fun submit(source: DetectionMode, event: CallEvent) {
+        if (source == active.get()) sink(event)
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.calls.CallEventRouterTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/calls/CallEventRouter.kt app/src/test/java/com/baba/callvault/calls/CallEventRouterTest.kt
+git commit -m "feat(calls): mode-aware CallEventRouter with source mutual-exclusion"
+```
+
+---
+
+## Task 3: `DIALER_MODE_ENABLED` preference
+
+**Files:**
+- Modify: `app/src/main/java/com/baba/callvault/data/AppPreferences.kt`
+- Test: `app/src/test/java/com/baba/callvault/data/DialerModePrefTest.kt`
+
+**Interfaces:**
+- Produces (on `AppPreferences`): `fun isDialerModeEnabled(): Boolean` (default `false`), `fun setDialerModeEnabled(enabled: Boolean)`.
+
+- [ ] **Step 1: Inspect existing pattern** — open `AppPreferences.kt`, find the `Key` enum, the defaults, and an existing boolean accessor pair (e.g. `isDynamicColorEnabled`/`setDynamicColorEnabled`). Mirror it exactly.
+
+- [ ] **Step 2: Write the failing test** at `DialerModePrefTest.kt`:
+
+```kotlin
+package com.baba.callvault.data
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DialerModePrefTest {
+    private val prefs = AppPreferences(ApplicationProvider.getApplicationContext())
+
+    @Test fun defaults_to_false() { assertFalse(prefs.isDialerModeEnabled()) }
+
+    @Test fun persists_true() {
+        prefs.setDialerModeEnabled(true)
+        assertTrue(prefs.isDialerModeEnabled())
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.data.DialerModePrefTest"`
+Expected: FAIL (unresolved `isDialerModeEnabled`).
+
+- [ ] **Step 4: Implement** — add a `DIALER_MODE_ENABLED("dialer_mode_enabled")` entry to the `Key` enum, a `false` default consistent with how other boolean defaults are declared, and the accessor pair mirroring `isDynamicColorEnabled`/`setDynamicColorEnabled`:
+
+```kotlin
+    fun isDialerModeEnabled(): Boolean =
+        sharedPreferences.getBoolean(Key.DIALER_MODE_ENABLED.id, false)
+
+    fun setDialerModeEnabled(enabled: Boolean) {
+        sharedPreferences.edit().putBoolean(Key.DIALER_MODE_ENABLED.id, enabled).apply()
+    }
+```
+(Adjust property/field names — `sharedPreferences`, `Key.id` — to match the actual file.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.data.DialerModePrefTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/data/AppPreferences.kt app/src/test/java/com/baba/callvault/data/DialerModePrefTest.kt
+git commit -m "feat(prefs): add DIALER_MODE_ENABLED preference (default off)"
+```
+
+---
+
+## Task 4: `DialerRoleController` (RoleManager wrapper)
+
+Thin wrapper over `RoleManager`. The only unit-testable logic is "is the role held?" and the intent
+factory; the actual grant happens via a system Activity result (verified on-device in Task 10).
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt`
+- Test: `app/src/test/java/com/baba/callvault/dialer/DialerRoleControllerTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `class DialerRoleController(private val context: Context)`
+  - `fun isDefaultDialer(): Boolean` — `RoleManager.isRoleHeld(ROLE_DIALER)`; `false` if RoleManager unavailable.
+  - `fun requestRoleIntent(): Intent?` — `RoleManager.createRequestRoleIntent(ROLE_DIALER)`; `null` if already held or unavailable.
+  - `fun releaseRoleHint(): Intent` — intent to system default-apps settings (we cannot programmatically drop the role; we send the user to settings).
+
+- [ ] **Step 1: Write the failing test** (Robolectric provides a `RoleManager`):
+
+```kotlin
+package com.baba.callvault.dialer
+
+import android.app.role.RoleManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class DialerRoleControllerTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val controller = DialerRoleController(context)
+
+    @Test fun reports_not_default_when_role_not_held() {
+        // Robolectric default: role not held
+        org.junit.Assert.assertFalse(controller.isDefaultDialer())
+    }
+
+    @Test fun request_intent_is_available_when_not_held() {
+        assertNotNull(controller.requestRoleIntent())
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.dialer.DialerRoleControllerTest"`
+Expected: FAIL (unresolved `DialerRoleController`).
+
+- [ ] **Step 3: Implement** `DialerRoleController.kt`:
+
+```kotlin
+package com.baba.callvault.dialer
+
+import android.app.role.RoleManager
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+
+/** Wraps RoleManager for the default-dialer (ROLE_DIALER) role. Truth = isRoleHeld, never a preference. */
+class DialerRoleController(private val context: Context) {
+
+    private val roleManager: RoleManager? =
+        context.getSystemService(Context.ROLE_SERVICE) as? RoleManager
+
+    fun isDefaultDialer(): Boolean {
+        val rm = roleManager ?: return false
+        return rm.isRoleAvailable(RoleManager.ROLE_DIALER) && rm.isRoleHeld(RoleManager.ROLE_DIALER)
+    }
+
+    /** Intent to ask the user to make CallVault the default phone app, or null if already held/unavailable. */
+    fun requestRoleIntent(): Intent? {
+        val rm = roleManager ?: return null
+        if (!rm.isRoleAvailable(RoleManager.ROLE_DIALER) || rm.isRoleHeld(RoleManager.ROLE_DIALER)) return null
+        return rm.createRequestRoleIntent(RoleManager.ROLE_DIALER)
+    }
+
+    /** We cannot drop the role programmatically; send the user to default-apps settings. */
+    fun releaseRoleHint(): Intent = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.dialer.DialerRoleControllerTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/dialer/DialerRoleController.kt app/src/test/java/com/baba/callvault/dialer/DialerRoleControllerTest.kt
+git commit -m "feat(dialer): DialerRoleController wrapping RoleManager(ROLE_DIALER)"
+```
+
+---
+
+## Task 5: Wire the existing detection through the router (recording-only unchanged)
+
+Make the current broadcast path emit through `CallEventRouter` without changing behavior. Provide a
+process-wide singleton holder so both the receiver and (later) the InCallService share one router +
+sink. The sink calls the existing `CallSessionManager` entry point.
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/calls/CallDetection.kt` (singleton holder + sink wiring)
+- Create: `app/src/main/java/com/baba/callvault/dialer/BroadcastCallEventSource.kt`
+- Modify: `app/src/main/java/com/baba/callvault/services/call/CallSessionManager.kt` (add a thin `onCallEvent(CallEvent)` adapter that maps to the existing `handlePhoneState`/`processSessionUpdate` inputs — do not change the decision logic)
+- Test: `app/src/test/java/com/baba/callvault/calls/CallDetectionSinkTest.kt`
+
+**Interfaces:**
+- Consumes: `CallEventRouter`, `DetectionMode`, `CallEvent` (Tasks 1–2); `AppPreferences.isDialerModeEnabled` (Task 3).
+- Produces:
+  - `object CallDetection { val router: CallEventRouter; fun init(context: Context); fun setMode(dialer: Boolean) }`
+  - `CallSessionManager.onCallEvent(event: CallEvent)` — adapter to the existing pipeline.
+
+- [ ] **Step 1: Inspect** `CallSessionManager.handlePhoneState(...)` and `processSessionUpdate(...)` signatures. Identify the minimal inputs (state string/number/direction) so the adapter maps `CallEvent` → existing call without touching `shouldAutoRecord`.
+
+- [ ] **Step 2: Write the failing test** — verify the router forwards a broadcast-sourced event to a sink (the adapter is exercised on-device; here we test the holder wiring with a fake sink):
+
+```kotlin
+package com.baba.callvault.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CallDetectionSinkTest {
+    @Test fun broadcast_source_reaches_sink_in_broadcast_mode() {
+        val seen = mutableListOf<CallEvent>()
+        val router = CallEventRouter(sink = { seen.add(it) })
+        router.setActiveMode(DetectionMode.BROADCAST)
+        val src = com.baba.callvault.dialer.BroadcastCallEventSource(router)
+        src.emit(CallEvent(CallEvent.Phase.ACTIVE, "1", CallDirection.OUTGOING, false))
+        assertEquals(1, seen.size)
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.calls.CallDetectionSinkTest"`
+Expected: FAIL (unresolved `BroadcastCallEventSource`).
+
+- [ ] **Step 4: Implement** `BroadcastCallEventSource.kt`:
+
+```kotlin
+package com.baba.callvault.dialer
+
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.calls.CallEventRouter
+import com.baba.callvault.calls.DetectionMode
+
+/** Adapts the existing PhoneStateReceiver/CallMonitorService path to the CallEventRouter. */
+class BroadcastCallEventSource(private val router: CallEventRouter) {
+    fun emit(event: CallEvent) = router.submit(DetectionMode.BROADCAST, event)
+}
+```
+
+- [ ] **Step 5: Implement** `CallDetection.kt` (singleton; sink → `CallSessionManager`):
+
+```kotlin
+package com.baba.callvault.calls
+
+import android.content.Context
+import com.baba.callvault.services.call.CallSessionManager
+
+/** Process-wide holder so broadcast + Telecom sources share one router and one sink. */
+object CallDetection {
+    lateinit var router: CallEventRouter
+        private set
+
+    fun init(context: Context) {
+        if (::router.isInitialized) return
+        val mgr = CallSessionManager.getInstance()
+        router = CallEventRouter(sink = { event -> mgr.onCallEvent(event) })
+    }
+
+    fun setMode(dialer: Boolean) {
+        router.setActiveMode(if (dialer) DetectionMode.TELECOM else DetectionMode.BROADCAST)
+    }
+}
+```
+
+- [ ] **Step 6: Add the adapter** to `CallSessionManager.kt` — a thin method mapping `CallEvent` to the existing internal handling (use the real internal method names found in Step 1; do not alter decision logic):
+
+```kotlin
+    /** Entry point for the CallEventRouter. Maps a normalized event onto the existing pipeline. */
+    fun onCallEvent(event: com.baba.callvault.calls.CallEvent) {
+        // Map phase → existing state handling. Emergency calls are passed through unchanged.
+        // Reuse the SAME processSessionUpdate/handlePhoneState path the broadcast already uses.
+        // (Wire using the inputs identified in Step 1 — number/direction/phase.)
+    }
+```
+
+- [ ] **Step 7: Initialize** `CallDetection` where the app starts (in `CallVaultApplication.onCreate`, after existing init) and set initial mode from the preference:
+
+```kotlin
+        com.baba.callvault.calls.CallDetection.init(this)
+        com.baba.callvault.calls.CallDetection.setMode(com.baba.callvault.data.AppPreferences(this).isDialerModeEnabled())
+```
+
+- [ ] **Step 8: Make `PhoneStateReceiver` route through the broadcast source AND defer in dialer mode.** In `PhoneStateReceiver.onReceive`, early-return when `AppPreferences(context).isDialerModeEnabled()` is true (Telecom owns detection then), preserving the existing `CallMonitorService.isListening` deferral.
+
+- [ ] **Step 9: Run unit test + build**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.calls.CallDetectionSinkTest" :app:assembleDebug`
+Expected: PASS + BUILD SUCCESSFUL.
+
+- [ ] **Step 10: On-device regression** — install, confirm recording-only mode still auto-records an incoming and an outgoing call exactly as v1.2.1 (dialer mode still off).
+
+Run: `adb -s 6011b07e install -r app/build/outputs/apk/debug/app-debug.apk` then place/receive a test call.
+Expected: recordings created as before.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/calls/CallDetection.kt app/src/main/java/com/baba/callvault/dialer/BroadcastCallEventSource.kt app/src/main/java/com/baba/callvault/services/call/CallSessionManager.kt app/src/main/java/com/baba/callvault/services/call/PhoneStateReceiver.kt app/src/main/java/com/baba/callvault/CallVaultApplication.kt app/src/test/java/com/baba/callvault/calls/CallDetectionSinkTest.kt
+git commit -m "feat(calls): route broadcast detection through CallEventRouter; defer in dialer mode"
+```
+
+---
+
+## Task 6: `CallStateRepository` — shared current-call state for the UI
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/calls/CallStateRepository.kt`
+- Test: `app/src/test/java/com/baba/callvault/calls/CallStateRepositoryTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `data class UiCall(val number: String?, val phase: CallEvent.Phase, val direction: CallDirection, val isEmergency: Boolean, val isRecording: Boolean)`
+  - `object CallStateRepository { val current: StateFlow<UiCall?>; fun update(call: UiCall?); fun setRecording(active: Boolean) }`
+
+- [ ] **Step 1: Write the failing test**:
+
+```kotlin
+package com.baba.callvault.calls
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CallStateRepositoryTest {
+    @Test fun update_and_clear_current_call() = runBlocking {
+        CallStateRepository.update(UiCall("1", CallEvent.Phase.ACTIVE, CallDirection.INCOMING, false, false))
+        assertEquals("1", CallStateRepository.current.first()!!.number)
+        CallStateRepository.update(null)
+        assertNull(CallStateRepository.current.first())
+    }
+
+    @Test fun set_recording_updates_flag() = runBlocking {
+        CallStateRepository.update(UiCall("1", CallEvent.Phase.ACTIVE, CallDirection.INCOMING, false, false))
+        CallStateRepository.setRecording(true)
+        assertEquals(true, CallStateRepository.current.first()!!.isRecording)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.calls.CallStateRepositoryTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** `CallStateRepository.kt`:
+
+```kotlin
+package com.baba.callvault.calls
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class UiCall(
+    val number: String?,
+    val phase: CallEvent.Phase,
+    val direction: CallDirection,
+    val isEmergency: Boolean,
+    val isRecording: Boolean,
+)
+
+/** Process-wide current-call state, shared between the InCallService and the in-call UI. */
+object CallStateRepository {
+    private val _current = MutableStateFlow<UiCall?>(null)
+    val current: StateFlow<UiCall?> = _current.asStateFlow()
+
+    fun update(call: UiCall?) { _current.value = call }
+
+    fun setRecording(active: Boolean) {
+        _current.value = _current.value?.copy(isRecording = active)
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.calls.CallStateRepositoryTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/calls/CallStateRepository.kt app/src/test/java/com/baba/callvault/calls/CallStateRepositoryTest.kt
+git commit -m "feat(calls): CallStateRepository for shared current-call UI state"
+```
+
+---
+
+## Task 7: `CallVaultInCallService` + `TelecomCallEventSource` + manifest
+
+Android-framework glue: receives Telecom `Call`s, maps states → `CallEvent`s (via the router as
+`TELECOM` source) and updates `CallStateRepository`, and launches `InCallActivity`. Not JVM-unit
+tested; verified on-device in Task 10.
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/dialer/TelecomCallEventSource.kt`
+- Create: `app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt`
+- Modify: `app/src/main/AndroidManifest.xml`
+
+**Interfaces:**
+- Consumes: `CallDetection.router`, `DetectionMode.TELECOM`, `CallEvent`, `CallStateRepository`.
+- Produces: a registered default-dialer `InCallService`.
+
+- [ ] **Step 1: Implement** `TelecomCallEventSource.kt` (pure mapping helpers kept here so they *could* be unit-tested later):
+
+```kotlin
+package com.baba.callvault.dialer
+
+import android.telecom.Call
+import com.baba.callvault.calls.CallDirection
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.calls.CallEventRouter
+import com.baba.callvault.calls.DetectionMode
+
+object TelecomCallEventSource {
+    fun phaseOf(state: Int): CallEvent.Phase = when (state) {
+        Call.STATE_RINGING -> CallEvent.Phase.RINGING
+        Call.STATE_DIALING, Call.STATE_CONNECTING -> CallEvent.Phase.DIALING
+        Call.STATE_ACTIVE -> CallEvent.Phase.ACTIVE
+        Call.STATE_DISCONNECTED, Call.STATE_DISCONNECTING -> CallEvent.Phase.ENDED
+        else -> CallEvent.Phase.ACTIVE
+    }
+
+    fun directionOf(details: Call.Details): CallDirection = when (details.callDirection) {
+        Call.Details.DIRECTION_INCOMING -> CallDirection.INCOMING
+        Call.Details.DIRECTION_OUTGOING -> CallDirection.OUTGOING
+        else -> CallDirection.UNKNOWN
+    }
+
+    fun numberOf(details: Call.Details): String? =
+        details.handle?.schemeSpecificPart
+
+    fun submit(router: CallEventRouter, call: Call) {
+        val d = call.details
+        router.submit(
+            DetectionMode.TELECOM,
+            CallEvent(phaseOf(call.state), numberOf(d), directionOf(d),
+                isEmergency = (d.callProperties and Call.Details.PROPERTY_EMERGENCY_CALLBACK_MODE) != 0),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Implement** `CallVaultInCallService.kt`:
+
+```kotlin
+package com.baba.callvault.dialer
+
+import android.content.Intent
+import android.telecom.Call
+import android.telecom.InCallService
+import com.baba.callvault.calls.CallDetection
+import com.baba.callvault.calls.CallStateRepository
+import com.baba.callvault.calls.UiCall
+import com.baba.callvault.ui.dialer.InCallActivity
+
+class CallVaultInCallService : InCallService() {
+
+    private val callbacks = mutableMapOf<Call, Call.Callback>()
+
+    override fun onCallAdded(call: Call) {
+        val cb = object : Call.Callback() {
+            override fun onStateChanged(c: Call, state: Int) = publish(c)
+        }
+        callbacks[call] = cb
+        call.registerCallback(cb)
+        publish(call)
+        startActivity(Intent(this, InCallActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    }
+
+    override fun onCallRemoved(call: Call) {
+        callbacks.remove(call)?.let { call.unregisterCallback(it) }
+        TelecomCallEventSource.submit(CallDetection.router, call) // ENDED
+        CallStateRepository.update(null)
+    }
+
+    private fun publish(call: Call) {
+        TelecomCallEventSource.submit(CallDetection.router, call)
+        val d = call.details
+        CallStateRepository.update(
+            UiCall(
+                number = TelecomCallEventSource.numberOf(d),
+                phase = TelecomCallEventSource.phaseOf(call.state),
+                direction = TelecomCallEventSource.directionOf(d),
+                isEmergency = (d.callProperties and Call.Details.PROPERTY_EMERGENCY_CALLBACK_MODE) != 0,
+                isRecording = CallStateRepository.current.value?.isRecording ?: false,
+            )
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Register in `AndroidManifest.xml`** (inside `<application>`):
+
+```xml
+        <service
+            android:name=".dialer.CallVaultInCallService"
+            android:exported="true"
+            android:permission="android.permission.BIND_INCALL_SERVICE"
+            android:foregroundServiceType="specialUse">
+            <meta-data android:name="android.telecom.IN_CALL_SERVICE_UI" android:value="true" />
+            <meta-data android:name="android.telecom.IN_CALL_SERVICE_RINGING" android:value="true" />
+            <intent-filter>
+                <action android:name="android.telecom.InCallService" />
+            </intent-filter>
+        </service>
+```
+And add permissions near the existing `<uses-permission>` block:
+
+```xml
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+```
+(Note: `CALL_PHONE`/`READ_CALL_LOG` are also implicitly granted while the role is held; declaring `CALL_PHONE` lets the dialpad place calls.)
+
+- [ ] **Step 4: Build** (UI class `InCallActivity` referenced here is created in Task 8 — if executing strictly in order, create an empty `InCallActivity` stub first, or reorder so Task 8 precedes this build). 
+
+Run: `JAVA_HOME=... ./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL (after Task 8 stub exists).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/dialer/TelecomCallEventSource.kt app/src/main/java/com/baba/callvault/dialer/CallVaultInCallService.kt app/src/main/AndroidManifest.xml
+git commit -m "feat(dialer): InCallService + Telecom→CallEvent mapping + manifest registration"
+```
+
+---
+
+## Task 8: In-call UI (`InCallActivity`, `InCallScreen`, `InCallViewModel`)
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/ui/dialer/InCallViewModel.kt`
+- Create: `app/src/main/java/com/baba/callvault/ui/dialer/InCallScreen.kt`
+- Create: `app/src/main/java/com/baba/callvault/ui/dialer/InCallActivity.kt`
+- Create: `app/src/main/res/values/strings_dialer.xml` + 9 locale copies
+- Test: `app/src/test/java/com/baba/callvault/ui/dialer/InCallViewModelTest.kt`
+
+**Interfaces:**
+- Consumes: `CallStateRepository.current` (Task 6), `InCallService` controls.
+- Produces: a full-screen calling Activity bound to current-call state.
+
+- [ ] **Step 1: Add strings** to `app/src/main/res/values/strings_dialer.xml`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dialer_incoming_title">Incoming call</string>
+    <string name="dialer_answer">Answer</string>
+    <string name="dialer_reject">Reject</string>
+    <string name="dialer_end_call">End call</string>
+    <string name="dialer_mute">Mute</string>
+    <string name="dialer_speaker">Speaker</string>
+    <string name="dialer_hold">Hold</string>
+    <string name="dialer_keypad">Keypad</string>
+    <string name="dialer_record">Record</string>
+    <string name="dialer_stop_recording">Stop recording</string>
+    <string name="dialer_unknown_caller">Unknown</string>
+</resources>
+```
+
+- [ ] **Step 2: Translate** — create `strings_dialer.xml` in each of `values-fr, values-de, values-es, values-it, values-hu, values-pl, values-ru, values-vi, values-zh-rCN` with the same keys translated (reuse the translation approach from the i18n work: natural text, escape downstream). This is REQUIRED or `lintDebug` fails.
+
+- [ ] **Step 3: Write the failing ViewModel test** (logic the VM exposes — label for a call):
+
+```kotlin
+package com.baba.callvault.ui.dialer
+
+import com.baba.callvault.calls.CallDirection
+import com.baba.callvault.calls.CallEvent
+import com.baba.callvault.calls.UiCall
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InCallViewModelTest {
+    @Test fun shows_unknown_when_number_null() {
+        assertEquals("Unknown", InCallLabels.displayNumber(UiCall(null, CallEvent.Phase.RINGING, CallDirection.INCOMING, false, false), unknown = "Unknown"))
+    }
+    @Test fun shows_number_when_present() {
+        assertEquals("+15551234", InCallLabels.displayNumber(UiCall("+15551234", CallEvent.Phase.ACTIVE, CallDirection.OUTGOING, false, false), unknown = "Unknown"))
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.ui.dialer.InCallViewModelTest"`
+Expected: FAIL.
+
+- [ ] **Step 5: Implement** `InCallViewModel.kt` (include the pure `InCallLabels` helper + VM that reads `CallStateRepository` and exposes call actions via the bound `InCallService`):
+
+```kotlin
+package com.baba.callvault.ui.dialer
+
+import com.baba.callvault.calls.UiCall
+
+object InCallLabels {
+    fun displayNumber(call: UiCall?, unknown: String): String =
+        call?.number?.takeIf { it.isNotBlank() } ?: unknown
+}
+```
+(Plus a `ViewModel` exposing `CallStateRepository.current` and action lambdas — answer/reject/end/mute/speaker/hold/toggleRecord — delegating to the active `Call` held by the service. Wire recording toggle to the same `RecordingForegroundService` action the auto path uses.)
+
+- [ ] **Step 6: Implement** `InCallScreen.kt` (Compose: render incoming vs active states from `current`, buttons using the string resources) and `InCallActivity.kt` (a `ComponentActivity` that sets `setShowWhenLocked(true)`, `setTurnScreenOn(true)`, hosts `InCallScreen` in `CallVaultTheme`). Keep these focused; no business logic.
+
+- [ ] **Step 7: Run unit test + build + lint**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.ui.dialer.InCallViewModelTest" :app:lintDebug`
+Expected: PASS + lint clean (translations present).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/ui/dialer/ app/src/main/res/values*/strings_dialer.xml app/src/test/java/com/baba/callvault/ui/dialer/InCallViewModelTest.kt
+git commit -m "feat(dialer): in-call UI (activity/screen/viewmodel) + localized strings"
+```
+
+---
+
+## Task 9: Minimal dialpad + place call (incl. emergency)
+
+**Files:**
+- Create: `app/src/main/java/com/baba/callvault/ui/dialer/DialpadScreen.kt`
+- Create: `app/src/main/java/com/baba/callvault/dialer/CallPlacer.kt`
+- Test: `app/src/test/java/com/baba/callvault/dialer/CallPlacerTest.kt`
+- Modify: `app/src/main/java/com/baba/callvault/AppNavigationScreen.kt` (expose dialpad entry in dialer mode), `ui/navigation/AppScreen.kt` (add `Dialer`)
+
+**Interfaces:**
+- Produces: `class CallPlacer(context)` with `fun place(number: String)` using `TelecomManager.placeCall`; emergency numbers pass straight through.
+
+- [ ] **Step 1: Write the failing test** (pure validation: which input is dialable):
+
+```kotlin
+package com.baba.callvault.dialer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CallPlacerTest {
+    @Test fun blank_is_not_dialable() { assertFalse(CallPlacer.isDialable("")) }
+    @Test fun digits_are_dialable() { assertTrue(CallPlacer.isDialable("112")) }
+    @Test fun sanitizes_display_to_dial_string() {
+        assertEquals("+15551234", CallPlacer.normalize(" +1 (555) 1234 "))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.dialer.CallPlacerTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** `CallPlacer.kt`:
+
+```kotlin
+package com.baba.callvault.dialer
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.telecom.TelecomManager
+import androidx.core.content.ContextCompat
+
+class CallPlacer(private val context: Context) {
+    fun place(number: String) {
+        if (!isDialable(number)) return
+        val tm = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
+        val uri = Uri.fromParts("tel", normalize(number), null)
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE)
+            == PackageManager.PERMISSION_GRANTED) {
+            tm.placeCall(uri, null) // emergency numbers handled by the platform
+        }
+    }
+    companion object {
+        fun isDialable(input: String): Boolean = normalize(input).isNotEmpty()
+        fun normalize(input: String): String =
+            input.trim().filter { it.isDigit() || it == '+' || it == '*' || it == '#' }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.dialer.CallPlacerTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Implement** `DialpadScreen.kt` (Compose: 0–9/*/# grid, display field, backspace, call button calling `CallPlacer.place`). Add `AppScreen.Dialer` and expose a dialpad entry point on Home **only when** `isDialerModeEnabled()` is true.
+
+- [ ] **Step 6: Build + lint**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest :app:lintDebug`
+Expected: PASS + clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/ui/dialer/DialpadScreen.kt app/src/main/java/com/baba/callvault/dialer/CallPlacer.kt app/src/main/java/com/baba/callvault/ui/navigation/AppScreen.kt app/src/main/java/com/baba/callvault/AppNavigationScreen.kt app/src/test/java/com/baba/callvault/dialer/CallPlacerTest.kt
+git commit -m "feat(dialer): minimal dialpad + CallPlacer (emergency-safe)"
+```
+
+---
+
+## Task 10: Settings toggle + role flow + fallback banner
+
+**Files:**
+- Modify: `app/src/main/java/com/baba/callvault/ui/viewmodels/SettingsViewModel.kt`
+- Modify: `app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt`
+- Modify: `app/src/main/res/values/strings_dialer.xml` + 9 locales (toggle labels, banner)
+- Test: `app/src/test/java/com/baba/callvault/dialer/DialerModeStateTest.kt`
+
+**Interfaces:**
+- Consumes: `DialerRoleController` (Task 4), `AppPreferences` (Task 3), `CallDetection.setMode` (Task 5).
+- Produces: reconciled mode state (pref ↔ real role).
+
+- [ ] **Step 1: Write the failing test** — the reconcile rule: effective dialer mode is true only if pref ON **and** role held:
+
+```kotlin
+package com.baba.callvault.dialer
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DialerModeStateTest {
+    @Test fun effective_requires_pref_and_role() {
+        assertTrue(DialerModeState.effective(prefOn = true, roleHeld = true))
+        assertFalse(DialerModeState.effective(prefOn = true, roleHeld = false))
+        assertFalse(DialerModeState.effective(prefOn = false, roleHeld = true))
+    }
+    @Test fun banner_shown_when_pref_on_but_role_lost() {
+        assertTrue(DialerModeState.shouldShowRoleLostBanner(prefOn = true, roleHeld = false))
+        assertFalse(DialerModeState.shouldShowRoleLostBanner(prefOn = false, roleHeld = false))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.dialer.DialerModeStateTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** `DialerModeState` (put alongside `DialerRoleController`):
+
+```kotlin
+package com.baba.callvault.dialer
+
+object DialerModeState {
+    fun effective(prefOn: Boolean, roleHeld: Boolean): Boolean = prefOn && roleHeld
+    fun shouldShowRoleLostBanner(prefOn: Boolean, roleHeld: Boolean): Boolean = prefOn && !roleHeld
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest --tests "com.baba.callvault.dialer.DialerModeStateTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Wire Settings UI** — add a "Dialer mode" switch. On enable: launch `DialerRoleController.requestRoleIntent()` via an `ActivityResultLauncher`; on success persist `setDialerModeEnabled(true)` and call `CallDetection.setMode(true)`; on denial revert the switch. On disable: `setDialerModeEnabled(false)`, `CallDetection.setMode(false)`, show `releaseRoleHint()` guidance. On screen resume, recompute `DialerModeState` from `controller.isDefaultDialer()`; if `shouldShowRoleLostBanner`, show a banner. Add the toggle/banner strings to `strings_dialer.xml` + all 9 locales.
+
+- [ ] **Step 6: Build + lint + unit tests**
+
+Run: `JAVA_HOME=... ./gradlew :app:testDebugUnitTest :app:lintDebug :app:assembleDebug`
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/com/baba/callvault/ui/ app/src/main/java/com/baba/callvault/dialer/DialerModeState.kt app/src/main/res/values*/strings_dialer.xml app/src/test/java/com/baba/callvault/dialer/DialerModeStateTest.kt
+git commit -m "feat(dialer): Settings toggle, role request flow, role-loss fallback banner"
+```
+
+---
+
+## Task 11: End-to-end on-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Install**
+
+Run: `JAVA_HOME=... ./gradlew :app:installDebug` (or `adb -s 6011b07e install -r app/build/outputs/apk/debug/app-debug.apk`).
+
+- [ ] **Step 2: Enable dialer mode** in Settings → accept the "make CallVault your default phone app" system prompt. Verify the switch reflects `isDefaultDialer() == true`.
+
+- [ ] **Step 3: Outgoing call** via the dialpad → in-call screen appears; recording starts per auto-record settings; recording lands in the catalog with correct number/direction.
+
+- [ ] **Step 4: Incoming call** → full-screen incoming UI over lock screen; answer/reject work; recording behaves per settings.
+
+- [ ] **Step 5: Emergency check (no real call):** type an emergency number on the dialpad and confirm the platform emergency UI takes over (do NOT place it); confirm it is never filtered or record-gated in code paths.
+
+- [ ] **Step 6: Role loss** → change default phone app away in Android settings → return to CallVault → banner shows, detection falls back to broadcast, recording-only still works.
+
+- [ ] **Step 7: Disable dialer mode** in Settings → role released/guided, app returns to pure recording-only behavior identical to v1.2.1.
+
+- [ ] **Step 8: Regression** → with dialer mode OFF, confirm incoming + outgoing auto-record exactly as before.
+
+- [ ] **Step 9: Commit** any fixes found; otherwise tag the working state.
+
+```bash
+git commit --allow-empty -m "test(dialer): Phase 1 on-device verification complete"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** mode infra (T3,T10) · role mgmt (T4,T10) · InCallService (T7) · incoming/in-call screen (T8) · minimal dialpad + emergency (T9) · Telecom detection feeding unchanged pipeline (T1,T2,T5,T7) · reversible toggle + fallback (T10) · recording-only regression (T5,T11) · testing (all). All Section 1–8 spec items mapped.
+- **Translation gate:** new strings introduced in T8/T10 include the all-locale step (constraint honored).
+- **Ordering caveat:** T7 references `InCallActivity` (created in T8). When executing strictly in order, create an empty `InCallActivity` stub in T7 Step 4 or build T8 before T7's build step. Flagged in T7 Step 4.
+- **Type consistency:** `CallEvent.Phase`, `CallDirection`, `UiCall`, `DetectionMode`, `CallDetection.router`, `CallSessionManager.onCallEvent` used consistently across tasks.


### PR DESCRIPTION
## Summary

Adds an **optional dialer mode** to CallVault, off by default. When enabled, CallVault becomes the device's default phone app, renders its own incoming/in-call/dialpad UI, and detects calls via Telecom (`InCallService`) instead of the `PHONE_STATE` broadcast — feeding the **unchanged** recording pipeline. Recording-only mode is byte-for-byte identical to v1.2.1 when the toggle is off.

**This is a large feature branch (~25 commits) and is NOT meant to auto-merge** — opening for review. Rollback-to-1.2.1 is intact (main == tag `v1.2.1`).

## The key breakthrough (validated on a OnePlus / OxygenOS device)

OEMs like OxygenOS grant the `ROLE_DIALER` role but **don't propagate it into Telecom's default-dialer cache**, so a normal role request never makes a third-party app the *functional* dialer. CallVault instead **forces the Telecom default over its existing embedded-ADB channel** (the same privilege it already uses for the recorder daemon):

- `cmd telecom set-default-dialer com.baba.callvault` + `pm grant … CALL_PHONE`, run in one ADB stream
- re-asserted on enable / boot / app-resume / banner-tap
- relinquished (prior dialer restored) on disable
- if ADB/daemon is unavailable, it **falls back to broadcast detection** so recording never dies

On-device log confirms the full path: `CallVaultInCallService` binds (type 1, not crashed), `PhoneStateReceiver` defers to Telecom, recording starts → saves → syncs to Drive.

## What's included

**Phase 1 (foundation):** `CallEvent` model + mode-aware `CallEventRouter` (broadcast↔Telecom mutual exclusion) · `DIALER_MODE_ENABLED` pref · `DialerRoleController` (Telecom-authoritative `isDefaultDialer()`) · `CallVaultInCallService` + Telecom→event mapping · in-call/incoming Compose UI · minimal dialpad + emergency-safe `CallPlacer` · Settings toggle + role-loss banner · the `ACTION_DIAL`/`tel:` manifest filters that make the app a valid dialer candidate.

**Engage + reachable (A+B):** `DialerDefaultEnforcer` (ADB-force/relinquish) · toggle-linked "CallVault Dialer" launcher icon (`activity-alias`) routing to the dialpad · boot/resume/banner re-assert · enable toggle routes through the enforcer.

## Quality

- Per-task review + a whole-branch review (most-capable model) on each increment; all findings fixed.
- Pure logic unit-tested (`CallEvent`, router, `DialerCommands`, `DialerModeState`, `CallPlacer`, prefs); Android/Telecom/UI verified on-device (it can't be JVM-tested).
- `lintDebug` clean incl. `MissingTranslation` — all new strings localized across 9 locales.
- Recording-only path untouched; emergency calls always use the preloaded dialer (AOSP).

## Caveats / known limitations

- Dialer mode requires the app's ADB/daemon setup (already mandatory for recording).
- The OEM launcher's hardcoded "Phone" icon still opens Google (cosmetic); calls route through CallVault's `InCallService` regardless.
- Not Play-Store-eligible (call recording) — distribution stays F-Droid/GitHub.
- Deferred Minors (non-blocking): cosmetic enforce() log when TelecomManager is null; no-op pref clear in relinquish(); a SettingsViewModel import-ordering nit.

## Test plan
- [x] Unit tests pass (`:app:testDebugUnitTest`)
- [x] `:app:assembleDebug` + `:app:lintDebug` clean
- [x] On-device: enable → CallVault becomes Telecom default + CALL_PHONE granted + launcher icon appears; dialpad places call → CallVault in-call UI + recording saved/synced; broadcast deferred to Telecom while effective
- [ ] On-device: disable → prior dialer restored + icon gone + recording-only works (spot-check)
- [ ] Reboot / Google-Phone-steal → re-assert (spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)