### PR TITLE
fix: voicemail contact label + honest failure states when Developer options is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,38 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
-## [1.2.1] — unreleased
+## [1.2.2] — 2026-07-19
+
+A field-report fix release: voicemail calls get their proper name, and the app now tells the truth
+when recording can't work instead of pretending everything is fine.
+
+### Fixed
+- **Voicemail calls are now labeled correctly.** Carrier voicemail short codes (e.g. `123` in
+  France) were being "standardized" into an invalid international number (`+33123`), which broke
+  contact-name resolution — and voicemail isn't a real contact anyway, so lookups always came up
+  empty. Short codes now keep their raw form, and calls to the carrier voicemail number are labeled
+  with a localized **"Voicemail"** name in file names and the recordings list.
+- **No more false "Ready to record" while Developer options is off.** If Developer options is
+  disabled (e.g. after an OS update or manual toggle), the recorder daemon cannot survive and every
+  "recording" comes out empty — but the Home screen still showed green. It now shows a clear red
+  **"Developer options is off"** status explaining what to re-enable.
+- **Empty recordings are no longer saved as if they succeeded.** A 0-byte file (daemon died before
+  capture started) used to be cataloged, copied to Drive, and shown as an unplayable entry
+  ("Can't read this file"). It is now deleted and reported with an error notification instead.
+- **You are warned during the call if recording silently stops.** The app now watches the recorder
+  daemon while a recording is live and immediately notifies **"this call is NOT being recorded"**
+  if the daemon dies mid-call, instead of discovering the loss after hanging up.
+- **Post-reboot and startup notifications are now translated.** The "Ready to record calls /
+  Listening for calls after restart" notification (and the boot-time "Preparing call recorder…")
+  were hardcoded in English; they now follow the app language like everything else.
+
+### Internal
+- Cross-country detection is preserved for invalid/foreign numbers (the ignore-cross-country
+  auto-record rules keep working for them).
+- The unit-test harness (JUnit/Robolectric) now lives on `main`, with tests covering the number
+  enrichment, voicemail matching, file-name fallback, and Developer-options detection.
+
+## [1.2.1] — 2026-06-26
 
 A localization release: every shipped language is now fully translated, fixing screens that
 appeared in English even when the rest of the app was localized.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ After a one-time pairing, CallVault runs a **persistent privileged daemon** — 
 
 - **Android 11 or newer** (best on Android 12+; on Android 11 the screen must be unlocked during a call).
 - **Wireless Debugging** available in Developer Options.
+- **Developer options must stay enabled.** If you turn Developer options off later (or an OS update
+  resets it), the recorder can't run and calls come out empty — the Home screen will show a red
+  **"Developer options is off"** status until you re-enable it (Wireless debugging itself stays
+  automatic; you never toggle that manually).
 - No root, no PC, no Shizuku.
 
 > [!IMPORTANT]

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -184,6 +184,12 @@ android {
     androidResources {
         generateLocaleConfig = true
     }
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
     lint {
         // Fail the build if any shipped locale is missing a translatable string, or has a
         // stale key that no longer exists in the default resources. This prevents the
@@ -289,4 +295,10 @@ dependencies {
     // pairing falls back to the platform Conscrypt and fails on Android 14+/OEM builds with
     // NoSuchMethodException: com.android.org.conscrypt.Conscrypt.exportKeyingMaterial.
     implementation("org.conscrypt:conscrypt-android:2.5.2")
+
+    // Test harness
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("org.robolectric:robolectric:4.14")
+    testImplementation("androidx.test:core:1.6.1")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,8 +113,8 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // (versionCode = the CI run number), but local builds and the in-app "About" version use these
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10201)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.2.1")
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10204)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.2.2")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/java/com/baba/callvault/data/recordings/RecordingMetadata.kt
+++ b/app/src/main/java/com/baba/callvault/data/recordings/RecordingMetadata.kt
@@ -78,6 +78,18 @@ data class RecordingMetadata(
                 )
             }
 
+            if (!phoneNumberManager.isValidNumber(parsedNumber)) {
+                // Short codes (e.g. the FR "123" voicemail number) parse but are not valid subscriber
+                // numbers; E.164-ifying them ("+33123") breaks contact lookup and display, so keep raw.
+                // Cross-country is still computed: an invalid number can carry a foreign country code,
+                // and hardcoding false here would bypass the ignore-cross-country recording rules.
+                AppLogger.i(TAG, "Number '$raw' is not a valid subscriber number (likely a short code); keeping raw form.")
+                return@withContext base.copy(
+                    isEnriched = true,
+                    isCrossCountry = phoneNumberManager.isNumberFromDifferentCountry(parsedNumber)
+                )
+            }
+
             val standardized = phoneNumberManager.formatToE164(parsedNumber)
             val crossCountry = phoneNumberManager.isNumberFromDifferentCountry(parsedNumber)
             AppLogger.i(TAG, "Enriched metadata for number: raw='$raw', standardized='$standardized', crossCountry=$crossCountry")

--- a/app/src/main/java/com/baba/callvault/data/recordings/RecordingsRepository.kt
+++ b/app/src/main/java/com/baba/callvault/data/recordings/RecordingsRepository.kt
@@ -18,6 +18,7 @@ import com.baba.callvault.data.StorageTarget
 import com.baba.callvault.data.recordings.db.RecordingEntry
 import com.baba.callvault.system.permissions.PermissionChecks
 import com.baba.callvault.utils.AppLogger
+import com.baba.callvault.utils.VoicemailLabel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
@@ -128,18 +129,22 @@ object RecordingsRepository {
 
             val items = RecordingCatalog.all(context).mapNotNull { toItem(it) }
 
-            // Resolve contact names from the parsed numbers (only when READ_CONTACTS is granted),
-            // caching by number within this call to avoid duplicate PhoneLookup queries.
-            if (!PermissionChecks.hasContactsPermission(context)) items
-            else {
-                val nameCache = HashMap<String, String?>()
-                items.map { item ->
-                    val number = item.number
-                    if (number.isNullOrBlank()) item
-                    else {
-                        val name = nameCache.getOrPut(number) { lookupContactName(context, number) }
-                        if (name == null) item else item.copy(contactName = name)
+            // Resolve contact names from the parsed numbers (PhoneLookup only when READ_CONTACTS is
+            // granted), caching by number within this call to avoid duplicate queries. Voicemail is
+            // not a real contact, so it gets its label as a fallback after the lookup misses.
+            // "No name" is cached as "" — getOrPut re-runs the lambda for stored nulls.
+            val hasContactsPermission = PermissionChecks.hasContactsPermission(context)
+            val nameCache = HashMap<String, String>()
+            items.map { item ->
+                val number = item.number
+                if (number.isNullOrBlank()) item
+                else {
+                    val name = nameCache.getOrPut(number) {
+                        (if (hasContactsPermission) lookupContactName(context, number) else null)
+                            ?: VoicemailLabel.labelOrNull(context, number)
+                            ?: ""
                     }
+                    if (name.isEmpty()) item else item.copy(contactName = name)
                 }
             }
         }.getOrElse { e ->

--- a/app/src/main/java/com/baba/callvault/integrations/adb/DeveloperOptions.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/DeveloperOptions.kt
@@ -1,0 +1,48 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.integrations.adb
+
+import android.content.Context
+import android.provider.Settings
+
+/**
+ * Reads the system Developer options master toggle.
+ *
+ * Developer options is the hard prerequisite for the whole recording stack: with it OFF, Wireless
+ * debugging cannot function and the privileged recorder daemon dies as soon as the app's WD policy
+ * turns Wireless debugging off — every "recording" then produces an empty file (observed on
+ * OnePlus/Android 16: the daemon binder dies within ~200ms of WD-off after each post-boot launch).
+ * Status surfaces must therefore treat "Developer options off" as a broken, not-ready state.
+ */
+object DeveloperOptions {
+
+    /**
+     * True when the Developer options master toggle is enabled. Wrapped in [runCatching]
+     * (defaults to false) because the global setting may be absent on some ROMs.
+     */
+    fun isEnabled(context: Context): Boolean = runCatching {
+        Settings.Global.getInt(
+            context.contentResolver,
+            Settings.Global.DEVELOPMENT_SETTINGS_ENABLED,
+            0
+        ) == 1
+    }.getOrDefault(false)
+
+    /**
+     * True only when the setting is POSITIVELY readable as disabled ("0"). Distinct from
+     * `!isEnabled()`: an absent or unreadable setting returns false here, so hard error states
+     * (like the Home status card) never go red on a ROM that simply doesn't expose the global.
+     */
+    fun isExplicitlyDisabled(context: Context): Boolean = runCatching {
+        Settings.Global.getString(
+            context.contentResolver,
+            Settings.Global.DEVELOPMENT_SETTINGS_ENABLED
+        )?.trim()?.toIntOrNull()
+    }.getOrNull() == 0
+}

--- a/app/src/main/java/com/baba/callvault/services/boot/AdbConnectionService.kt
+++ b/app/src/main/java/com/baba/callvault/services/boot/AdbConnectionService.kt
@@ -20,6 +20,7 @@ import android.os.IBinder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import com.baba.callvault.R
 import com.baba.callvault.server.RecorderServerLauncher
 import com.baba.callvault.utils.AppLogger
 
@@ -37,7 +38,7 @@ class AdbConnectionService : Service() {
         getSystemService(NotificationManager::class.java).createNotificationChannel(
             NotificationChannel(
                 CHANNEL_ID,
-                "Startup",
+                getString(R.string.notif_startup_channel),
                 NotificationManager.IMPORTANCE_MIN,
             ).apply {
                 setSound(null, null)
@@ -50,13 +51,13 @@ class AdbConnectionService : Service() {
         runCatching {
             startForeground(
                 NOTIF_ID,
-                buildNotification("Preparing call recorder…"),
+                buildNotification(getString(R.string.notif_startup_preparing)),
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
             )
         }.onFailure {
             AppLogger.e(TAG, "startForeground failed", it)
             getSystemService(NotificationManager::class.java)
-                .notify(NOTIF_ID, buildNotification("Preparing call recorder…"))
+                .notify(NOTIF_ID, buildNotification(getString(R.string.notif_startup_preparing)))
         }
 
         CoroutineScope(Dispatchers.IO).launch {

--- a/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
@@ -23,6 +23,7 @@ import android.telephony.PhoneStateListener
 import android.telephony.TelephonyCallback
 import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
+import com.baba.callvault.R
 import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.utils.AppLogger
 
@@ -92,7 +93,7 @@ class CallMonitorService : Service() {
     override fun onCreate() {
         super.onCreate()
         getSystemService(NotificationManager::class.java).createNotificationChannel(
-            NotificationChannel(CHANNEL_ID, "Call monitor", NotificationManager.IMPORTANCE_MIN).apply {
+            NotificationChannel(CHANNEL_ID, getString(R.string.notif_call_monitor_channel), NotificationManager.IMPORTANCE_MIN).apply {
                 setSound(null, null)
                 setShowBadge(false)
             },
@@ -219,10 +220,17 @@ class CallMonitorService : Service() {
     private fun buildNotification(ready: Boolean): Notification =
         Notification.Builder(this, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.stat_notify_sync)
-            .setContentTitle(if (ready) "Ready to record calls" else "Call recorder starting up…")
+            .setContentTitle(
+                getString(
+                    if (ready) R.string.notif_readiness_ready_title
+                    else R.string.notif_readiness_starting_title,
+                ),
+            )
             .setContentText(
-                if (ready) "Listening for calls after restart."
-                else "Connecting the recorder — calls won't record until this finishes.",
+                getString(
+                    if (ready) R.string.notif_readiness_reboot_ready_text
+                    else R.string.notif_readiness_starting_text,
+                ),
             )
             .setOnlyAlertOnce(true)
             .build()

--- a/app/src/main/java/com/baba/callvault/services/recording/AudioRecordingEngine.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/AudioRecordingEngine.kt
@@ -11,6 +11,8 @@ package com.baba.callvault.services.recording
 import android.app.Service
 import android.content.Context
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.os.ParcelFileDescriptor
 import androidx.documentfile.provider.DocumentFile
 import com.baba.callvault.R
@@ -48,6 +50,9 @@ class AudioRecordingEngine {
 
     companion object {
         private const val TAG = "CV:AudioRecordingEngine"
+
+        /** How often the daemon-mode liveness watch re-checks that the daemon's binder is alive. */
+        private const val DAEMON_LIVENESS_POLL_MS = 2000L
     }
 
     /**
@@ -126,6 +131,33 @@ class AudioRecordingEngine {
     @Volatile
     var daemonRecording: Boolean = false
         private set
+
+    /**
+     * Fired at most once per session when the liveness watch finds the daemon's binder dead while a
+     * daemon-mode recording is supposed to be live (observed when Developer options is off: the
+     * daemon dies within ~200ms of Wireless debugging being turned off, so `startRecording` is
+     * dispatched into a corpse and the output file stays empty). Set by the owning service BEFORE
+     * [startPipeline] to surface an honest "this call is NOT being recorded" failure.
+     */
+    var onDaemonLostDuringRecording: (() -> Unit)? = null
+
+    private val livenessHandler = Handler(Looper.getMainLooper())
+    private val livenessWatch = object : Runnable {
+        override fun run() {
+            if (!daemonRecording) return
+            // pingBinder() probes the daemon process directly, so a dead daemon is detected even if
+            // the provider's linkToDeath failed and RecorderConnection.isConnected never cleared.
+            val alive = runCatching {
+                RecorderConnection.service?.asBinder()?.pingBinder() == true
+            }.getOrDefault(false)
+            if (!alive) {
+                AppLogger.e(TAG, "Recorder daemon binder died while a recording is live — no audio is being captured")
+                onDaemonLostDuringRecording?.invoke()
+                return // One-shot: the daemon-mode pipeline cannot recover mid-call.
+            }
+            livenessHandler.postDelayed(this, DAEMON_LIVENESS_POLL_MS)
+        }
+    }
 
     /**
      * Whether the recording is currently paused by the user.
@@ -296,6 +328,9 @@ class AudioRecordingEngine {
             service.startRecording(audioSourceEnum.cliKey, codecEnum.cliKey, bitRate, outputPfd)
             daemonRecording = true
             AppLogger.i(TAG, "Daemon startRecording dispatched; daemon now owns scrcpy + muxing")
+            // A successful dispatch only proves the binder was alive at that instant — watch it so a
+            // daemon that dies moments later surfaces as a failure instead of a silent empty file.
+            livenessHandler.postDelayed(livenessWatch, DAEMON_LIVENESS_POLL_MS)
             true
         } catch (e: Exception) {
             AppLogger.w(TAG, "Daemon startRecording failed; will fall back to local path: ${e.message}", e)
@@ -322,6 +357,7 @@ class AudioRecordingEngine {
      */
     fun release() {
         AppLogger.i(TAG, "Releasing session resources and recording pipeline...")
+        livenessHandler.removeCallbacks(livenessWatch)
 
         if (daemonMode) {
             // Ask the daemon to stop + finalise the container, then close our local fd handle. The local

--- a/app/src/main/java/com/baba/callvault/services/recording/RecordingForegroundService.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/RecordingForegroundService.kt
@@ -117,6 +117,14 @@ class RecordingForegroundService : Service() {
     @Volatile
     private var stopRequested: Boolean = false
 
+    /**
+     * True once the mid-call daemon-death warning has been shown for the current session. The
+     * end-of-call empty-file check consults this so the same failure doesn't raise a second error
+     * notification that overwrites the first (both share the error notification ID).
+     */
+    @Volatile
+    private var daemonLossNotified: Boolean = false
+
     /** True while a recording session object is present (initializing, active, or pending teardown). */
     private val hasSession: Boolean
         get() = currentState is RecordingServiceState.Active
@@ -289,6 +297,13 @@ class RecordingForegroundService : Service() {
 
         // 1. Create a new session (declared here to allow cleanup if startPipeline fails)
         val activeSession = AudioRecordingEngine()
+        daemonLossNotified = false
+        // Surface a mid-call daemon death immediately — the pipeline "started successfully" only
+        // proves the dispatch worked, and a daemon that dies right after leaves an empty file.
+        activeSession.onDaemonLostDuringRecording = {
+            daemonLossNotified = true
+            notificationHelper.showErrorNotification(getString(R.string.recording_error_daemon_died))
+        }
 
         try {
             // 2. Try to start the pipeline. Pass our stop flag so the (slow, daemon-cold-start) start
@@ -448,6 +463,21 @@ class RecordingForegroundService : Service() {
         val name = doc.name ?: return
         val sizeBytes = doc.length()
         val lastModified = doc.lastModified()
+        // An empty file means capture never actually ran (typically: the daemon died right after
+        // startRecording was dispatched — seen when Developer options is off and Wireless debugging
+        // teardown kills the daemon). Surface an honest failure instead of cataloging an unplayable
+        // entry and copying zero bytes to Drive.
+        if (sizeBytes <= 0L) {
+            AppLogger.e(TAG, "Recording '$name' is empty (0 bytes) — capture never ran. Deleting it and notifying instead of cataloging.")
+            // The mid-call daemon-death warning is the more actionable message and shares the same
+            // notification ID — don't overwrite it (and double-vibrate) with the empty-file variant.
+            if (!daemonLossNotified) {
+                notificationHelper.showErrorNotification(getString(R.string.recording_error_empty_file))
+            }
+            runCatching { doc.delete() }
+                .onFailure { AppLogger.w(TAG, "Failed to delete empty recording '$name': ${it.message}") }
+            return
+        }
         // Record this finished recording in CallVault's own catalog (the Home list's source of truth).
         // The file is on the device now, so this is the local copy; the copy/sweep workers later stamp
         // the Drive copy onto this same row by name. Done on a detached IO scope because the service may

--- a/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
@@ -239,11 +239,13 @@ private fun HeroStatusCard(status: HomeViewModel.HomeStatus) {
         HomeViewModel.HomeStatus.READY -> CvTone.Success
         HomeViewModel.HomeStatus.NOT_PAIRED -> CvTone.Warning
         HomeViewModel.HomeStatus.NO_FOLDER -> CvTone.Error
+        HomeViewModel.HomeStatus.DEV_OPTIONS_OFF -> CvTone.Error
     }
     val pillText = when (status) {
         HomeViewModel.HomeStatus.READY -> stringResource(R.string.home_hero_pill_ready)
         HomeViewModel.HomeStatus.NOT_PAIRED -> stringResource(R.string.home_hero_pill_not_paired)
         HomeViewModel.HomeStatus.NO_FOLDER -> stringResource(R.string.home_hero_pill_no_folder)
+        HomeViewModel.HomeStatus.DEV_OPTIONS_OFF -> stringResource(R.string.home_hero_pill_dev_options_off)
     }
 
     // Subtle accent-tinted surface so the banner reads as a confident state, not a stock card.

--- a/app/src/main/java/com/baba/callvault/ui/screens/PermissionsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/PermissionsScreen.kt
@@ -65,6 +65,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.baba.callvault.R
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.integrations.adb.AdbShell
+import com.baba.callvault.integrations.adb.DeveloperOptions
 import com.baba.callvault.onboarding.OnboardingStatus
 import com.baba.callvault.system.openAppSettings
 import com.baba.callvault.system.openDeveloperSettings
@@ -356,18 +357,9 @@ fun PermissionsContent(
     }
 }
 
-/**
- * Reads whether Developer Options is currently enabled on this device.
- * Wrapped in [runCatching] (defaults to false) because the global setting may be absent on some ROMs.
- */
+/** Reads whether Developer Options is currently enabled. Delegates to the shared [DeveloperOptions]. */
 private fun isDeveloperOptionsEnabled(context: android.content.Context): Boolean =
-    runCatching {
-        Settings.Global.getInt(
-            context.contentResolver,
-            Settings.Global.DEVELOPMENT_SETTINGS_ENABLED,
-            0
-        ) == 1
-    }.getOrDefault(false)
+    DeveloperOptions.isEnabled(context)
 
 /**
  * The dedicated, full-width ADB hero card.

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
@@ -19,6 +19,7 @@ import com.baba.callvault.data.recordings.RecordingDirection
 import com.baba.callvault.data.recordings.RecordingsRepository
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingItem
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingSource
+import com.baba.callvault.integrations.adb.DeveloperOptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -62,6 +63,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     ) {
         NO_FOLDER(R.string.home_status_no_folder_title, R.string.home_status_no_folder_suggestion),
         NOT_PAIRED(R.string.home_status_not_paired_title, R.string.home_status_not_paired_suggestion),
+        DEV_OPTIONS_OFF(R.string.home_status_dev_options_off_title, R.string.home_status_dev_options_off_suggestion),
         READY(R.string.home_status_ready_title, R.string.home_status_ready_suggestion, isReady = true)
     }
 
@@ -216,9 +218,12 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
     /**
      * Derives the current [HomeStatus]. First match wins:
-     *  1. NO_FOLDER   — no device recording folder configured.
-     *  2. NOT_PAIRED  — Wireless Debugging pairing was never completed in setup.
-     *  3. READY       — everything looks good.
+     *  1. NO_FOLDER        — no device recording folder configured.
+     *  2. NOT_PAIRED       — Wireless Debugging pairing was never completed in setup.
+     *  3. DEV_OPTIONS_OFF  — the Developer options master toggle is disabled, so Wireless debugging
+     *                        (and with it the recorder daemon) cannot function; recordings come out
+     *                        empty while everything else still "looks" configured.
+     *  4. READY            — everything looks good.
      *
      * By design, Wireless Debugging (ADB) is INTENTIONALLY transient: it is turned off between
      * calls and recording flows over the privileged daemon's binder, not over ADB. So a live
@@ -226,11 +231,15 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
      * checked here. Likewise the daemon launches on demand, so an idle binder is fine and never
      * turns the card red.
      *
-     * All checks are synchronous reads of [AppPreferences]; none launch the daemon or do I/O.
+     * All checks are synchronous, cheap reads (AppPreferences + one Settings.Global int); none
+     * launch the daemon or do I/O.
      */
     private fun computeStatus(): HomeStatus {
         if (preferences.getRecordingFolderUri() == null) return HomeStatus.NO_FOLDER
         if (!preferences.isAdbPaired()) return HomeStatus.NOT_PAIRED
+        // isExplicitlyDisabled (not !isEnabled): an absent/unreadable global must not paint a
+        // permanent red banner on ROMs that don't expose the setting.
+        if (DeveloperOptions.isExplicitlyDisabled(appContext)) return HomeStatus.DEV_OPTIONS_OFF
         return HomeStatus.READY
     }
 

--- a/app/src/main/java/com/baba/callvault/utils/PhoneNumberManager.kt
+++ b/app/src/main/java/com/baba/callvault/utils/PhoneNumberManager.kt
@@ -129,6 +129,17 @@ class PhoneNumberManager private constructor(context: Context) {
     }
 
     /**
+     * Checks whether the parsed number is a valid, fully-dialable subscriber number for its region.
+     * Short codes and carrier service numbers (e.g. the FR "123" voicemail code) are NOT valid here,
+     * even though they parse successfully.
+     * @param phoneNumber The structured phone number object to validate.
+     * @return True only for numbers that match a real numbering plan.
+     */
+    suspend fun isValidNumber(phoneNumber: Phonenumber.PhoneNumber): Boolean = withContext(Dispatchers.Default) {
+        return@withContext phoneUtil.isValidNumber(phoneNumber)
+    }
+
+    /**
      * Extracts the region code (ISO country code) from a phone number.
      * @param phoneNumber The phone number to check.
      * @return The region code (e.g., "FR", "US").

--- a/app/src/main/java/com/baba/callvault/utils/RecordingFileNameFormatter.kt
+++ b/app/src/main/java/com/baba/callvault/utils/RecordingFileNameFormatter.kt
@@ -72,7 +72,10 @@ object RecordingFileNameFormatter {
         var contactStr = ""
 
         if (template.contains(FileNamePlaceholder.CONTACT_NAME.tag) && phoneStr.isNotEmpty()) {
-            contactStr = getContactName(context, phoneStr) ?: ""
+            // Voicemail is not a real contact — PhoneLookup misses it, so fall back to its label.
+            contactStr = getContactName(context, phoneStr)
+                ?: VoicemailLabel.labelOrNull(context, phoneStr)
+                ?: ""
         }
 
         val crossCountryStr = metadata.isCrossCountry.toString()

--- a/app/src/main/java/com/baba/callvault/utils/VoicemailLabel.kt
+++ b/app/src/main/java/com/baba/callvault/utils/VoicemailLabel.kt
@@ -1,0 +1,71 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.utils
+
+import android.content.Context
+import android.telephony.PhoneNumberUtils
+import android.telephony.TelephonyManager
+import com.baba.callvault.R
+import com.baba.callvault.system.permissions.PermissionChecks
+
+/**
+ * Detects the carrier voicemail number so it can be labeled like a contact.
+ *
+ * Voicemail is usually NOT a real contact: stock dialers display "Voicemail" by comparing against
+ * [TelephonyManager.getVoiceMailNumber], not via a ContactsContract lookup. Contact resolution
+ * therefore comes up empty for calls to voicemail (e.g. the FR short code "123") unless callers
+ * fall back to this helper.
+ */
+object VoicemailLabel {
+    /**
+     * Device voicemail number memoized after the first successful fetch:
+     * [TelephonyManager.getVoiceMailNumber] is a cross-process binder call and the value is
+     * effectively constant for the process lifetime (a SIM swap resets it only after restart).
+     * Failed fetches (permission denied, telephony not ready) are NOT memoized, so the lookup
+     * retries once conditions improve.
+     */
+    @Volatile
+    private var cachedVoicemailNumber: String? = null
+
+    /**
+     * True when [number] is the device's voicemail number. Compares against
+     * [TelephonyManager.getVoiceMailNumber] and falls back to [PhoneNumberUtils.isVoiceMailNumber].
+     * Both telephony calls require READ_PHONE_STATE, so without that permission this is always
+     * false. Never throws; returns false on a blank number or any failure.
+     */
+    fun isVoicemailNumber(context: Context, number: String?): Boolean {
+        if (number.isNullOrBlank()) return false
+        if (!PermissionChecks.hasPhoneStatePermission(context)) return false
+        val trimmed = number.trim()
+
+        val deviceVoicemail = cachedVoicemailNumber ?: runCatching {
+            val telephonyManager =
+                context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+            telephonyManager.voiceMailNumber
+        }.getOrNull()?.also { fetched ->
+            if (fetched.isNotBlank()) cachedVoicemailNumber = fetched
+        }
+        if (!deviceVoicemail.isNullOrBlank() && PhoneNumberUtils.compare(context, trimmed, deviceVoicemail)) {
+            return true
+        }
+
+        return runCatching { PhoneNumberUtils.isVoiceMailNumber(trimmed) }.getOrDefault(false)
+    }
+
+    /**
+     * The localized "Voicemail" display label when [number] is the voicemail number, else null.
+     * Meant as a fallback after a contact lookup returns no match.
+     */
+    fun labelOrNull(context: Context, number: String?): String? =
+        if (isVoicemailNumber(context, number)) {
+            context.getString(R.string.voicemail_contact_label)
+        } else {
+            null
+        }
+}

--- a/app/src/main/java/com/baba/callvault/utils/VoicemailLabel.kt
+++ b/app/src/main/java/com/baba/callvault/utils/VoicemailLabel.kt
@@ -8,6 +8,7 @@
 
 package com.baba.callvault.utils
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.telephony.PhoneNumberUtils
 import android.telephony.TelephonyManager
@@ -39,6 +40,9 @@ object VoicemailLabel {
      * Both telephony calls require READ_PHONE_STATE, so without that permission this is always
      * false. Never throws; returns false on a blank number or any failure.
      */
+    // Permission is verified via PermissionChecks.hasPhoneStatePermission() below (and the calls are
+    // wrapped in runCatching); lint can't trace into the helper, so the check is suppressed here.
+    @SuppressLint("MissingPermission")
     fun isVoicemailNumber(context: Context, number: String?): Boolean {
         if (number.isNullOrBlank()) return false
         if (!PermissionChecks.hasPhoneStatePermission(context)) return false

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -216,4 +216,9 @@
     <string name="wizard_storage_subtitle">Wählen Sie, wo Ihre Aufnahmen gespeichert werden. Sie können dies später in den Einstellungen ändern.</string>
     <string name="wizard_storage_title">Speicherort für Aufnahmen</string>
     <string name="wizard_title">CallVault einrichten</string>
+    <string name="voicemail_contact_label">Mailbox</string>
+    <string name="home_status_dev_options_off_title">Entwickleroptionen sind deaktiviert</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault nimmt über das drahtlose Debugging auf, das die Entwickleroptionen benötigt. Die Aufnahme funktioniert erst wieder, wenn Sie die Entwickleroptionen (und das drahtlose Debugging) in den Systemeinstellungen aktivieren.</string>
+    <string name="recording_error_empty_file">Die Aufnahme ist leer — es wurde kein Audio aufgezeichnet, da der Aufnahme-Daemon nicht lief. Prüfen Sie, ob die Entwickleroptionen und das drahtlose Debugging aktiviert sind.</string>
+    <string name="recording_error_daemon_died">Der Aufnahme-Daemon wurde beendet — dieser Anruf wird NICHT aufgezeichnet. Prüfen Sie, ob die Entwickleroptionen und das drahtlose Debugging aktiviert sind.</string>
 </resources>

--- a/app/src/main/res/values-de/strings_home.xml
+++ b/app/src/main/res/values-de/strings_home.xml
@@ -9,4 +9,5 @@
     <string name="home_recordings_count">%1$d gespeichert</string>
     <string name="home_recordings_empty_hint">Wenn CallVault einen Anruf aufzeichnet, erscheint er hier. Tätigen oder nehmen Sie einen Anruf an, um zu beginnen.</string>
     <string name="home_recordings_empty_title">Noch keine Aufnahmen</string>
+    <string name="home_hero_pill_dev_options_off">Aufnahme nicht möglich</string>
 </resources>

--- a/app/src/main/res/values-de/strings_notifications.xml
+++ b/app/src/main/res/values-de/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">Stopp</string>
     <string name="notif_pairing_action_enter_code">Kopplungscode eingeben</string>
     <string name="notif_pairing_remote_input_label">Kopplungscode</string>
+    <string name="notif_call_monitor_channel">Anrufüberwachung</string>
+    <string name="notif_readiness_reboot_ready_text">Wartet nach dem Neustart auf Anrufe.</string>
+    <string name="notif_startup_channel">Start</string>
+    <string name="notif_startup_preparing">Anrufaufzeichnung wird vorbereitet…</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -216,4 +216,9 @@
     <string name="wizard_storage_subtitle">Elija dónde se almacenan sus grabaciones. Puede cambiar esto más tarde en Ajustes.</string>
     <string name="wizard_storage_title">Dónde guardar las grabaciones</string>
     <string name="wizard_title">Configurar CallVault</string>
+    <string name="voicemail_contact_label">Buzón de voz</string>
+    <string name="home_status_dev_options_off_title">Las opciones de desarrollador están desactivadas</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault graba a través de la depuración inalámbrica, que necesita las opciones de desarrollador. La grabación no funcionará hasta que reactives las opciones de desarrollador (y la depuración inalámbrica) en los ajustes del sistema.</string>
+    <string name="recording_error_empty_file">La grabación está vacía: no se capturó audio porque el daemon de grabación no estaba en ejecución. Comprueba que las opciones de desarrollador y la depuración inalámbrica estén activadas.</string>
+    <string name="recording_error_daemon_died">El daemon de grabación se detuvo: esta llamada NO se está grabando. Comprueba que las opciones de desarrollador y la depuración inalámbrica estén activadas.</string>
 </resources>

--- a/app/src/main/res/values-es/strings_home.xml
+++ b/app/src/main/res/values-es/strings_home.xml
@@ -9,4 +9,5 @@
     <string name="home_recordings_count">%1$d guardadas</string>
     <string name="home_recordings_empty_hint">Cuando CallVault grabe una llamada, aparecerá aquí. Haga o reciba una llamada para empezar.</string>
     <string name="home_recordings_empty_title">Aún no hay grabaciones</string>
+    <string name="home_hero_pill_dev_options_off">Grabación no disponible</string>
 </resources>

--- a/app/src/main/res/values-es/strings_notifications.xml
+++ b/app/src/main/res/values-es/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">Detener</string>
     <string name="notif_pairing_action_enter_code">Introducir código de vinculación</string>
     <string name="notif_pairing_remote_input_label">Código de vinculación</string>
+    <string name="notif_call_monitor_channel">Supervisión de llamadas</string>
+    <string name="notif_readiness_reboot_ready_text">Escuchando llamadas tras el reinicio.</string>
+    <string name="notif_startup_channel">Inicio</string>
+    <string name="notif_startup_preparing">Preparando la grabadora de llamadas…</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -25,6 +25,7 @@
     <string name="disclaimer_wait">Attendez %1$ds</string>
     <string name="general_cancel">Annuler</string>
     <string name="general_close">Fermer</string>
+    <string name="voicemail_contact_label">Messagerie vocale</string>
     <string name="general_continue">Continuer</string>
     <string name="general_copied_to_clipboard">Copié dans le presse-papiers</string>
     <string name="general_incoming">Entrant</string>
@@ -56,6 +57,8 @@
     <string name="home_status_no_folder_title">Aucun dossier d\'enregistrement défini</string>
     <string name="home_status_not_paired_suggestion">Terminez l\'association du débogage sans fil lors de la configuration.</string>
     <string name="home_status_not_paired_title">Configuration incomplète</string>
+    <string name="home_status_dev_options_off_title">Options pour les développeurs désactivées</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault enregistre via le débogage sans fil, qui nécessite les options pour les développeurs. L\'enregistrement ne peut pas fonctionner tant que vous ne réactivez pas les options pour les développeurs (et le débogage sans fil) dans les paramètres du système.</string>
     <string name="home_status_ready_suggestion">CallVault enregistre les appels automatiquement selon vos paramètres.</string>
     <string name="home_status_ready_title">Prêt à enregistrer</string>
     <string name="permission_adb_description">Nécessaire pour capturer l\'audio des appels. Associez une fois via la notification, puis la connexion se fait automatiquement.</string>
@@ -87,6 +90,8 @@
     <string name="recording_error_folder_missing">Le dossier de sortie sélectionné est manquant, invalide ou nous n\'avons pas l\'autorisation d\'y écrire. Veuillez en sélectionner un dans les paramètres de l\'application.</string>
     <string name="recording_error_server_missing">Le fichier du serveur Scrcpy est manquant ou la vérification de sécurité SHA256 a échoué. Ceci ne devrait pas se produire, veuillez le signaler.</string>
     <string name="recording_error_start_failed">L\'enregistrement n\'a pas pu démarrer. Une erreur s\'est produite lors de l\'appel de ShellService binder method.</string>
+    <string name="recording_error_empty_file">L\'enregistrement est vide — aucun audio n\'a été capturé car le démon d\'enregistrement n\'était pas actif. Vérifiez que les options pour les développeurs et le débogage sans fil sont activés.</string>
+    <string name="recording_error_daemon_died">Le démon d\'enregistrement s\'est arrêté — cet appel n\'est PAS enregistré. Vérifiez que les options pour les développeurs et le débogage sans fil sont activés.</string>
     <string name="recording_error_title">Erreur d\'enregistrement</string>
     <string name="recording_notification_cross_country_tip">🌐International</string>
     <string name="recording_notification_current_country_tip">🏠Pays d\'origine</string>

--- a/app/src/main/res/values-fr/strings_home.xml
+++ b/app/src/main/res/values-fr/strings_home.xml
@@ -2,6 +2,7 @@
 <!-- Auto-completed translations. Do not hand-edit placeholders (%1$s etc.). -->
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="home_hero_pill_no_folder">Action requise</string>
+    <string name="home_hero_pill_dev_options_off">Enregistrement impossible</string>
     <string name="home_hero_pill_not_paired">Action requise</string>
     <string name="home_hero_pill_ready">Actif</string>
     <string name="home_hero_status_label">État</string>

--- a/app/src/main/res/values-fr/strings_notifications.xml
+++ b/app/src/main/res/values-fr/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">Arrêter</string>
     <string name="notif_pairing_action_enter_code">Saisir le code d\'association</string>
     <string name="notif_pairing_remote_input_label">Code d\'association</string>
+    <string name="notif_call_monitor_channel">Surveillance des appels</string>
+    <string name="notif_readiness_reboot_ready_text">En écoute des appels après le redémarrage.</string>
+    <string name="notif_startup_channel">Démarrage</string>
+    <string name="notif_startup_preparing">Préparation de l\'enregistreur d\'appels…</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -216,4 +216,9 @@
     <string name="wizard_storage_subtitle">Válassza ki, hová mentse a felvételeit. Ezt később a Beállításokban módosíthatja.</string>
     <string name="wizard_storage_title">Hová mentse a felvételeket</string>
     <string name="wizard_title">CallVault beállítása</string>
+    <string name="voicemail_contact_label">Hangposta</string>
+    <string name="home_status_dev_options_off_title">A fejlesztői beállítások ki vannak kapcsolva</string>
+    <string name="home_status_dev_options_off_suggestion">A CallVault a vezeték nélküli hibakeresésen keresztül rögzít, amelyhez a fejlesztői beállítások szükségesek. A rögzítés nem működik, amíg újra nem engedélyezi a fejlesztői beállításokat (és a vezeték nélküli hibakeresést) a rendszerbeállításokban.</string>
+    <string name="recording_error_empty_file">A felvétel üres — nem történt hangrögzítés, mert a rögzítő démon nem futott. Ellenőrizze, hogy a fejlesztői beállítások és a vezeték nélküli hibakeresés engedélyezve vannak-e.</string>
+    <string name="recording_error_daemon_died">A rögzítő démon leállt — ez a hívás NINCS rögzítve. Ellenőrizze, hogy a fejlesztői beállítások és a vezeték nélküli hibakeresés engedélyezve vannak-e.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_home.xml
+++ b/app/src/main/res/values-hu/strings_home.xml
@@ -9,4 +9,5 @@
     <string name="home_recordings_count">%1$d mentve</string>
     <string name="home_recordings_empty_hint">Amikor a CallVault rögzít egy hívást, az itt jelenik meg. Kezdje el egy hívás indításával vagy fogadásával.</string>
     <string name="home_recordings_empty_title">Még nincsenek felvételek</string>
+    <string name="home_hero_pill_dev_options_off">A rögzítés nem működik</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_notifications.xml
+++ b/app/src/main/res/values-hu/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">Leállítás</string>
     <string name="notif_pairing_action_enter_code">Párosítási kód megadása</string>
     <string name="notif_pairing_remote_input_label">Párosítási kód</string>
+    <string name="notif_call_monitor_channel">Hívásfigyelés</string>
+    <string name="notif_readiness_reboot_ready_text">Hívások figyelése újraindítás után.</string>
+    <string name="notif_startup_channel">Indítás</string>
+    <string name="notif_startup_preparing">Hívásrögzítő előkészítése…</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -216,4 +216,9 @@
     <string name="wizard_storage_subtitle">Scelga dove archiviare le registrazioni. Potrà modificarlo in seguito nelle Impostazioni.</string>
     <string name="wizard_storage_title">Dove salvare le registrazioni</string>
     <string name="wizard_title">Configura CallVault</string>
+    <string name="voicemail_contact_label">Segreteria telefonica</string>
+    <string name="home_status_dev_options_off_title">Opzioni sviluppatore disattivate</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault registra tramite il debug wireless, che richiede le opzioni sviluppatore. La registrazione non può funzionare finché non riattivi le opzioni sviluppatore (e il debug wireless) nelle impostazioni di sistema.</string>
+    <string name="recording_error_empty_file">La registrazione è vuota — nessun audio è stato acquisito perché il daemon di registrazione non era in esecuzione. Verifica che le opzioni sviluppatore e il debug wireless siano attivi.</string>
+    <string name="recording_error_daemon_died">Il daemon di registrazione si è arrestato — questa chiamata NON viene registrata. Verifica che le opzioni sviluppatore e il debug wireless siano attivi.</string>
 </resources>

--- a/app/src/main/res/values-it/strings_home.xml
+++ b/app/src/main/res/values-it/strings_home.xml
@@ -9,4 +9,5 @@
     <string name="home_recordings_count">%1$d salvate</string>
     <string name="home_recordings_empty_hint">Quando CallVault registra una chiamata, comparirà qui. Effettui o riceva una chiamata per iniziare.</string>
     <string name="home_recordings_empty_title">Ancora nessuna registrazione</string>
+    <string name="home_hero_pill_dev_options_off">Registrazione non disponibile</string>
 </resources>

--- a/app/src/main/res/values-it/strings_notifications.xml
+++ b/app/src/main/res/values-it/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">Interrompi</string>
     <string name="notif_pairing_action_enter_code">Inserisci codice di associazione</string>
     <string name="notif_pairing_remote_input_label">Codice di associazione</string>
+    <string name="notif_call_monitor_channel">Monitoraggio chiamate</string>
+    <string name="notif_readiness_reboot_ready_text">In ascolto delle chiamate dopo il riavvio.</string>
+    <string name="notif_startup_channel">Avvio</string>
+    <string name="notif_startup_preparing">Preparazione del registratore di chiamate…</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -216,4 +216,9 @@
     <string name="wizard_storage_subtitle">Wybierz, gdzie przechowywane są Twoje nagrania. Możesz to zmienić później w Ustawieniach.</string>
     <string name="wizard_storage_title">Gdzie zapisywać nagrania</string>
     <string name="wizard_title">Skonfiguruj CallVault</string>
+    <string name="voicemail_contact_label">Poczta głosowa</string>
+    <string name="home_status_dev_options_off_title">Opcje programistyczne są wyłączone</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault nagrywa przez debugowanie bezprzewodowe, które wymaga opcji programistycznych. Nagrywanie nie będzie działać, dopóki nie włączysz ponownie opcji programistycznych (i debugowania bezprzewodowego) w ustawieniach systemu.</string>
+    <string name="recording_error_empty_file">Nagranie jest puste — nie przechwycono dźwięku, ponieważ demon nagrywania nie był uruchomiony. Sprawdź, czy opcje programistyczne i debugowanie bezprzewodowe są włączone.</string>
+    <string name="recording_error_daemon_died">Demon nagrywania zatrzymał się — to połączenie NIE jest nagrywane. Sprawdź, czy opcje programistyczne i debugowanie bezprzewodowe są włączone.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_home.xml
+++ b/app/src/main/res/values-pl/strings_home.xml
@@ -9,4 +9,5 @@
     <string name="home_recordings_count">%1$d zapisanych</string>
     <string name="home_recordings_empty_hint">Gdy CallVault nagra rozmowę, pojawi się ona tutaj. Wykonaj lub odbierz połączenie, aby rozpocząć.</string>
     <string name="home_recordings_empty_title">Brak nagrań</string>
+    <string name="home_hero_pill_dev_options_off">Nagrywanie niemożliwe</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_notifications.xml
+++ b/app/src/main/res/values-pl/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">Zatrzymaj</string>
     <string name="notif_pairing_action_enter_code">Wprowadź kod parowania</string>
     <string name="notif_pairing_remote_input_label">Kod parowania</string>
+    <string name="notif_call_monitor_channel">Monitorowanie połączeń</string>
+    <string name="notif_readiness_reboot_ready_text">Nasłuchiwanie połączeń po ponownym uruchomieniu.</string>
+    <string name="notif_startup_channel">Uruchamianie</string>
+    <string name="notif_startup_preparing">Przygotowywanie rejestratora połączeń…</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -216,4 +216,9 @@
     <string name="wizard_storage_subtitle">Выберите, где будут храниться ваши записи. Это можно изменить позже в настройках.</string>
     <string name="wizard_storage_title">Куда сохранять записи</string>
     <string name="wizard_title">Настройка CallVault</string>
+    <string name="voicemail_contact_label">Голосовая почта</string>
+    <string name="home_status_dev_options_off_title">Параметры разработчика отключены</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault записывает через беспроводную отладку, для которой нужны параметры разработчика. Запись не будет работать, пока вы не включите параметры разработчика (и беспроводную отладку) в настройках системы.</string>
+    <string name="recording_error_empty_file">Запись пуста — звук не был захвачен, так как демон записи не был запущен. Убедитесь, что параметры разработчика и беспроводная отладка включены.</string>
+    <string name="recording_error_daemon_died">Демон записи остановился — этот вызов НЕ записывается. Убедитесь, что параметры разработчика и беспроводная отладка включены.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_home.xml
+++ b/app/src/main/res/values-ru/strings_home.xml
@@ -9,4 +9,5 @@
     <string name="home_recordings_count">%1$d сохранено</string>
     <string name="home_recordings_empty_hint">Когда CallVault запишет звонок, он появится здесь. Совершите или примите звонок, чтобы начать.</string>
     <string name="home_recordings_empty_title">Записей пока нет</string>
+    <string name="home_hero_pill_dev_options_off">Запись невозможна</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_notifications.xml
+++ b/app/src/main/res/values-ru/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">Остановить</string>
     <string name="notif_pairing_action_enter_code">Ввести код подключения</string>
     <string name="notif_pairing_remote_input_label">Код подключения</string>
+    <string name="notif_call_monitor_channel">Отслеживание вызовов</string>
+    <string name="notif_readiness_reboot_ready_text">Ожидание вызовов после перезагрузки.</string>
+    <string name="notif_startup_channel">Запуск</string>
+    <string name="notif_startup_preparing">Подготовка записи звонков…</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -216,4 +216,9 @@
     <string name="wizard_storage_subtitle">Chọn nơi lưu các bản ghi âm. Bạn có thể thay đổi sau trong Cài đặt.</string>
     <string name="wizard_storage_title">Nơi lưu bản ghi âm</string>
     <string name="wizard_title">Thiết lập CallVault</string>
+    <string name="voicemail_contact_label">Thư thoại</string>
+    <string name="home_status_dev_options_off_title">Tùy chọn nhà phát triển đang tắt</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault ghi âm qua gỡ lỗi không dây, tính năng này cần Tùy chọn nhà phát triển. Không thể ghi âm cho đến khi bạn bật lại Tùy chọn nhà phát triển (và Gỡ lỗi không dây) trong cài đặt hệ thống.</string>
+    <string name="recording_error_empty_file">Bản ghi trống — không có âm thanh nào được thu vì trình nền ghi âm không chạy. Hãy kiểm tra xem Tùy chọn nhà phát triển và Gỡ lỗi không dây đã được bật chưa.</string>
+    <string name="recording_error_daemon_died">Trình nền ghi âm đã dừng — cuộc gọi này KHÔNG được ghi âm. Hãy kiểm tra xem Tùy chọn nhà phát triển và Gỡ lỗi không dây đã được bật chưa.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_home.xml
+++ b/app/src/main/res/values-vi/strings_home.xml
@@ -9,4 +9,5 @@
     <string name="home_recordings_count">Đã lưu %1$d</string>
     <string name="home_recordings_empty_hint">Khi CallVault ghi âm một cuộc gọi, nó sẽ hiển thị ở đây. Hãy thực hiện hoặc nhận một cuộc gọi để bắt đầu.</string>
     <string name="home_recordings_empty_title">Chưa có bản ghi âm nào</string>
+    <string name="home_hero_pill_dev_options_off">Không thể ghi âm</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_notifications.xml
+++ b/app/src/main/res/values-vi/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">Dừng</string>
     <string name="notif_pairing_action_enter_code">Nhập mã ghép nối</string>
     <string name="notif_pairing_remote_input_label">Mã ghép nối</string>
+    <string name="notif_call_monitor_channel">Theo dõi cuộc gọi</string>
+    <string name="notif_readiness_reboot_ready_text">Đang chờ cuộc gọi sau khi khởi động lại.</string>
+    <string name="notif_startup_channel">Khởi động</string>
+    <string name="notif_startup_preparing">Đang chuẩn bị trình ghi âm cuộc gọi…</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -216,4 +216,9 @@
     <string name="wizard_storage_subtitle">选择录音的存储位置。你之后可以在设置中更改。</string>
     <string name="wizard_storage_title">录音保存位置</string>
     <string name="wizard_title">设置 CallVault</string>
+    <string name="voicemail_contact_label">语音信箱</string>
+    <string name="home_status_dev_options_off_title">开发者选项已关闭</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault 通过无线调试进行录音，需要开发者选项。在系统设置中重新启用开发者选项（和无线调试）之前，无法录音。</string>
+    <string name="recording_error_empty_file">录音为空 — 由于录音守护进程未运行，未捕获任何音频。请检查开发者选项和无线调试是否已启用。</string>
+    <string name="recording_error_daemon_died">录音守护进程已停止 — 此通话未被录音。请检查开发者选项和无线调试是否已启用。</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_home.xml
+++ b/app/src/main/res/values-zh-rCN/strings_home.xml
@@ -9,4 +9,5 @@
     <string name="home_recordings_count">已保存 %1$d 个</string>
     <string name="home_recordings_empty_hint">当 CallVault 录制通话后，会显示在这里。拨打或接听一通电话即可开始。</string>
     <string name="home_recordings_empty_title">暂无录音</string>
+    <string name="home_hero_pill_dev_options_off">无法录音</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_notifications.xml
+++ b/app/src/main/res/values-zh-rCN/strings_notifications.xml
@@ -21,4 +21,8 @@
     <string name="notif_pairing_action_stop">停止</string>
     <string name="notif_pairing_action_enter_code">输入配对码</string>
     <string name="notif_pairing_remote_input_label">配对码</string>
+    <string name="notif_call_monitor_channel">通话监听</string>
+    <string name="notif_readiness_reboot_ready_text">重启后正在监听来电。</string>
+    <string name="notif_startup_channel">启动</string>
+    <string name="notif_startup_preparing">正在准备通话录音…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <!-- ========================================== -->
     <string name="app_name" translatable="false">CallVault</string>
     <string name="general_close">Close</string>
+    <string name="voicemail_contact_label">Voicemail</string>
     <string name="general_recommended">Recommended</string>
     <string name="general_continue">Continue</string>
     <string name="general_ok">OK</string>
@@ -285,6 +286,8 @@
     <string name="recording_error_server_missing">Scrcpy-server binary is missing or the security SHA256 check failed. This should not happen, please report this.</string>
     <string name="recording_error_file_creation">Failed to create recording file. Please check the storage permissions and/or select a new recording folder in the app settings.</string>
     <string name="recording_error_start_failed">Failed to start the recording. An error occurred when calling the ShellService binder method.</string>
+    <string name="recording_error_empty_file">The recording is empty — no audio was captured because the recorder daemon was not running. Check that Developer options and Wireless debugging are enabled.</string>
+    <string name="recording_error_daemon_died">The recorder daemon stopped — this call is NOT being recorded. Check that Developer options and Wireless debugging are enabled.</string>
     <string name="recording_unexpected_error">An unexpected error occurred during recording. Please report this with the steps to reproduce and the apps logs.</string>
 
     <!-- Setup Wizard -->
@@ -334,6 +337,8 @@
     <string name="home_status_no_folder_suggestion">Open Settings to choose where recordings are saved.</string>
     <string name="home_status_not_paired_title">Setup not complete</string>
     <string name="home_status_not_paired_suggestion">Finish Wireless Debugging pairing in setup.</string>
+    <string name="home_status_dev_options_off_title">Developer options is off</string>
+    <string name="home_status_dev_options_off_suggestion">CallVault records through Wireless debugging, which needs Developer options. Recording cannot work until you re-enable Developer options (and Wireless debugging) in system settings.</string>
     <string name="home_status_ready_title">Ready to record</string>
     <string name="home_status_ready_suggestion">CallVault records calls automatically per your settings.</string>
 

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -11,6 +11,7 @@
     <string name="home_hero_pill_ready">Active</string>
     <string name="home_hero_pill_not_paired">Action needed</string>
     <string name="home_hero_pill_no_folder">Action needed</string>
+    <string name="home_hero_pill_dev_options_off">Recording broken</string>
 
     <!-- Recordings section -->
     <string name="home_recordings_count">%1$d saved</string>

--- a/app/src/main/res/values/strings_notifications.xml
+++ b/app/src/main/res/values/strings_notifications.xml
@@ -23,4 +23,8 @@
     <string name="notif_pairing_action_stop">Stop</string>
     <string name="notif_pairing_action_enter_code">Enter pairing code</string>
     <string name="notif_pairing_remote_input_label">Pairing code</string>
+    <string name="notif_call_monitor_channel">Call monitor</string>
+    <string name="notif_readiness_reboot_ready_text">Listening for calls after restart.</string>
+    <string name="notif_startup_channel">Startup</string>
+    <string name="notif_startup_preparing">Preparing call recorder…</string>
 </resources>

--- a/app/src/test/java/com/baba/callvault/data/RecordingMetadataEnrichmentTest.kt
+++ b/app/src/test/java/com/baba/callvault/data/RecordingMetadataEnrichmentTest.kt
@@ -1,0 +1,87 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.data
+
+import android.content.Context
+import android.telephony.TelephonyManager
+import androidx.test.core.app.ApplicationProvider
+import com.baba.callvault.data.recordings.RecordingDirection
+import com.baba.callvault.data.recordings.RecordingMetadata
+import com.baba.callvault.utils.PhoneNumberManager
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35]) // Robolectric 4.14 max; project targets SDK 36
+class RecordingMetadataEnrichmentTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun resetPhoneNumberManagerSingleton() {
+        // The singleton holds the previous test's application context; reset it so each test's
+        // TelephonyManager shadow (device country) is the one actually read.
+        PhoneNumberManager::class.java.getDeclaredField("INSTANCE").apply {
+            isAccessible = true
+            set(null, null)
+        }
+    }
+
+    private fun setDeviceCountry(iso: String) {
+        val telephonyManager =
+            context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+        shadowOf(telephonyManager).setNetworkCountryIso(iso)
+    }
+
+    @Test
+    fun short_code_is_not_standardized_and_keeps_raw_number() = runBlocking {
+        // "123" is a carrier voicemail short code in FR — must not become "+33123".
+        setDeviceCountry("fr")
+        val base = RecordingMetadata(rawPhoneNumber = "123", direction = RecordingDirection.OUTGOING)
+
+        val enriched = RecordingMetadata.enrichMetadata(context, base)
+
+        assertNull(enriched.standardizedNumber)
+        assertEquals("123", enriched.getBestNumber())
+        assertFalse(enriched.isCrossCountry)
+    }
+
+    @Test
+    fun valid_national_number_is_standardized_to_e164() = runBlocking {
+        setDeviceCountry("fr")
+        val base = RecordingMetadata(rawPhoneNumber = "0612345678", direction = RecordingDirection.OUTGOING)
+
+        val enriched = RecordingMetadata.enrichMetadata(context, base)
+
+        assertEquals("+33612345678", enriched.standardizedNumber)
+        assertEquals("+33612345678", enriched.getBestNumber())
+    }
+
+    @Test
+    fun invalid_foreign_number_still_counts_as_cross_country() = runBlocking {
+        // A parseable-but-invalid number with a foreign country code must keep its raw form AND
+        // stay cross-country, so the ignore-cross-country recording rules still apply to it.
+        setDeviceCountry("us")
+        val base = RecordingMetadata(rawPhoneNumber = "+33123", direction = RecordingDirection.OUTGOING)
+
+        val enriched = RecordingMetadata.enrichMetadata(context, base)
+
+        assertNull(enriched.standardizedNumber)
+        assertEquals("+33123", enriched.getBestNumber())
+        assertTrue(enriched.isCrossCountry)
+    }
+}

--- a/app/src/test/java/com/baba/callvault/integrations/adb/DeveloperOptionsTest.kt
+++ b/app/src/test/java/com/baba/callvault/integrations/adb/DeveloperOptionsTest.kt
@@ -1,0 +1,61 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.integrations.adb
+
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35]) // Robolectric 4.14 max; project targets SDK 36
+class DeveloperOptionsTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun disabled_when_setting_is_absent() {
+        assertFalse(DeveloperOptions.isEnabled(context))
+    }
+
+    @Test
+    fun disabled_when_setting_is_zero() {
+        Settings.Global.putInt(context.contentResolver, Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0)
+        assertFalse(DeveloperOptions.isEnabled(context))
+    }
+
+    @Test
+    fun enabled_when_setting_is_one() {
+        Settings.Global.putInt(context.contentResolver, Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 1)
+        assertTrue(DeveloperOptions.isEnabled(context))
+    }
+
+    @Test
+    fun absent_setting_is_not_explicitly_disabled() {
+        // An unreadable/absent global must NOT count as disabled — hard error states rely on this.
+        assertFalse(DeveloperOptions.isExplicitlyDisabled(context))
+    }
+
+    @Test
+    fun zero_setting_is_explicitly_disabled() {
+        // putString mirrors real framework storage (Settings.Global.putInt writes the string form).
+        Settings.Global.putString(context.contentResolver, Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, "0")
+        assertTrue(DeveloperOptions.isExplicitlyDisabled(context))
+    }
+
+    @Test
+    fun one_setting_is_not_explicitly_disabled() {
+        Settings.Global.putString(context.contentResolver, Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, "1")
+        assertFalse(DeveloperOptions.isExplicitlyDisabled(context))
+    }
+}

--- a/app/src/test/java/com/baba/callvault/utils/RecordingFileNameFormatterVoicemailTest.kt
+++ b/app/src/test/java/com/baba/callvault/utils/RecordingFileNameFormatterVoicemailTest.kt
@@ -1,0 +1,62 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.utils
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.telephony.TelephonyManager
+import androidx.test.core.app.ApplicationProvider
+import com.baba.callvault.data.recordings.RecordingDirection
+import com.baba.callvault.data.recordings.RecordingMetadata
+import com.baba.callvault.integrations.scrcpy.ScrcpyAudioCodec
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35]) // Robolectric 4.14 max; project targets SDK 36
+class RecordingFileNameFormatterVoicemailTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setDeviceVoicemailNumber() {
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .grantPermissions(Manifest.permission.READ_PHONE_STATE)
+        val telephonyManager =
+            context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+        shadowOf(telephonyManager).setVoiceMailNumber("123")
+    }
+
+    @Test
+    fun contact_name_placeholder_falls_back_to_voicemail_label() {
+        val metadata = RecordingMetadata(rawPhoneNumber = "123", direction = RecordingDirection.OUTGOING)
+
+        val fileName = RecordingFileNameFormatter.formatFileName(
+            context, metadata, ScrcpyAudioCodec.OPUS, customFormat = "{contact_name}"
+        )
+
+        assertEquals("Voicemail.ogg", fileName)
+    }
+
+    @Test
+    fun contact_name_placeholder_stays_empty_for_regular_unsaved_number() {
+        val metadata = RecordingMetadata(rawPhoneNumber = "0612345678", direction = RecordingDirection.OUTGOING)
+
+        val fileName = RecordingFileNameFormatter.formatFileName(
+            context, metadata, ScrcpyAudioCodec.OPUS, customFormat = "{contact_name}"
+        )
+
+        assertEquals(".ogg", fileName)
+    }
+}

--- a/app/src/test/java/com/baba/callvault/utils/VoicemailLabelTest.kt
+++ b/app/src/test/java/com/baba/callvault/utils/VoicemailLabelTest.kt
@@ -1,0 +1,62 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.utils
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.telephony.TelephonyManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35]) // Robolectric 4.14 max; project targets SDK 36
+class VoicemailLabelTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setUpTelephony() {
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .grantPermissions(Manifest.permission.READ_PHONE_STATE)
+        val telephonyManager =
+            context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+        shadowOf(telephonyManager).setVoiceMailNumber("123")
+    }
+
+    @Test
+    fun matches_device_voicemail_number() {
+        assertTrue(VoicemailLabel.isVoicemailNumber(context, "123"))
+    }
+
+    @Test
+    fun does_not_match_regular_number() {
+        assertFalse(VoicemailLabel.isVoicemailNumber(context, "0612345678"))
+    }
+
+    @Test
+    fun null_or_blank_is_never_voicemail() {
+        assertFalse(VoicemailLabel.isVoicemailNumber(context, null))
+        assertFalse(VoicemailLabel.isVoicemailNumber(context, " "))
+    }
+
+    @Test
+    fun without_phone_state_permission_is_never_voicemail() {
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .denyPermissions(Manifest.permission.READ_PHONE_STATE)
+
+        assertFalse(VoicemailLabel.isVoicemailNumber(context, "123"))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two field-reported bugs from the same user (OnePlus CPH2653, Android 16, v1.2.1, French locale):

**1. Voicemail calls lost their contact name.**
- Carrier voicemail short codes (FR `123`) were E.164-ified into `+33123`, breaking PhoneLookup; short codes now keep their raw form (validity-gated via libphonenumber), while cross-country detection is preserved for invalid foreign numbers so the ignore-cross-country auto-record rules keep working.
- Voicemail isn't a real contact — a new `VoicemailLabel` helper (memoized `TelephonyManager.getVoiceMailNumber`, READ_PHONE_STATE-gated) provides a localized "Voicemail" fallback in file names and the recordings list.

**2. "Ready to record" shown while Developer options was off; 0-byte recordings saved as success.**
Debug logs showed that with Developer options off, the daemon dies ~30–180 ms after Wireless debugging is disabled post-launch, so `startRecording` was dispatched into a dead binder and every call produced an empty file that was cataloged and copied to Drive.
- New red `DEV_OPTIONS_OFF` Home status (only when the setting is positively readable as `0`).
- 0-byte recordings are deleted + reported with an error notification instead of cataloged/routed.
- A liveness watch pings the daemon binder during a session and warns "this call is NOT being recorded" on mid-call daemon death.

**i18n:** the post-boot "Ready to record calls" and startup notifications were hardcoded English — now resourced; all new strings translated across the 9 shipped locales (lint `MissingTranslation` gate passes).

Also ports the JUnit/Robolectric test harness to main and bumps default version to 1.2.2 (10204).

## Test plan
- [x] Full unit test suite green (enrichment incl. cross-country regression, VoicemailLabel, file-name fallback, DeveloperOptions)
- [x] `lintDebug` green (MissingTranslation/ExtraTranslation enforced)
- [x] `1.2.2-test1/2` builds side-loaded and confirmed by the reporting user ("looks good")