### PR TITLE
fix: fall back to the phone number in filenames for unsaved contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.2.3] — 2026-07-19
+
+### Fixed
+- **Filenames no longer lose the caller for unsaved numbers.** With a file-name template using
+  `{contact_name}`, calls from numbers not saved in your contacts produced a name with an empty
+  contact segment — no way to tell who the recording was from. The placeholder now falls back to
+  the **phone number itself** when there is no saved contact (and it's not voicemail). If your
+  template already includes `{phone_number}`, the fallback stays empty so the number isn't
+  written twice.
+
 ## [1.2.2] — 2026-07-19
 
 A field-report fix release: voicemail calls get their proper name, and the app now tells the truth

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,8 +113,8 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // (versionCode = the CI run number), but local builds and the in-app "About" version use these
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10204)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.2.2")
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10206)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.2.3")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/java/com/baba/callvault/utils/RecordingFileNameFormatter.kt
+++ b/app/src/main/java/com/baba/callvault/utils/RecordingFileNameFormatter.kt
@@ -73,8 +73,12 @@ object RecordingFileNameFormatter {
 
         if (template.contains(FileNamePlaceholder.CONTACT_NAME.tag) && phoneStr.isNotEmpty()) {
             // Voicemail is not a real contact — PhoneLookup misses it, so fall back to its label.
+            // For numbers with no saved contact at all, fall back to the number itself so the
+            // filename still identifies the call — unless the template already carries the number
+            // via {phone_number}, in which case duplicating it would just add noise.
             contactStr = getContactName(context, phoneStr)
                 ?: VoicemailLabel.labelOrNull(context, phoneStr)
+                ?: phoneStr.takeUnless { template.contains(FileNamePlaceholder.PHONE_NUMBER.tag) }
                 ?: ""
         }
 

--- a/app/src/test/java/com/baba/callvault/utils/RecordingFileNameFormatterVoicemailTest.kt
+++ b/app/src/test/java/com/baba/callvault/utils/RecordingFileNameFormatterVoicemailTest.kt
@@ -50,13 +50,37 @@ class RecordingFileNameFormatterVoicemailTest {
     }
 
     @Test
-    fun contact_name_placeholder_stays_empty_for_regular_unsaved_number() {
+    fun contact_name_placeholder_falls_back_to_number_for_unsaved_number() {
+        // No saved contact and not voicemail: the filename must still identify the call.
         val metadata = RecordingMetadata(rawPhoneNumber = "0612345678", direction = RecordingDirection.OUTGOING)
 
         val fileName = RecordingFileNameFormatter.formatFileName(
             context, metadata, ScrcpyAudioCodec.OPUS, customFormat = "{contact_name}"
         )
 
-        assertEquals(".ogg", fileName)
+        assertEquals("0612345678.ogg", fileName)
+    }
+
+    @Test
+    fun number_fallback_is_skipped_when_template_already_has_the_number() {
+        // {phone_number} already carries the number — an unsaved contact must not duplicate it.
+        val metadata = RecordingMetadata(rawPhoneNumber = "0612345678", direction = RecordingDirection.OUTGOING)
+
+        val fileName = RecordingFileNameFormatter.formatFileName(
+            context, metadata, ScrcpyAudioCodec.OPUS, customFormat = "{phone_number}_{contact_name}"
+        )
+
+        assertEquals("0612345678_.ogg", fileName)
+    }
+
+    @Test
+    fun voicemail_label_still_wins_over_number_fallback() {
+        val metadata = RecordingMetadata(rawPhoneNumber = "123", direction = RecordingDirection.OUTGOING)
+
+        val fileName = RecordingFileNameFormatter.formatFileName(
+            context, metadata, ScrcpyAudioCodec.OPUS, customFormat = "{contact_name}"
+        )
+
+        assertEquals("Voicemail.ogg", fileName)
     }
 }


### PR DESCRIPTION
## Summary

Field feedback: with a file-name template like `{date}_{direction}_{contact_name}`, calls from numbers **not saved as contacts** produced filenames with an empty contact segment — the recording couldn't be identified.

The `{contact_name}` placeholder now resolves: saved contact name → localized voicemail label → **the phone number itself**. When the template already contains `{phone_number}`, the fallback stays empty to avoid duplicating the number. Applies both at recording start and in the end-of-call CallLog rename path (both use the same formatter).

## Test plan
- [x] TDD: 3 formatter tests (number fallback, no duplication with `{phone_number}`, voicemail label precedence) — RED confirmed before the fix
- [x] Full unit suite + `lintDebug` green
- [x] `1.2.3-test1` side-loaded and confirmed by the reporting user