### PR TITLE
v1.4.0 + v1.4.1 — off-Wi-Fi recording, direct capture, fast recovery, update self-heal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.4.0] — 2026-07-23
+
+The headline: **record calls even without Wi-Fi**, plus a much faster, more reliable recorder.
+
+### Added
+- **Offline recording (opt-in) — record with no Wi-Fi.** A new option (Settings → Debug → "Offline
+  recording") lets CallVault capture calls even when you're not on a Wi-Fi network — for the important
+  call you get on the road. It's **off by default** and shows a short security note when you turn it on,
+  because it opens a local debugging port on your own device. You can also enable it straight from the
+  "What's new" note after updating.
+- **The recorder stays warm and comes back fast.** CallVault now keeps its privileged recorder ready and
+  relaunches it within a few seconds when the system reclaims it — so a call after your phone has been
+  idle is captured almost immediately instead of after a long "starting up" wait.
+
+### Changed
+- **New audio-capture engine.** Calls are recorded through a direct on-device audio path instead of the
+  previous screen-mirroring helper. Capture begins from the first moment (no clipped beginnings), the
+  daemon boots faster, and the app has fewer moving parts. (Falls back to the old path automatically if a
+  device can't use the new one.)
+- **One clear "ready to record" notification** instead of the occasional duplicates.
+
+### Fixed
+- **No more Wireless-Debugging notification flapping** on and off while idle.
+- **Recovery after the system reclaims the recorder is now seconds, not up to a minute** — the old
+  behaviour left "starting up" showing long after recording was actually ready.
+
 ## [1.3.1] — 2026-07-22
 
 A reliability release for recordings saved to cloud folders (e.g. Google Drive), based on field reports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.4.1] — 2026-07-24
+
+A focused fix for a problem some people hit after updating to 1.4.0.
+
+### Fixed
+- **Recording no longer breaks after updating without a reinstall.** When CallVault was updated in place
+  (e.g. via Obtainium or a sideloaded APK), Android could quietly drop a permission the app needs to run
+  the recorder — leaving recording dead until a full clean reinstall. CallVault now heals this itself:
+  right after an update it reconnects over any still-open channel and restores the permission
+  automatically. If it can't (nothing to reconnect through), the Home screen shows a clear
+  **"Recording paused after update"** banner — tap it and turn Wireless debugging on once, and recording
+  restores itself. **No reinstall needed.**
+
 ## [1.4.0] — 2026-07-23
 
 The headline: **record calls even without Wi-Fi**, plus a much faster, more reliable recorder.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## What is CallVault?
 
-**CallVault** is a **non-root, FOSS call recorder for Android** that records **both sides** of a phone call. It drives a privileged shell session entirely **on-device** — no root, no [Shizuku](https://github.com/RikkaApps/Shizuku), no companion PC — using an embedded ADB client ([libadb-android](https://github.com/MuntashirAkon/libadb-android)) over Android's own **Wireless Debugging**, with [scrcpy-server](https://github.com/genymobile/scrcpy) as the audio-capture engine.
+**CallVault** is a **non-root, FOSS call recorder for Android** that records **both sides** of a phone call. It drives a privileged shell session entirely **on-device** — no root, no [Shizuku](https://github.com/RikkaApps/Shizuku), no companion PC — using an embedded ADB client ([libadb-android](https://github.com/MuntashirAkon/libadb-android)) over Android's own **Wireless Debugging**. Audio is captured through a direct on-device path, with [scrcpy-server](https://github.com/genymobile/scrcpy) as an automatic fallback.
 
 You pair **once**; after that it's hands-free.
 
@@ -30,6 +30,7 @@ You pair **once**; after that it's hands-free.
 | | Feature |
 |:---:|---|
 | 🎙️ | Records **both sides** of incoming & outgoing calls (incl. Bluetooth / headset) |
+| 📶 | **Offline recording (opt-in)** — record calls even with **no Wi-Fi network**, for calls on the road (off by default; opens a local, RSA-gated debugging port when enabled) |
 | 🤖 | **Automatic** recording with per-call rules — ignore anonymous, cross-country, or specific contacts |
 | ☁️ | Save to **device, a cloud folder, or both**, with optional **scheduled sync** (immediate / daily / weekly) |
 | 🧹 | **Retention / auto-delete** — remove recordings after a chosen age, separately for device & cloud, swept daily at a time you pick (your local time zone) |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,8 +113,8 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // (versionCode = the CI run number), but local builds and the in-app "About" version use these
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10403)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.3.1")
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10426)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.0")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,8 +113,8 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // (versionCode = the CI run number), but local builds and the in-app "About" version use these
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10426)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.0")
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10427)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.1")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -197,6 +197,18 @@
                 android:value="Call recording: listen for call state after reboot to record reliably." />
         </service>
 
+        <!-- Persistent keep-alive: anchors our process + watchdog-relaunches the privileged recorder
+             daemon so calls are captured instantly (over binder, no Wi-Fi needed) instead of paying a
+             cold-start. Our equivalent of Shizuku's always-on manager presence. -->
+        <service
+            android:name=".services.recording.DaemonKeepAliveService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Call recording: keep the privileged recorder daemon warm so calls are captured instantly." />
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
+++ b/app/src/main/java/com/baba/callvault/CallVaultApplication.kt
@@ -10,10 +10,8 @@ package com.baba.callvault
 
 import android.app.Application
 import com.baba.callvault.data.AppPreferences
-import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.server.RecorderServerLauncher
 import com.baba.callvault.services.debug.DebugNotificationHelper
-import com.baba.callvault.services.recording.RecorderReadinessNotifier
 import com.baba.callvault.system.storage.RetentionScheduler
 import com.baba.callvault.system.updates.UpdateScheduler
 import com.baba.callvault.utils.AppLogger
@@ -24,11 +22,27 @@ import com.baba.callvault.utils.AppLogger
 class CallVaultApplication : Application() {
     private companion object {
         const val TAG = "CV:CallVaultApplication"
+
+        /** Old CallMonitorService notification id (pre-consolidation) — now shares 4720; cancel the stale one. */
+        const val LEGACY_READINESS_NOTIF_ID = 4714
+
+        /** Old RecorderReadinessNotifier notification id (pre-consolidation, transient launch notice). */
+        const val LEGACY_LAUNCH_NOTIF_ID = 4715
     }
 
     override fun onCreate() {
         super.onCreate()
         AppLogger.init(applicationContext)
+
+        // Migration: pre-consolidation builds showed readiness from THREE sources (the transient launch
+        // notifier id 4715 + the post-boot CallMonitorService id 4714), duplicating the single permanent
+        // keep-alive notification (id 4720). Cancel those stale ids once on startup so an updated install
+        // immediately drops to ONE readiness notification instead of waiting for a reboot to clear them.
+        runCatching {
+            getSystemService(android.app.NotificationManager::class.java)?.apply {
+                cancel(LEGACY_READINESS_NOTIF_ID); cancel(LEGACY_LAUNCH_NOTIF_ID)
+            }
+        }
 
         // Re-assert the "debug logging is on" reminder if the user left logging enabled across an
         // app restart, so the nudge to turn it back off survives process death.
@@ -53,20 +67,12 @@ class CallVaultApplication : Application() {
         // WD is off when idle, with no user action. Best-effort; the call path also ensures it on demand.
         if (AppPreferences(applicationContext).isAdbPaired()) {
             Thread {
-                // If the daemon is cold at app start (fresh install/update, post-reboot, or after the OS
-                // killed us), surface a "starting up… → ready to record" notification so the user knows
-                // when a call will actually be captured — the same signal the post-reboot path gives.
-                val coldAtStart = !RecorderConnection.isConnected
-                if (coldAtStart) RecorderReadinessNotifier.showStarting(applicationContext)
-
-                val connected = runCatching { RecorderServerLauncher.ensureServerRunning(applicationContext) }
+                // Warm the persistent daemon in the background so the app is recording-ready over binder.
+                // Readiness ("starting up… → ready to record") is surfaced by the SINGLE persistent
+                // DaemonKeepAliveService notification — no separate notifier here, which previously
+                // produced a DUPLICATE readiness notification alongside the keep-alive one.
+                runCatching { RecorderServerLauncher.ensureServerRunning(applicationContext) }
                     .onFailure { AppLogger.w(TAG, "Startup recorder-daemon warmup failed: ${it.message}") }
-                    .getOrDefault(false)
-
-                if (coldAtStart) {
-                    if (connected) RecorderReadinessNotifier.showReadyThenDismiss(applicationContext)
-                    else RecorderReadinessNotifier.dismiss(applicationContext)
-                }
             }.apply { isDaemon = true }.start()
         }
     }

--- a/app/src/main/java/com/baba/callvault/MainActivity.kt
+++ b/app/src/main/java/com/baba/callvault/MainActivity.kt
@@ -12,6 +12,8 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.services.recording.DaemonKeepAliveService
 
 /**
  * MainActivity is the single Android Activity entry point for CallVault.
@@ -27,6 +29,16 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         setContent {
             AppNavigationScreen()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Anchor the recorder daemon whenever the app is opened. Modern Android requires a foreground
+        // context to (re)start a foreground service, so we do it here rather than from Application.onCreate.
+        // Idempotent — no-op if the keep-alive service is already running.
+        if (AppPreferences(applicationContext).isAdbPaired()) {
+            DaemonKeepAliveService.start(applicationContext)
         }
     }
 }

--- a/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
+++ b/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
@@ -28,6 +28,14 @@ class AppPreferences(context: Context) {
 
         /** Public key id for the available-update tag, for change-listener comparisons. */
         const val AVAILABLE_UPDATE_TAG_KEY = "available_update_tag"
+
+        /**
+         * Range for the randomly-chosen loopback ADB port ([getLoopbackAdbPort]). Deliberately an
+         * uncommon high range: above the ephemeral/registered clutter, and NOT the well-known adb
+         * 5555, the adb-server 5037, or the emulator 5554–5585 band.
+         */
+        private const val LOOPBACK_PORT_MIN = 47000
+        private const val LOOPBACK_PORT_MAX = 59999
     }
 
     /**
@@ -157,6 +165,8 @@ class AppPreferences(context: Context) {
 
         // --- ADB ---
         ADB_PAIRED("adb_paired"),
+        LOOPBACK_ADB_PORT("loopback_adb_port"),
+        OFFLINE_RECORDING_ENABLED("offline_recording_enabled"),
 
         // --- In-app updates ---
         UPDATE_CHECK_ENABLED("update_check_enabled"),
@@ -310,6 +320,34 @@ class AppPreferences(context: Context) {
 
     /** Marks the one-time ADB pairing as completed (set after the first successful connection). */
     fun setAdbPaired(paired: Boolean) = setBoolean(Key.ADB_PAIRED, paired)
+
+    /**
+     * Returns this install's fixed loopback ADB port for the classic `adb tcpip` listener
+     * (`127.0.0.1:<port>`), which — unlike Wireless Debugging — survives WiFi-off because loopback
+     * is always up. Generated ONCE at random in an uncommon range (deliberately NOT the well-known
+     * 5555) on first read and persisted, so it is stable across app updates (SharedPreferences
+     * survives in-place same-cert updates) and across reboots (we re-arm adbd with the same number).
+     * It resets only on uninstall/clear-data, which also wipes the ADB pairing and forces re-onboard.
+     */
+    fun getLoopbackAdbPort(): Int {
+        val existing = getInt(Key.LOOPBACK_ADB_PORT, 0)
+        if (existing in LOOPBACK_PORT_MIN..LOOPBACK_PORT_MAX) return existing
+        val port = LOOPBACK_PORT_MIN + java.security.SecureRandom().nextInt(LOOPBACK_PORT_MAX - LOOPBACK_PORT_MIN + 1)
+        setInt(Key.LOOPBACK_ADB_PORT, port)
+        return port
+    }
+
+    /**
+     * Whether the user has OPTED IN to "offline recording (no Wi-Fi)" — the loopback `adb tcpip` mode.
+     * OFF by default: it opens a local debugging port bound to all interfaces (RSA-key-gated but a real
+     * surface), so it's only enabled after an explicit security-warning confirmation. When on,
+     * [com.baba.callvault.integrations.adb.AdbShell.ensureConnected] prefers the loopback port so calls
+     * record with no Wi-Fi.
+     */
+    fun isOfflineRecordingEnabled() = getBoolean(Key.OFFLINE_RECORDING_ENABLED, false)
+
+    /** Sets the offline-recording (loopback) opt-in flag. */
+    fun setOfflineRecordingEnabled(enabled: Boolean) = setBoolean(Key.OFFLINE_RECORDING_ENABLED, enabled)
 
     // -------- Persistent Recorder Server (CallVault Plan 5) --------
 

--- a/app/src/main/java/com/baba/callvault/integrations/adb/AdbConnectionManager.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/AdbConnectionManager.kt
@@ -54,6 +54,10 @@ class AdbConnectionManager private constructor(context: Context) : AbsAdbConnect
     init {
         // Tell the library which Android API level we're running on; it selects TLS vs plain TCP.
         setApi(Build.VERSION.SDK_INT)
+        // Bound EVERY connect() — the library defaults to an effectively infinite timeout, so a stalled
+        // handshake (e.g. reconnecting to the loopback tcpip port right after adbd restarts) would hang
+        // the caller forever. This covers connectLoopback at call time too.
+        setTimeout(CONNECT_TIMEOUT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)
 
         val appContext = context.applicationContext
         val loadedKey = loadPrivateKey(appContext)
@@ -93,6 +97,10 @@ class AdbConnectionManager private constructor(context: Context) : AbsAdbConnect
 
         /** Name shown in the ADB "Allow USB debugging?" / wireless pairing dialog. */
         private const val DEVICE_NAME = "CallVault"
+
+        /** Upper bound for a single connect() handshake (WD TLS or plain loopback). Generous for TLS,
+         *  but finite so a stalled handshake fails instead of hanging the recording/arming path. */
+        private const val CONNECT_TIMEOUT_SECONDS = 20L
 
         private const val PRIVATE_KEY_FILE = "adbkey"
         private const val CERTIFICATE_FILE = "adbkey.pem"

--- a/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
@@ -40,6 +40,16 @@ object AdbShell {
     private const val POST_DISCONNECT_WAIT_MS = 500L
     /** Hard cap on the tcpip: arm open (adbd restarts mid-open, so the call can stall — don't wait forever). */
     private const val ARM_FIRE_CAP_MS = 3000L
+    /** Max time to wait for an armed-but-restarting loopback listener to reappear before re-arming via WD. */
+    private const val LOOPBACK_SELFHEAL_MS = 12_000L
+    /** Poll interval while waiting for the loopback listener to self-heal after an adbd restart. */
+    private const val LOOPBACK_RETRY_INTERVAL_MS = 1500L
+    /** Sentinel echoed by [waitForShellReady] to confirm adbd actually answers a shell command. */
+    private const val SHELL_PROBE_TOKEN = "cv_shell_ok"
+    /** Poll interval between shell-readiness probes while adbd is coming back after a restart. */
+    private const val SHELL_PROBE_INTERVAL_MS = 400L
+    /** Hard cap per shell probe so a half-open (mid-restart) adbd connection can never hang the caller. */
+    private const val SHELL_PROBE_CAP_MS = 1500L
 
     /**
      * Ensures the ADB connection is up (mDNS-discover the connect port, connect, settle).
@@ -65,17 +75,69 @@ object AdbShell {
             grantSecureSettingsIfNeeded(context)
             return true
         }
-        // Loopback-first — ONLY when the user has opted in to offline recording. The persistent
-        // classic-tcpip port (see [armLoopbackIfNeeded]) works OFF-WiFi (loopback is always up, no mDNS,
-        // no WiFi), so a call on the road records without any network. Fails fast (connection refused)
-        // when not armed, falling through to Wireless Debugging. Gated behind the opt-in because arming
-        // opens a local debugging port (RSA-gated but a real surface) — see AppPreferences.isOfflineRecordingEnabled.
-        if (AppPreferences(context).isOfflineRecordingEnabled() && connectLoopback(context)) {
-            Thread.sleep(CONNECT_SETTLE_MS)
-            AppPreferences(context).setAdbPaired(true)
-            grantSecureSettingsIfNeeded(context)
-            return true
+        // OFFLINE MODE = LOOPBACK ONLY. We deliberately do NOT enable Wireless Debugging on this hot path:
+        // writing adb_wifi_enabled restarts adbd, and when classic-tcpip (loopback) is the daemon's only
+        // lifeline that restart KILLS the daemon. On-device heartbeat proof: the WD-enable churn was the
+        // PRIMARY cause of every daemon death — with WD kept off and loopback armed the daemon persists
+        // across screen-off + deep doze (~30 min, Athena-limited). If loopback is DOWN (e.g. tcpip cleared
+        // on reboot) we do NOT fall back to persistent WD here; the launcher re-arms loopback via
+        // [armLoopbackIfNeeded] (a deliberate, transient one-time WD bootstrap), which is not this churn.
+        if (AppPreferences(context).isOfflineRecordingEnabled()) {
+            var ok = connectLoopback(context)
+            // Loopback can be MOMENTARILY unavailable while adbd restarts (a USB plug/unplug transition,
+            // or a WD toggle) — but the tcpip listener SELF-HEALS because `service.adb.tcp.port` persists
+            // across adbd restarts, so it reappears within a few seconds. If the port is still armed, WAIT
+            // for it rather than re-arm via WD (which is what caused the transient WD "blips" on unplug).
+            // Only when the port is genuinely gone (e.g. tcpip cleared on reboot) do we let the caller
+            // re-arm — distinguished by isLoopbackArmed() so a post-reboot connect isn't delayed here.
+            if (!ok && isLoopbackArmed(context)) {
+                var waited = 0L
+                while (!ok && waited < LOOPBACK_SELFHEAL_MS) {
+                    Thread.sleep(LOOPBACK_RETRY_INTERVAL_MS)
+                    waited += LOOPBACK_RETRY_INTERVAL_MS
+                    ok = connectLoopback(context)
+                }
+                if (ok) AppLogger.i(TAG, "Loopback self-healed after ${waited}ms (adbd restart) — no WD needed")
+            }
+            if (ok) {
+                Thread.sleep(CONNECT_SETTLE_MS)
+                AppPreferences(context).setAdbPaired(true)
+                grantSecureSettingsIfNeeded(context)
+            }
+            return ok
         }
+        return connectViaWirelessDebugging(context)
+    }
+
+    /**
+     * True if adbd's classic-tcpip listener is armed on OUR loopback port — i.e. `service.adb.tcp.port`
+     * equals [AppPreferences.getLoopbackAdbPort]. The property PERSISTS across adbd restarts (only a
+     * reboot clears it), so "armed but connect refused" means adbd is mid-restart and the port will come
+     * back — worth waiting for instead of re-arming via Wireless Debugging.
+     */
+    private fun isLoopbackArmed(context: Context): Boolean =
+        getSystemProperty("service.adb.tcp.port") == AppPreferences(context).getLoopbackAdbPort().toString()
+
+    /** Reads a system property via the hidden `SystemProperties.get` (reflection; public SDK-safe). */
+    private fun getSystemProperty(key: String): String = runCatching {
+        Class.forName("android.os.SystemProperties")
+            .getMethod("get", String::class.java)
+            .invoke(null, key) as? String ?: ""
+    }.getOrDefault("")
+
+    /**
+     * Wireless-Debugging bootstrap: enable WD if the OEM turned it off, mDNS-discover the connect port,
+     * connect, settle. This is the ONLY path that writes `adb_wifi_enabled=1`. Used by the non-offline
+     * recording path and by [armLoopbackIfNeeded] for the one-time base connection it needs to arm the
+     * loopback listener (arming inherently needs a transport once).
+     *
+     * @Synchronized (instance monitor) — where both are held it is always acquired AFTER
+     * [heavyOperationLock], matching every other lock site (heavy → instance), so no inversion.
+     */
+    @Synchronized
+    private fun connectViaWirelessDebugging(context: Context): Boolean {
+        val mgr = AdbConnectionManager.getInstance(context)
+        if (mgr.isConnected) return true
         // Re-enable Wireless debugging if the OEM turned it off on reboot (needs WRITE_SECURE_SETTINGS).
         if (!isWirelessDebuggingEnabled(context) && enableWirelessDebugging(context)) {
             AppLogger.i(TAG, "Re-enabled Wireless debugging; waiting for adbd to advertise…")
@@ -83,9 +145,8 @@ object AdbShell {
         }
         val port = AdbMdns.discoverPort(context, AdbMdns.TLS_CONNECT, MDNS_TIMEOUT_MS) ?: return false
         // connect() THROWS on an unpaired/unauthorised identity (AdbPairingRequiredException) or a flaky
-        // TLS handshake (SSLProtocolException: CERTIFICATE_UNKNOWN). ensureConnected MUST return a boolean —
-        // callers branch on it (onboarding's setupAdb starts pairing when false; the recording/boot paths
-        // treat false as "not available"). Propagating crashed the app at the onboarding "Setup ADB" step.
+        // TLS handshake (SSLProtocolException: CERTIFICATE_UNKNOWN). Callers branch on the boolean —
+        // propagating crashed the app at onboarding's "Setup ADB" step — so swallow to false.
         val ok = runCatching { mgr.connect("127.0.0.1", port) }.getOrElse { e ->
             AppLogger.w(TAG, "ADB connect failed (pairing required or transport error): ${e.message}")
             false
@@ -125,6 +186,58 @@ object AdbShell {
      */
     fun openShell(context: Context, command: String): AdbStream =
         AdbConnectionManager.getInstance(context).openStream("shell:$command")
+
+    /**
+     * Polls a trivial shell round-trip until adbd actually answers, or [timeoutMs] elapses.
+     *
+     * On OnePlus, adbd RESTARTS on screen on/off transitions (even cable-out, WD off) — a TCP connect to
+     * the loopback port can succeed while adbd is still mid-init, so firing the daemon-launch command then
+     * lands on a dead shell and we wait out a full launch timeout for a binder that never comes. Verifying
+     * a cheap `echo` round-trips first means we launch ONLY into a live shell — the daemon then boots
+     * instantly. Cheap and bounded: each probe is one short shell exec; the daemon relaunch calls this
+     * right before [RecorderServerLauncher.launchOnce].
+     *
+     * @return true once a shell command round-trips; false if none did within [timeoutMs].
+     */
+    fun waitForShellReady(context: Context, timeoutMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var probes = 0
+        while (System.currentTimeMillis() < deadline) {
+            probes++
+            if (probeShellOnce(context)) {
+                if (probes > 1) AppLogger.i(TAG, "Loopback shell became ready after $probes probes")
+                return true
+            }
+            Thread.sleep(SHELL_PROBE_INTERVAL_MS)
+        }
+        AppLogger.w(TAG, "Loopback shell not ready within ${timeoutMs}ms ($probes probes) — adbd still restarting?")
+        return false
+    }
+
+    /**
+     * One shell round-trip, HARD-CAPPED at [SHELL_PROBE_CAP_MS]. Runs the exec on a throwaway daemon
+     * thread and joins with a timeout: if adbd is mid-restart the connection can half-open so the read
+     * never sees EOF — we then close the stream (unblocking the read) and report "not ready" instead of
+     * hanging the caller. This is the fix for the stall the un-bounded version caused on unplug.
+     */
+    private fun probeShellOnce(context: Context): Boolean {
+        val streamRef = java.util.concurrent.atomic.AtomicReference<AdbStream?>()
+        val ok = java.util.concurrent.atomic.AtomicBoolean(false)
+        val t = Thread {
+            runCatching {
+                val s = openShell(context, "echo $SHELL_PROBE_TOKEN")
+                streamRef.set(s)
+                s.use { if (it.openInputStream().bufferedReader().use { r -> r.readText() }.contains(SHELL_PROBE_TOKEN)) ok.set(true) }
+            }
+        }.apply { isDaemon = true; name = "cv-shell-probe" }
+        t.start()
+        t.join(SHELL_PROBE_CAP_MS)
+        if (t.isAlive) {
+            runCatching { streamRef.get()?.close() } // unblock the hung read so the abandoned thread dies
+            return false
+        }
+        return ok.get()
+    }
 
     /**
      * Opens an ADB `exec:` stream for [command] — a RAW, PTY-less bidirectional stream. Use this
@@ -190,8 +303,10 @@ object AdbShell {
             AppLogger.i(TAG, "Loopback already armed & reachable — nothing to do")
             return@synchronized true
         }
-        // Need a base connection to arm through (Wireless Debugging → needs WiFi once).
-        if (!ensureConnected(context)) {
+        // Need a base connection to arm through — bootstrap via Wireless Debugging directly (NOT
+        // ensureConnected, which in offline mode is loopback-only and would just fail here). This is the
+        // one deliberate, transient WD use in offline mode; applyWdPolicy turns WD back off once armed.
+        if (!connectViaWirelessDebugging(context)) {
             AppLogger.i(TAG, "Cannot arm loopback — no base connection (needs WiFi + Wireless debugging once)")
             return@synchronized false
         }

--- a/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
@@ -34,6 +34,12 @@ object AdbShell {
      * advertises — so a long fixed pre-sleep was mostly dead time on the post-boot cold-start path.
      */
     private const val WD_START_WAIT_MS = 750L
+    /** Time to let adbd restart into tcp mode after opening the `tcpip:` service, before reconnecting. */
+    private const val TCPIP_RESTART_WAIT_MS = 1500L
+    /** Settle after dropping the (now-dead) pre-restart connection, before the loopback reconnect. */
+    private const val POST_DISCONNECT_WAIT_MS = 500L
+    /** Hard cap on the tcpip: arm open (adbd restarts mid-open, so the call can stall — don't wait forever). */
+    private const val ARM_FIRE_CAP_MS = 3000L
 
     /**
      * Ensures the ADB connection is up (mDNS-discover the connect port, connect, settle).
@@ -55,6 +61,17 @@ object AdbShell {
     fun ensureConnected(context: Context): Boolean {
         val mgr = AdbConnectionManager.getInstance(context)
         if (mgr.isConnected) {
+            AppPreferences(context).setAdbPaired(true)
+            grantSecureSettingsIfNeeded(context)
+            return true
+        }
+        // Loopback-first — ONLY when the user has opted in to offline recording. The persistent
+        // classic-tcpip port (see [armLoopbackIfNeeded]) works OFF-WiFi (loopback is always up, no mDNS,
+        // no WiFi), so a call on the road records without any network. Fails fast (connection refused)
+        // when not armed, falling through to Wireless Debugging. Gated behind the opt-in because arming
+        // opens a local debugging port (RSA-gated but a real surface) — see AppPreferences.isOfflineRecordingEnabled.
+        if (AppPreferences(context).isOfflineRecordingEnabled() && connectLoopback(context)) {
+            Thread.sleep(CONNECT_SETTLE_MS)
             AppPreferences(context).setAdbPaired(true)
             grantSecureSettingsIfNeeded(context)
             return true
@@ -132,6 +149,110 @@ object AdbShell {
      */
     fun openLocalAbstract(context: Context, name: String): AdbStream =
         AdbConnectionManager.getInstance(context).openStream("localabstract:$name")
+
+    // ---- Off-WiFi recording: persistent classic-tcpip loopback listener (opt-in) ----
+
+    /**
+     * Attempts the persistent classic-tcpip loopback connection (`127.0.0.1:<port>`).
+     *
+     * Unlike Wireless Debugging this needs NO WiFi (loopback is always up) — but only works once the
+     * port has been armed since the last reboot (see [armLoopbackIfNeeded]). Returns false FAST
+     * (connection refused) when unarmed, so callers fall back to Wireless Debugging. libadb-android
+     * reacts to the daemon's AUTH-vs-STLS message dynamically, so the same identity authenticates over
+     * this plain RSA-AUTH port. Holds no lock itself — callers order locks (heavy → monitor).
+     */
+    private fun connectLoopback(context: Context): Boolean {
+        val port = AppPreferences(context).getLoopbackAdbPort()
+        val mgr = AdbConnectionManager.getInstance(context)
+        return runCatching { mgr.connect("127.0.0.1", port) }
+            .onFailure { AppLogger.d(TAG, "Loopback :$port unavailable (unarmed/refused): ${it.message}") }
+            .getOrDefault(false)
+            .also { if (it) AppLogger.i(TAG, "Connected over loopback tcpip :$port (works off-WiFi)") }
+    }
+
+    /**
+     * Arms the persistent classic-tcpip loopback listener so future connects work OFF-WiFi.
+     *
+     * Opens the `tcpip:<port>` adb service → adbd restarts listening on `0.0.0.0:<port>` (reachable on
+     * loopback, which is always up). Because the restart DROPS the live connection, this is disruptive
+     * and must run only at a SAFE idle moment — NEVER while recording. It needs a base connection to arm
+     * through, which comes via Wireless Debugging, so WiFi + WD must be available ONCE; after arming,
+     * calls record off-WiFi until the next reboot (tcpip mode clears on reboot → re-arm on next
+     * connectivity). No-op (returns true) if the loopback port is already armed and reachable.
+     *
+     * Lock order: takes [heavyOperationLock] FIRST, then [ensureConnected] acquires the AdbShell
+     * monitor — matching the recorder launcher's heavy→monitor order so the two never deadlock.
+     *
+     * @return true if the loopback listener is armed and reachable after the call.
+     */
+    fun armLoopbackIfNeeded(context: Context): Boolean = synchronized(heavyOperationLock) {
+        if (connectLoopback(context)) {
+            AppLogger.i(TAG, "Loopback already armed & reachable — nothing to do")
+            return@synchronized true
+        }
+        // Need a base connection to arm through (Wireless Debugging → needs WiFi once).
+        if (!ensureConnected(context)) {
+            AppLogger.i(TAG, "Cannot arm loopback — no base connection (needs WiFi + Wireless debugging once)")
+            return@synchronized false
+        }
+        // ensureConnected may itself have landed us on loopback already (nothing left to arm).
+        if (connectLoopback(context)) return@synchronized true
+
+        val port = AppPreferences(context).getLoopbackAdbPort()
+        val mgr = AdbConnectionManager.getInstance(context)
+        AppLogger.i(TAG, "Arming loopback tcpip on :$port (adbd will restart)…")
+        // Fire the tcpip: arm WITHOUT blocking. adbd restarts on receiving the OPEN and kills this very
+        // connection, so reading the stream's response can stall forever (the read never gets an EOF when
+        // the socket dies mid-flight). Opening the stream is what arms adbd; do it on a daemon thread with
+        // a hard cap so a stalled open/close can never hang the caller.
+        armFireThread(mgr, port)
+
+        Thread.sleep(TCPIP_RESTART_WAIT_MS)
+        runCatching { mgr.disconnect() }.onFailure { AppLogger.d(TAG, "post-arm disconnect ignored: ${it.message}") }
+        Thread.sleep(POST_DISCONNECT_WAIT_MS)
+
+        val armed = connectLoopback(context)
+        AppLogger.i(TAG, "Loopback arm result on :$port = $armed")
+        armed
+    }
+
+    /**
+     * Opens `tcpip:<port>` to arm adbd, on a bounded daemon thread. The open triggers adbd's restart;
+     * we neither read the response (the connection dies mid-read) nor wait beyond [ARM_FIRE_CAP_MS]
+     * (a stalled open must not hang arming). Any leftover thread is a daemon and self-reaps.
+     */
+    private fun armFireThread(mgr: AdbConnectionManager, port: Int) {
+        val t = Thread {
+            runCatching { mgr.openStream("tcpip:$port").close() }
+                .onFailure { AppLogger.d(TAG, "arm open/close ended: ${it.message} (adbd restarting — expected)") }
+        }.apply { isDaemon = true; name = "cv-arm-tcpip" }
+        t.start()
+        t.join(ARM_FIRE_CAP_MS)
+        if (t.isAlive) AppLogger.d(TAG, "arm open did not return within ${ARM_FIRE_CAP_MS}ms; proceeding (request already sent)")
+    }
+
+    /**
+     * Closes the classic-tcpip listener (reverting adbd to USB mode via the `usb:` service — the device
+     * side of `adb usb`), so the open port doesn't linger until reboot after the user turns OFF offline
+     * recording. Best-effort + bounded (adbd restarts on the request, so it can stall); if it can't run
+     * now, the port simply closes on the next reboot. Call OFF the main thread.
+     */
+    fun disarmLoopback(context: Context) = synchronized(heavyOperationLock) {
+        val mgr = AdbConnectionManager.getInstance(context)
+        if (!mgr.isConnected && !ensureConnected(context)) {
+            AppLogger.i(TAG, "disarmLoopback: no connection to send usb: (port closes on next reboot)")
+            return@synchronized
+        }
+        AppLogger.i(TAG, "Disarming loopback tcpip (reverting adbd to usb mode)…")
+        val t = Thread {
+            runCatching { mgr.openStream("usb:").close() }
+                .onFailure { AppLogger.d(TAG, "usb: revert ended: ${it.message} (adbd restarting — expected)") }
+        }.apply { isDaemon = true; name = "cv-disarm-tcpip" }
+        t.start()
+        t.join(ARM_FIRE_CAP_MS)
+        Thread.sleep(TCPIP_RESTART_WAIT_MS)
+        runCatching { mgr.disconnect() }.onFailure { AppLogger.d(TAG, "post-disarm disconnect ignored: ${it.message}") }
+    }
 
     // ---- Wireless-debugging helpers ----
 

--- a/app/src/main/java/com/baba/callvault/integrations/adb/OfflineRecording.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/OfflineRecording.kt
@@ -1,0 +1,52 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.integrations.adb
+
+import android.content.Context
+import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.server.RecorderServerLauncher
+import com.baba.callvault.utils.AppLogger
+
+/**
+ * Enables/disables the opt-in "offline recording" (classic-tcpip loopback) transport, so the same
+ * behaviour is shared by the Settings toggle and the post-update "What's new" note — one place that
+ * sets the preference AND arms/disarms the loopback listener.
+ *
+ * The loopback port works OFF-WiFi (127.0.0.1 is always up), letting a call record with no network —
+ * but arming it opens a local, RSA-gated debugging port, which is why it is opt-in behind a warning.
+ * All methods do blocking ADB I/O — call OFF the main thread.
+ */
+object OfflineRecording {
+
+    private const val TAG = "CV:OfflineRecording"
+
+    /**
+     * Turns offline recording ON: persists the opt-in and arms the loopback listener (needs Wi-Fi +
+     * Wireless Debugging ONCE to arm; records off-WiFi thereafter until reboot). Re-warms the daemon so
+     * the first off-WiFi call records. Returns true if the loopback listener is armed and reachable.
+     */
+    fun enable(context: Context): Boolean {
+        AppPreferences(context).setOfflineRecordingEnabled(true)
+        val armed = AdbShell.armLoopbackIfNeeded(context)
+        if (armed) {
+            runCatching { RecorderServerLauncher.ensureServerRunning(context) }
+                .onFailure { AppLogger.w(TAG, "re-warm after enable failed: ${it.message}") }
+        } else {
+            AppLogger.i(TAG, "Could not arm loopback (needs Wi-Fi + Wireless Debugging once)")
+        }
+        return armed
+    }
+
+    /** Turns offline recording OFF: clears the opt-in and closes the loopback port (best-effort). */
+    fun disable(context: Context) {
+        AppPreferences(context).setOfflineRecordingEnabled(false)
+        runCatching { AdbShell.disarmLoopback(context) }
+            .onFailure { AppLogger.d(TAG, "disarmLoopback on disable ignored: ${it.message}") }
+    }
+}

--- a/app/src/main/java/com/baba/callvault/server/DirectAudioRecorderSession.kt
+++ b/app/src/main/java/com/baba/callvault/server/DirectAudioRecorderSession.kt
@@ -1,0 +1,252 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.server
+
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.media.MediaRecorder
+import android.os.ParcelFileDescriptor
+import com.baba.callvault.integrations.scrcpy.ScrcpyAudioCodec
+import com.baba.callvault.integrations.scrcpy.ScrcpyAudioSource
+import com.baba.callvault.utils.AppLogger
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * FAST capture pipeline: a direct `AudioRecord` → `MediaCodec` (encode) → `MediaMuxer` (mux) chain,
+ * running IN the privileged daemon process. Replaces the scrcpy-server child for the common case.
+ *
+ * **Why it's faster.** The scrcpy path spawns a second `app_process`, extracts+verifies the scrcpy jar,
+ * and does an abstract-socket handshake before a single sample is captured — ~1–2 s that clips the front
+ * of the call, and it also adds the jar extraction to every daemon boot. Here the daemon (already a warm,
+ * shell-uid process that holds `CAPTURE_AUDIO_OUTPUT`) opens `AudioRecord` directly: `startRecording()`
+ * is ~milliseconds, so capture begins at the first frame with no child process and no jar.
+ *
+ * **Format parity.** The app creates the SAF output file from the chosen [ScrcpyAudioCodec] (Opus→.ogg,
+ * AAC→.m4a), so this encodes to that exact codec/container — no app-side change. [supports] gates use to
+ * a mic-type source AND a device that actually has the needed encoder; anything else falls back to scrcpy.
+ */
+internal class DirectAudioRecorderSession(
+    private val source: ScrcpyAudioSource,
+    private val codec: ScrcpyAudioCodec,
+    private val bitRate: Int,
+    /** The daemon's received fd copy. The muxer writes through it; [stop] closes it after finalising. */
+    private val outFd: ParcelFileDescriptor,
+) : RecordingSession {
+
+    private val stopRequested = AtomicBoolean(false)
+    @Volatile private var audioRecord: AudioRecord? = null
+    @Volatile private var encoder: MediaCodec? = null
+    @Volatile private var muxer: MediaMuxer? = null
+    @Volatile private var readThread: Thread? = null
+
+    override fun start() {
+        try {
+            startInternal()
+        } catch (t: Throwable) {
+            // Release our OWN resources but do NOT close outFd — the caller may retry over scrcpy with it.
+            // MediaMuxer(FileDescriptor) does not own the fd, so release() leaves it open for the fallback.
+            cleanupPartial()
+            throw t
+        }
+    }
+
+    private fun startInternal() {
+        val androidSource = androidSourceFor(source)
+            ?: throw UnsupportedOperationException("source ${source.cliKey} is not a mic-type source")
+        val mime = encoderMimeFor(codec)
+
+        // Try stereo first (matches scrcpy's 48 kHz stereo output); fall back to mono if the source
+        // won't initialise in stereo (some OEM VOICE_CALL routes are mono-only).
+        val (record, channelCount) = openAudioRecord(androidSource)
+        audioRecord = record
+
+        val format = MediaFormat.createAudioFormat(mime, SAMPLE_RATE, channelCount).apply {
+            setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
+            if (mime == MediaFormat.MIMETYPE_AUDIO_AAC) {
+                setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC)
+            }
+            setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, MAX_INPUT_SIZE)
+        }
+        val enc = MediaCodec.createEncoderByType(mime).apply {
+            configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+        }
+        encoder = enc
+
+        // Create the muxer LAST — the risky AudioRecord/encoder setup above has succeeded, so if we get
+        // here the output fd is only now consumed (keeps a clean fd for the scrcpy fallback if we'd thrown).
+        val mux = MediaMuxer(outFd.fileDescriptor, codec.outputFormat)
+        muxer = mux
+
+        enc.start()
+        record.startRecording()
+        if (record.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
+            throw IllegalStateException("AudioRecord failed to enter RECORDING state")
+        }
+        AppLogger.i(TAG, "Direct capture started: source=${source.cliKey} codec=${codec.cliKey} ch=$channelCount rate=$SAMPLE_RATE")
+
+        readThread = Thread { runCatching { captureLoop(record, enc, mux) }
+            .onFailure { AppLogger.w(TAG, "Direct capture loop ended: ${it.message}") } }
+            .apply { isDaemon = true; name = "direct-capture" }
+            .also { it.start() }
+    }
+
+    /**
+     * Reads PCM from [record], feeds it to [enc], and muxes the encoded output into [mux] until [stop]
+     * signals EOS. Standard synchronous MediaCodec drive: queue input with a monotonic sample-count PTS,
+     * drain output, add the track on INFO_OUTPUT_FORMAT_CHANGED (its format carries the Opus/AAC CSD).
+     */
+    private fun captureLoop(record: AudioRecord, enc: MediaCodec, mux: MediaMuxer) {
+        val pcm = ByteArray(READ_CHUNK_BYTES)
+        val info = MediaCodec.BufferInfo()
+        var muxerStarted = false
+        var totalFrames = 0L
+        val bytesPerFrame = 2 * record.channelCount // PCM-16
+
+        while (!stopRequested.get()) {
+            val read = record.read(pcm, 0, pcm.size)
+            if (read <= 0) continue
+
+            val inIdx = enc.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
+            if (inIdx >= 0) {
+                val inBuf = enc.getInputBuffer(inIdx)!!
+                inBuf.clear(); inBuf.put(pcm, 0, read)
+                val ptsUs = totalFrames * 1_000_000L / SAMPLE_RATE
+                enc.queueInputBuffer(inIdx, 0, read, ptsUs, 0)
+                totalFrames += read / bytesPerFrame
+            }
+            muxerStarted = drainEncoder(enc, mux, info, muxerStarted)
+        }
+
+        // Signal end-of-stream so the encoder flushes its tail, then drain what's left.
+        val inIdx = enc.dequeueInputBuffer(END_OF_STREAM_TIMEOUT_US)
+        if (inIdx >= 0) enc.queueInputBuffer(inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+        drainEncoder(enc, mux, info, muxerStarted, drainToEos = true)
+    }
+
+    /** Drains available encoder output into the muxer. Returns whether the muxer is (now) started. */
+    private fun drainEncoder(
+        enc: MediaCodec, mux: MediaMuxer, info: MediaCodec.BufferInfo,
+        muxerStartedIn: Boolean, drainToEos: Boolean = false,
+    ): Boolean {
+        var muxerStarted = muxerStartedIn
+        var track = if (muxerStarted) 0 else -1
+        while (true) {
+            val outIdx = enc.dequeueOutputBuffer(info, if (drainToEos) END_OF_STREAM_TIMEOUT_US else 0)
+            when {
+                outIdx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                    track = mux.addTrack(enc.outputFormat) // format carries codec-specific data (CSD)
+                    mux.start()
+                    muxerStarted = true
+                }
+                outIdx == MediaCodec.INFO_TRY_AGAIN_LATER -> {
+                    if (drainToEos) continue else return muxerStarted // no output ready right now
+                }
+                outIdx >= 0 -> {
+                    val outBuf = enc.getOutputBuffer(outIdx)!!
+                    val isConfig = info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0
+                    if (!isConfig && info.size > 0 && muxerStarted) {
+                        outBuf.position(info.offset)
+                        outBuf.limit(info.offset + info.size)
+                        mux.writeSampleData(track, outBuf, info)
+                    }
+                    enc.releaseOutputBuffer(outIdx, false)
+                    if (info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) return muxerStarted
+                }
+            }
+        }
+    }
+
+    override fun stop() {
+        AppLogger.i(TAG, "Stopping direct capture session")
+        stopRequested.set(true)
+        // Let the capture loop notice the stop flag, flush EOS, and finalise the muxer.
+        runCatching { readThread?.join(READ_JOIN_MS) }
+        runCatching { audioRecord?.stop() }
+        runCatching { audioRecord?.release() }
+        runCatching { encoder?.stop() }
+        runCatching { encoder?.release() }
+        // Muxer LAST among writers — stop() writes the container trailer (without it the file won't play).
+        runCatching { muxer?.stop() }
+        runCatching { muxer?.release() }
+        runCatching { outFd.close() }
+        AppLogger.i(TAG, "Direct capture session stopped")
+    }
+
+    /** Releases capture resources on a failed [start] WITHOUT closing [outFd] (the caller retries scrcpy). */
+    private fun cleanupPartial() {
+        runCatching { audioRecord?.release() }
+        runCatching { encoder?.release() }
+        runCatching { muxer?.release() } // MediaMuxer.release() does NOT close the fd — outFd stays usable
+        audioRecord = null; encoder = null; muxer = null
+    }
+
+    private fun openAudioRecord(androidSource: Int): Pair<AudioRecord, Int> {
+        for (channelMask in intArrayOf(AudioFormat.CHANNEL_IN_STEREO, AudioFormat.CHANNEL_IN_MONO)) {
+            val channels = if (channelMask == AudioFormat.CHANNEL_IN_STEREO) 2 else 1
+            val minBuf = AudioRecord.getMinBufferSize(SAMPLE_RATE, channelMask, AudioFormat.ENCODING_PCM_16BIT)
+            if (minBuf <= 0) continue
+            val rec = runCatching {
+                @Suppress("MissingPermission") // shell uid holds CAPTURE_AUDIO_OUTPUT; the daemon is not an app.
+                AudioRecord(androidSource, SAMPLE_RATE, channelMask, AudioFormat.ENCODING_PCM_16BIT, minBuf * BUFFER_FACTOR)
+            }.getOrNull()
+            if (rec != null && rec.state == AudioRecord.STATE_INITIALIZED) return rec to channels
+            runCatching { rec?.release() }
+        }
+        throw IllegalStateException("AudioRecord would not initialise for source $androidSource (stereo or mono)")
+    }
+
+    companion object {
+        private const val TAG = "CV:DirectCapture"
+
+        /** Match scrcpy's output so the muxed file is equivalent (48 kHz). */
+        private const val SAMPLE_RATE = 48_000
+        private const val READ_CHUNK_BYTES = 4096
+        private const val MAX_INPUT_SIZE = 16_384
+        private const val BUFFER_FACTOR = 4
+        private const val DEQUEUE_TIMEOUT_US = 10_000L
+        private const val END_OF_STREAM_TIMEOUT_US = 100_000L
+        private const val READ_JOIN_MS = 2_000L
+
+        /**
+         * True if the direct pipeline can handle this [source]+[codec] on THIS device: the source must be
+         * a mic-type `AudioSource` (not output/playback capture) AND the device must have an encoder for
+         * the codec's MIME. Otherwise [RecorderServer] uses the scrcpy fallback.
+         */
+        fun supports(source: ScrcpyAudioSource, codec: ScrcpyAudioCodec): Boolean {
+            if (androidSourceFor(source) == null) return false
+            return runCatching { hasEncoder(encoderMimeFor(codec)) }.getOrDefault(false)
+        }
+
+        /** Maps our scrcpy `audio_source` cliKey to an Android [MediaRecorder.AudioSource]; null = needs scrcpy. */
+        private fun androidSourceFor(source: ScrcpyAudioSource): Int? = when (source.cliKey) {
+            "voice-call" -> MediaRecorder.AudioSource.VOICE_CALL
+            "mic-voice-communication" -> MediaRecorder.AudioSource.VOICE_COMMUNICATION
+            "mic" -> MediaRecorder.AudioSource.MIC
+            "mic-voice-recognition" -> MediaRecorder.AudioSource.VOICE_RECOGNITION
+            "mic-voice-performance" -> MediaRecorder.AudioSource.VOICE_PERFORMANCE
+            else -> null // "output"/playback-capture etc. — not a plain AudioRecord source
+        }
+
+        private fun encoderMimeFor(codec: ScrcpyAudioCodec): String = when (codec) {
+            ScrcpyAudioCodec.OPUS -> MediaFormat.MIMETYPE_AUDIO_OPUS
+            ScrcpyAudioCodec.AAC -> MediaFormat.MIMETYPE_AUDIO_AAC
+        }
+
+        private fun hasEncoder(mime: String): Boolean =
+            MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos.any { info ->
+                info.isEncoder && info.supportedTypes.any { it.equals(mime, ignoreCase = true) }
+            }
+    }
+}

--- a/app/src/main/java/com/baba/callvault/server/RecorderConnection.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderConnection.kt
@@ -53,8 +53,18 @@ object RecorderConnection {
         AppLogger.i(TAG, "RecorderConnection received daemon binder")
     }
 
+    /**
+     * Optional hook fired (in addition to clearing [service]) the instant the daemon binder dies, so a
+     * watcher (the keep-alive service) can relaunch the daemon RIGHT AWAY instead of waiting for its next
+     * poll. Since linkToDeath only fires on genuine process death, this is an authoritative "daemon gone"
+     * signal — the fastest possible recovery trigger.
+     */
+    @Volatile
+    var onDeath: (() -> Unit)? = null
+
     /** Cleared when the daemon dies (via [deathRecipient]) so callers observe a stale channel. */
     fun onBinderDied() {
         this.service = null
+        runCatching { onDeath?.invoke() }.onFailure { AppLogger.w(TAG, "onDeath hook failed: ${it.message}") }
     }
 }

--- a/app/src/main/java/com/baba/callvault/server/RecorderServer.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderServer.kt
@@ -56,10 +56,7 @@ object RecorderServer {
     private val recordingActive = AtomicBoolean(false)
 
     /** The active session, owned by the worker thread; null between recordings. */
-    @Volatile private var session: RecorderSession? = null
-
-    /** scrcpy binary path established by [ensureScrcpyJar] in [main]; reused per session. */
-    @Volatile private var scrcpyJarPath: String = ScrcpyJarExtractor.JAR_PATH
+    @Volatile private var session: RecordingSession? = null
 
     /** The daemon's own APK path (launch arg), used to (re)extract scrcpy if it goes missing. */
     @Volatile private var apkPath: String = ""
@@ -99,8 +96,9 @@ object RecorderServer {
             // A main looper is required (binder dispatch + system-context ContentResolver fallback).
             Looper.prepareMainLooper()
 
-            // Self-extract scrcpy from our OWN apk to a reaper-safe, ADB-free, namespace-safe path.
-            scrcpyJarPath = ScrcpyJarExtractor.ensureScrcpyJar(apkPath)
+            // NOTE: scrcpy is NOT extracted here anymore — the direct AudioRecord path needs no jar, and
+            // the scrcpy fallback re-extracts on demand ([startWithFallback]). Keeps daemon boot fast so a
+            // relaunch after an Athena reap is ready sooner (the cold-start that a call races).
 
             val stub = createStub()
             val delivered = BinderDelivery.deliverBinderToApp(stub.asBinder(), authority)
@@ -115,8 +113,39 @@ object RecorderServer {
     }
 
     /**
+     * Starts capture, preferring the FAST direct AudioRecord pipeline and falling back to scrcpy.
+     *
+     * The direct path ([DirectAudioRecorderSession]) spawns no child process and needs no scrcpy jar, so
+     * it begins capturing near-instantly — used whenever it can handle the source+codec on this device
+     * ([DirectAudioRecorderSession.supports]). If it throws during setup it releases its own resources
+     * WITHOUT closing [outFd], so the live fd can still be handed to scrcpy. Throws if BOTH paths fail.
+     */
+    private fun startWithFallback(
+        source: ScrcpyAudioSource,
+        codec: ScrcpyAudioCodec,
+        bitRate: Int,
+        outFd: ParcelFileDescriptor,
+    ): RecordingSession {
+        if (DirectAudioRecorderSession.supports(source, codec)) {
+            val direct = DirectAudioRecorderSession(source, codec, bitRate, outFd)
+            if (runCatching { direct.start() }
+                    .onFailure { AppLogger.w(TAG, "Direct capture unavailable, falling back to scrcpy: ${it.message}") }
+                    .isSuccess
+            ) {
+                AppLogger.i(TAG, "Recording via DIRECT AudioRecord — source=${source.cliKey} codec=${codec.cliKey}")
+                return direct
+            }
+        }
+        val freshJar = ScrcpyJarExtractor.ensureScrcpyJar(apkPath) // scrcpy needs its extracted jar
+        val scrcpy = RecorderSession(source, codec, bitRate, outFd, freshJar)
+        scrcpy.start()
+        AppLogger.i(TAG, "Recording via scrcpy — source=${source.cliKey} codec=${codec.cliKey}")
+        return scrcpy
+    }
+
+    /**
      * The daemon-side [IRecorderService] implementation. Binder transactions are short and never block
-     * on scrcpy: [startRecording]/[stopRecording] post the heavy work to [workerHandler].
+     * on capture setup: [startRecording]/[stopRecording] post the heavy work to [workerHandler].
      */
     private fun createStub(): IRecorderService.Stub = object : IRecorderService.Stub() {
 
@@ -147,23 +176,17 @@ object RecorderServer {
 
             AppLogger.i(TAG, "startRecording source=$source codec=$codec bitRate=$bitRate")
 
-            // Heavy work (scrcpy launch, socket retry) OFF the binder thread.
+            // Heavy work (AudioRecord/encoder init or scrcpy launch) OFF the binder thread.
             workerHandler.post {
-                var built: RecorderSession? = null
-                runCatching {
-                    val freshJar = ScrcpyJarExtractor.ensureScrcpyJar(apkPath) // re-extract if reaper ate it
-                    val s = RecorderSession(sourceEnum, codecEnum, bitRate, outFd, freshJar)
-                    built = s
-                    s.start()
-                    session = s
-                }.onFailure {
-                    AppLogger.e(TAG, "startRecording failed: ${it.message}", it)
-                    // If the session was constructed, stop() destroys the (possibly-launched) scrcpy child,
-                    // closes the socket/muxer AND closes outFd — without this a failed start would LEAK the
-                    // shell-uid scrcpy child, which holds the audio source and breaks the NEXT recording.
-                    // If construction never happened, close the fd directly.
-                    val s = built
-                    if (s != null) runCatching { s.stop() } else runCatching { outFd.close() }
+                val active = runCatching { startWithFallback(sourceEnum, codecEnum, bitRate, outFd) }
+                    .onFailure { AppLogger.e(TAG, "startRecording failed (all paths): ${it.message}", it) }
+                    .getOrNull()
+                if (active != null) {
+                    session = active
+                } else {
+                    // Both paths failed and neither owns the fd now — close it so it isn't leaked, and
+                    // release the recording latch so a later attempt can run.
+                    runCatching { outFd.close() }
                     session = null
                     recordingActive.set(false)
                 }

--- a/app/src/main/java/com/baba/callvault/server/RecorderServerLauncher.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderServerLauncher.kt
@@ -10,6 +10,7 @@ package com.baba.callvault.server
 
 import android.content.Context
 import android.os.SystemClock
+import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.integrations.adb.AdbShell
 import com.baba.callvault.utils.AppLogger
 
@@ -64,16 +65,19 @@ object RecorderServerLauncher {
     /**
      * Kills any already-running [RecorderServer] daemon before launching a fresh one. The daemon is a
      * detached shell-uid `app_process` reparented to init, so it SURVIVES app uninstall/update — without
-     * this, stale OLD-code daemons accumulate across reinstalls/updates and orphan until reboot. Scans
-     * `/proc/<pid>/cmdline` for the daemon FQCN and `kill`s the matches.
+     * this, stale OLD-code daemons accumulate across reinstalls/updates and orphan until reboot.
      *
-     * Self-exclusion: the FQCN is written `Recorder[S]erver` so this kill shell's OWN cmdline (which
-     * contains the literal `Recorder[S]erver`) does NOT match the regex, while a real daemon's cmdline
-     * (`…RecorderServer …`) does. Run only on the launch path (binder not connected), so killing an
-     * existing daemon is safe — a fresh one is about to replace it.
+     * Uses `pgrep -f` (a single fast kernel scan) — the previous `for d in /proc/[0-9]*; do grep …`
+     * loop forked a `grep` per process and measured **~25 s** on this device, dwarfing the whole rest of
+     * a relaunch (the dominant chunk of the post-death "starting up" window a call races). pgrep is ~70 ms.
+     *
+     * Self-exclusion: the FQCN is written `Recorder[S]erver` so this command's OWN cmdline (which contains
+     * the literal `Recorder[S]erver`) does NOT match the regex, while a real daemon's cmdline
+     * (`…RecorderServer …`) does. Run only on the launch path (binder not connected), and only AFTER
+     * [AdbShell.waitForShellReady] confirms the shell answers, so pgrep can't hang mid-restart.
      */
     private const val KILL_STALE_CMD =
-        "for d in /proc/[0-9]*; do grep -qa 'com.baba.callvault.server.Recorder[S]erver' \"\$d/cmdline\" 2>/dev/null && kill \"\${d#/proc/}\" 2>/dev/null; done"
+        "p=\$(pgrep -f 'com.baba.callvault.server.Recorder[S]erver' 2>/dev/null); [ -n \"\$p\" ] && kill \$p 2>/dev/null; true"
 
     /** Drain cap for [killStaleDaemons]; the command isn't backgrounded, so it usually EOFs sooner. */
     private const val KILL_DRAIN_MS = 1500L
@@ -96,6 +100,9 @@ object RecorderServerLauncher {
      */
     private const val MAX_LAUNCH_ATTEMPTS = 3
 
+    /** Per-attempt budget to wait for the loopback shell to actually answer (adbd finishing a restart). */
+    private const val SHELL_READY_TIMEOUT_MS = 6_000L
+
     /**
      * Ensures the privileged recorder daemon is running and its binder is available in
      * [RecorderConnection]. Call OFF the main thread (does ADB network I/O and polls/sleeps).
@@ -117,7 +124,10 @@ object RecorderServerLauncher {
      * other mid-connect and spawn duplicate daemons — observed to thrash the embedded ADB connection into
      * a "Stream closed" state. One launch at a time; the second caller sees the connected binder and returns.
      */
-    fun ensureServerRunning(context: Context, timeoutMs: Long = 12_000): Boolean =
+    // 24s total / 3 attempts = 8s per attempt. The old 12s (=4s/attempt) was shorter than the daemon's
+    // cold-start, so attempt 1 ALWAYS timed out and we burned ~8s before even retrying — the biggest
+    // avoidable chunk of the post-reap "starting up" window a call races. 8s comfortably covers a cold boot.
+    fun ensureServerRunning(context: Context, timeoutMs: Long = 24_000): Boolean =
         // Serialize with the update installer (and other daemon launches) on the shared ADB lock, so
         // a launch's reconnect/WD-toggle never tears down an in-flight update install stream.
         synchronized(AdbShell.heavyOperationLock) { ensureServerRunningLocked(context, timeoutMs) }
@@ -143,10 +153,27 @@ object RecorderServerLauncher {
             // (Re)establish ADB. On a retry, force a fresh connection — a stale half-dead connection
             // still reports isConnected but its openStream throws "Stream closed". This also re-enables
             // Wireless debugging if the WD policy had turned it off (needed to relaunch the daemon).
-            val connected = if (attempt == 0) AdbShell.ensureConnected(context)
+            var connected = if (attempt == 0) AdbShell.ensureConnected(context)
             else AdbShell.forceReconnect(context)
+            // Offline mode: if we couldn't connect, the loopback listener is DOWN (e.g. tcpip cleared on
+            // reboot). Re-ARM it (a deliberate, transient WD bootstrap) rather than run on persistent
+            // Wireless Debugging — WD's adbd churn is what kills the daemon. Held under heavyOperationLock
+            // (this method), so armLoopbackIfNeeded's lock is re-entrant. No-op/fast when already armed.
+            if (!connected && AppPreferences(context).isOfflineRecordingEnabled()) {
+                AppLogger.i(TAG, "Attempt $n: offline mode but no connection — re-arming loopback")
+                if (AdbShell.armLoopbackIfNeeded(context)) connected = AdbShell.ensureConnected(context)
+            }
             if (!connected) {
                 AppLogger.w(TAG, "Attempt $n/$MAX_LAUNCH_ATTEMPTS: ADB not connected; retrying")
+                return@repeat
+            }
+
+            // A TCP connect to loopback can succeed while adbd is still mid-restart (OnePlus restarts adbd
+            // on screen transitions), so the launch command would land on a dead shell and we'd wait out
+            // the whole poll for a binder that never arrives. Confirm the shell actually round-trips FIRST
+            // — the daemon boots instantly once the command lands, so this turns a ~40s stall into seconds.
+            if (!AdbShell.waitForShellReady(context, SHELL_READY_TIMEOUT_MS)) {
+                AppLogger.w(TAG, "Attempt $n/$MAX_LAUNCH_ATTEMPTS: loopback shell not ready (adbd restarting); retrying")
                 return@repeat
             }
 

--- a/app/src/main/java/com/baba/callvault/server/RecorderSession.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderSession.kt
@@ -44,7 +44,7 @@ internal class RecorderSession(
     /** The daemon's received fd copy. Muxer writes through it; closed by [stop] after muxer.close(). */
     private val outFd: ParcelFileDescriptor,
     private val scrcpyJarPath: String
-) {
+) : RecordingSession {
 
     private companion object {
         private const val TAG = "CV:RecorderServer"
@@ -78,7 +78,7 @@ internal class RecorderSession(
      *
      * @throws IOException if the scrcpy jar is missing or the abstract socket never becomes ready.
      */
-    fun start() {
+    override fun start() {
         // Guard: a missing/empty jar would make app_process fail with ClassNotFound — surface it clearly.
         if (!File(scrcpyJarPath).exists()) {
             throw IOException("scrcpy jar missing at $scrcpyJarPath")
@@ -167,7 +167,7 @@ internal class RecorderSession(
      * socket → close the daemon's received outFd copy → pkill stale. Best-effort throughout. Idempotent
      * (the caller's AtomicBoolean ensures one invocation; each step is independently guarded anyway).
      */
-    fun stop() {
+    override fun stop() {
         AppLogger.i(TAG, "Stopping recording session")
 
         // Stop the parser loop first so it releases the socket read.

--- a/app/src/main/java/com/baba/callvault/server/RecordingSession.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecordingSession.kt
@@ -1,0 +1,27 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.server
+
+/**
+ * One recording pipeline run by the privileged daemon. Two implementations:
+ *  - [DirectAudioRecorderSession] — direct `AudioRecord` → `MediaCodec` → `MediaMuxer` (FAST: no child
+ *    process, no scrcpy jar, captures from the first millisecond — the preferred path).
+ *  - [RecorderSession] — the scrcpy-server child pipeline (fallback for sources/codecs the direct path
+ *    can't handle, e.g. output/playback capture or a device missing the Opus encoder).
+ *
+ * [RecorderServer] chooses the direct path when [DirectAudioRecorderSession.supports] is true and falls
+ * back to scrcpy otherwise. Both are single-use, not thread-safe; the server serialises lifecycle calls.
+ */
+internal interface RecordingSession {
+    /** Starts capture; returns once the pipeline is running (capture continues on its own thread). */
+    fun start()
+
+    /** Tears down the pipeline and finalises the output container. Idempotent, best-effort. */
+    fun stop()
+}

--- a/app/src/main/java/com/baba/callvault/services/boot/BootReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/services/boot/BootReceiver.kt
@@ -13,6 +13,7 @@ import android.content.Context
 import android.content.Intent
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.services.call.CallMonitorService
+import com.baba.callvault.services.recording.DaemonKeepAliveService
 import com.baba.callvault.utils.AppLogger
 
 /**
@@ -29,6 +30,9 @@ class BootReceiver : BroadcastReceiver() {
         // Hold a live telephony listener for a bounded window so the first call(s) after a reboot are
         // detected in real time, instead of via the post-boot-delayed PHONE_STATE broadcast.
         CallMonitorService.start(context)
+        // Persistent anchor: keep the recorder daemon warm from boot onward so calls record instantly
+        // (and off-Wi-Fi over binder) without a per-call cold-start. Boot grants the FGS-start exemption.
+        DaemonKeepAliveService.start(context)
     }
 
     companion object {

--- a/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
+++ b/app/src/main/java/com/baba/callvault/services/call/CallMonitorService.kt
@@ -93,7 +93,7 @@ class CallMonitorService : Service() {
     override fun onCreate() {
         super.onCreate()
         getSystemService(NotificationManager::class.java).createNotificationChannel(
-            NotificationChannel(CHANNEL_ID, getString(R.string.notif_call_monitor_channel), NotificationManager.IMPORTANCE_MIN).apply {
+            NotificationChannel(CHANNEL_ID, getString(R.string.notif_readiness_channel), NotificationManager.IMPORTANCE_MIN).apply {
                 setSound(null, null)
                 setShowBadge(false)
             },
@@ -136,6 +136,10 @@ class CallMonitorService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onDestroy() {
+        // Detach (do NOT remove) the SHARED readiness notification so DaemonKeepAliveService's permanent
+        // one survives this transient post-boot service ending — they share NOTIF_ID + channel so the user
+        // only ever sees ONE readiness notification.
+        runCatching { stopForeground(STOP_FOREGROUND_DETACH) }
         stopHandler.removeCallbacks(windowElapsed)
         readinessHandler.removeCallbacks(readinessPoll)
         unregisterListener()
@@ -228,7 +232,7 @@ class CallMonitorService : Service() {
             )
             .setContentText(
                 getString(
-                    if (ready) R.string.notif_readiness_reboot_ready_text
+                    if (ready) R.string.notif_readiness_ready_text
                     else R.string.notif_readiness_starting_text,
                 ),
             )
@@ -237,8 +241,11 @@ class CallMonitorService : Service() {
 
     companion object {
         private const val TAG = "CV:CallMonitorService"
-        private const val CHANNEL_ID = "call_monitor"
-        private const val NOTIF_ID = 4714
+        // Shares the SINGLE readiness notification with DaemonKeepAliveService (same channel + id) so this
+        // transient post-boot monitor never adds a duplicate "starting up / ready" notification. Detached
+        // (not removed) in onDestroy so the permanent keep-alive notification outlives this service.
+        private const val CHANNEL_ID = "recorder_keepalive"
+        private const val NOTIF_ID = 4720
 
         /** How long after boot the live listener stays registered before the broadcast path takes over. */
         private const val WINDOW_MS = 10 * 60 * 1000L

--- a/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
@@ -1,0 +1,175 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.SystemClock
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.baba.callvault.R
+import com.baba.callvault.server.RecorderConnection
+import com.baba.callvault.server.RecorderServerLauncher
+import com.baba.callvault.utils.AppLogger
+
+/**
+ * Persistent foreground service that keeps CallVault's privileged recorder daemon WARM — our
+ * equivalent of what Shizuku's manager app does for its server: a durable foreground presence that
+ * anchors the app process and actively re-warms the daemon the moment it dies, so a call is captured
+ * instantly (over binder, no Wi-Fi needed) instead of paying a ~10–24s cold-start that outlasts short
+ * calls.
+ *
+ * **Why a foreground service.** OnePlus/ColorOS reaps our detached shell-uid daemon after a few minutes
+ * of idle. Holding a foreground service (a) keeps our own process important, giving the daemon a best-
+ * effort priority anchor, and (b) lets a watchdog notice the daemon died and relaunch it BEFORE the
+ * next call, not during it. Recording itself flows over the daemon's binder, so once warm, calls record
+ * with Wi-Fi off — this service is the thing that keeps it warm.
+ *
+ * **Battery-safe.** The watchdog is a cheap 60s binder-liveness check. A relaunch is only attempted
+ * when the daemon is down AND Wi-Fi is available (Wireless debugging needs Wi-Fi to relaunch) and is
+ * throttled — so off-Wi-Fi idle costs nothing (the daemon simply can't be relaunched there; that gap is
+ * what the opt-in loopback mode covers).
+ */
+class DaemonKeepAliveService : Service() {
+
+    private val watchdogHandler = Handler(Looper.getMainLooper())
+    private var lastReady: Boolean? = null
+
+    @Volatile private var rewarming = false
+    private var lastRewarmAtMs = 0L
+
+    private val watchdog = object : Runnable {
+        override fun run() {
+            val ready = RecorderConnection.isConnected
+            if (ready != lastReady) {
+                lastReady = ready
+                updateNotification(ready)
+                AppLogger.d(TAG, "keep-alive: daemon ready=$ready")
+            }
+            if (!ready) maybeRewarm()
+            watchdogHandler.postDelayed(this, WATCHDOG_INTERVAL_MS)
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        getSystemService(NotificationManager::class.java).createNotificationChannel(
+            NotificationChannel(CHANNEL_ID, getString(R.string.notif_readiness_channel), NotificationManager.IMPORTANCE_MIN).apply {
+                setShowBadge(false)
+                enableVibration(false)
+                setSound(null, null)
+            },
+        )
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val startedForeground = runCatching {
+            startForeground(NOTIF_ID, buildNotification(RecorderConnection.isConnected), ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+        }.onFailure { AppLogger.e(TAG, "keep-alive startForeground failed", it) }.isSuccess
+        if (!startedForeground) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        // Kick the watchdog now (first tick warms the daemon immediately if it's cold).
+        lastReady = null
+        watchdogHandler.removeCallbacks(watchdog)
+        watchdogHandler.post(watchdog)
+        // START_STICKY: if the OS kills us under pressure, restart so the daemon anchor comes back.
+        return START_STICKY
+    }
+
+    /**
+     * Relaunch the daemon if it's down — but only when it can actually succeed (Wi-Fi up, since
+     * Wireless debugging needs it) and not more than once per [REWARM_THROTTLE_MS]. When the daemon is
+     * already connected the [watchdog] never calls this, so an active recording (daemon connected) is
+     * implicitly skipped and never churned.
+     */
+    private fun maybeRewarm() {
+        if (rewarming) return
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastRewarmAtMs < REWARM_THROTTLE_MS) return
+        if (!isWifiConnected()) return // off-Wi-Fi we can't relaunch (WD needs Wi-Fi) — save battery
+        lastRewarmAtMs = now
+        rewarming = true
+        Thread {
+            AppLogger.i(TAG, "keep-alive: daemon down — relaunching over Wi-Fi")
+            runCatching { RecorderServerLauncher.ensureServerRunning(applicationContext) }
+                .onFailure { AppLogger.w(TAG, "keep-alive relaunch failed: ${it.message}") }
+            rewarming = false
+        }.apply { isDaemon = true; name = "cv-keepalive-rewarm" }.start()
+    }
+
+    private fun isWifiConnected(): Boolean = runCatching {
+        val cm = getSystemService(ConnectivityManager::class.java) ?: return false
+        val caps = cm.getNetworkCapabilities(cm.activeNetwork) ?: return false
+        caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+    }.getOrDefault(false)
+
+    private fun updateNotification(ready: Boolean) {
+        runCatching {
+            getSystemService(NotificationManager::class.java).notify(NOTIF_ID, buildNotification(ready))
+        }
+    }
+
+    private fun buildNotification(ready: Boolean): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setContentTitle(
+                getString(if (ready) R.string.notif_readiness_ready_title else R.string.notif_readiness_starting_title),
+            )
+            .setContentText(
+                getString(if (ready) R.string.notif_readiness_ready_text else R.string.notif_readiness_starting_text),
+            )
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_MIN)
+            .setVisibility(NotificationCompat.VISIBILITY_SECRET)
+            .build()
+
+    override fun onDestroy() {
+        watchdogHandler.removeCallbacks(watchdog)
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    companion object {
+        private const val TAG = "CV:DaemonKeepAlive"
+        private const val CHANNEL_ID = "recorder_keepalive"
+        private const val NOTIF_ID = 4720
+
+        /** How often the watchdog checks the daemon is alive. Cheap (a binder ping). */
+        private const val WATCHDOG_INTERVAL_MS = 60_000L
+
+        /** Minimum gap between daemon relaunch attempts, so a persistently-down daemon isn't hammered. */
+        private const val REWARM_THROTTLE_MS = 90_000L
+
+        /** Start (or no-op if already running) the persistent keep-alive anchor. Safe to call repeatedly. */
+        fun start(context: Context) {
+            runCatching {
+                ContextCompat.startForegroundService(context, Intent(context, DaemonKeepAliveService::class.java))
+            }.onFailure { AppLogger.w(TAG, "Failed to start keep-alive service: ${it.message}") }
+        }
+
+        /** Stop the keep-alive anchor (e.g. if the user disables persistence). */
+        fun stop(context: Context) {
+            runCatching { context.stopService(Intent(context, DaemonKeepAliveService::class.java)) }
+        }
+    }
+}

--- a/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
@@ -53,19 +53,37 @@ class DaemonKeepAliveService : Service() {
 
     @Volatile private var rewarming = false
     private var lastRewarmAtMs = 0L
+    /** Consecutive "daemon down" readings — we only relaunch after a couple, to not churn on a blip. */
+    private var downStreak = 0
 
     private val watchdog = object : Runnable {
         override fun run() {
-            val ready = RecorderConnection.isConnected
-            if (ready != lastReady) {
-                lastReady = ready
-                updateNotification(ready)
-                AppLogger.d(TAG, "keep-alive: daemon ready=$ready")
+            val alive = isDaemonAlive()
+            if (alive != (lastReady == true)) {
+                lastReady = alive
+                updateNotification(alive)
+                AppLogger.d(TAG, "keep-alive: daemon alive=$alive")
             }
-            if (!ready) maybeRewarm()
+            if (alive) {
+                downStreak = 0
+            } else {
+                downStreak++
+                // Debounce: act only after DOWN_STREAK_THRESHOLD consecutive down reads, so a transient
+                // binder blip doesn't trigger a relaunch (which would kill+respawn a daemon that was fine).
+                if (downStreak >= DOWN_STREAK_THRESHOLD) maybeRewarm()
+            }
             watchdogHandler.postDelayed(this, WATCHDOG_INTERVAL_MS)
         }
     }
+
+    /**
+     * True only if the daemon process actually answers a binder ping — more reliable than
+     * [RecorderConnection.isConnected] (`service != null`), which can stay stale-true if linkToDeath
+     * missed, or read false on a transient. Matches the recording liveness watch's probe.
+     */
+    private fun isDaemonAlive(): Boolean = runCatching {
+        RecorderConnection.service?.asBinder()?.pingBinder() == true
+    }.getOrDefault(false)
 
     override fun onCreate() {
         super.onCreate()
@@ -159,6 +177,9 @@ class DaemonKeepAliveService : Service() {
 
         /** Minimum gap between daemon relaunch attempts, so a persistently-down daemon isn't hammered. */
         private const val REWARM_THROTTLE_MS = 90_000L
+
+        /** Consecutive down reads before relaunching — debounces a transient binder blip into no action. */
+        private const val DOWN_STREAK_THRESHOLD = 2
 
         /** Start (or no-op if already running) the persistent keep-alive anchor. Safe to call repeatedly. */
         fun start(context: Context) {

--- a/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
@@ -24,6 +24,7 @@ import android.os.SystemClock
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.baba.callvault.R
+import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.server.RecorderServerLauncher
 import com.baba.callvault.utils.AppLogger
@@ -32,19 +33,17 @@ import com.baba.callvault.utils.AppLogger
  * Persistent foreground service that keeps CallVault's privileged recorder daemon WARM — our
  * equivalent of what Shizuku's manager app does for its server: a durable foreground presence that
  * anchors the app process and actively re-warms the daemon the moment it dies, so a call is captured
- * instantly (over binder, no Wi-Fi needed) instead of paying a ~10–24s cold-start that outlasts short
- * calls.
+ * instantly (over binder) instead of paying a cold-start that outlasts a short call.
  *
- * **Why a foreground service.** OnePlus/ColorOS reaps our detached shell-uid daemon after a few minutes
- * of idle. Holding a foreground service (a) keeps our own process important, giving the daemon a best-
- * effort priority anchor, and (b) lets a watchdog notice the daemon died and relaunch it BEFORE the
- * next call, not during it. Recording itself flows over the daemon's binder, so once warm, calls record
- * with Wi-Fi off — this service is the thing that keeps it warm.
+ * **Why a foreground service.** OnePlus/ColorOS reaps our detached shell-uid daemon on idle and on
+ * screen transitions (it restarts adbd, which the daemon dies with). Holding a foreground service (a)
+ * keeps our own process important, and (b) lets us notice the daemon died and relaunch it — ideally
+ * BEFORE the next call. Recording itself flows over the daemon's binder, so once warm, calls record
+ * even with Wi-Fi off (over the opt-in loopback transport).
  *
- * **Battery-safe.** The watchdog is a cheap 60s binder-liveness check. A relaunch is only attempted
- * when the daemon is down AND Wi-Fi is available (Wireless debugging needs Wi-Fi to relaunch) and is
- * throttled — so off-Wi-Fi idle costs nothing (the daemon simply can't be relaunched there; that gap is
- * what the opt-in loopback mode covers).
+ * **Fast recovery.** A confirmed binder-death ([onDaemonDiedImmediate]) relaunches immediately, and the
+ * notification flips to "ready" the instant the relaunch succeeds. A cheap 60s binder-liveness watchdog
+ * is the backup for a death we somehow missed.
  */
 class DaemonKeepAliveService : Service() {
 
@@ -126,28 +125,39 @@ class DaemonKeepAliveService : Service() {
             lastReady = false
             updateNotification(false)
             downStreak = DOWN_STREAK_THRESHOLD // death confirmed — no debounce needed
-            maybeRewarm()
+            // Confirmed death (linkToDeath) is authoritative — relaunch NOW, bypassing the throttle.
+            // The throttle exists to avoid HAMMERING a failed relaunch, NOT to delay a genuine recovery:
+            // on OnePlus the daemon dies on every screen transition, so a death shortly after a prior
+            // relaunch was being throttled — the cause of a long "starting up" window a call would race.
+            maybeRewarm(force = true)
         }
     }
 
     /**
-     * Relaunch the daemon if it's down — but only when it can actually succeed (Wi-Fi up, since
-     * Wireless debugging needs it) and not more than once per [REWARM_THROTTLE_MS]. When the daemon is
-     * already connected the [watchdog] never calls this, so an active recording (daemon connected) is
-     * implicitly skipped and never churned.
+     * Relaunch the daemon if it's down. [force] (a confirmed binder-death) bypasses the throttle so a
+     * genuine recovery isn't delayed; the un-forced watchdog path still throttles to avoid hammering a
+     * relaunch that keeps failing. Loopback records off-Wi-Fi, so only the non-offline (Wireless
+     * Debugging) relaunch path requires Wi-Fi. When the daemon is already connected the [watchdog] never
+     * calls this, so an active recording is implicitly skipped and never churned.
      */
-    private fun maybeRewarm() {
+    private fun maybeRewarm(force: Boolean = false) {
         if (rewarming) return
         val now = SystemClock.elapsedRealtime()
-        if (now - lastRewarmAtMs < REWARM_THROTTLE_MS) return
-        if (!isWifiConnected()) return // off-Wi-Fi we can't relaunch (WD needs Wi-Fi) — save battery
+        if (!force && now - lastRewarmAtMs < REWARM_THROTTLE_MS) return
+        val offline = runCatching { AppPreferences(this).isOfflineRecordingEnabled() }.getOrDefault(false)
+        if (!offline && !isWifiConnected()) return // the WD relaunch path needs Wi-Fi; loopback doesn't
         lastRewarmAtMs = now
         rewarming = true
         Thread {
-            AppLogger.i(TAG, "keep-alive: daemon down — relaunching over Wi-Fi")
-            runCatching { RecorderServerLauncher.ensureServerRunning(applicationContext) }
+            AppLogger.i(TAG, "keep-alive: daemon down — relaunching (force=$force offline=$offline)")
+            val ok = runCatching { RecorderServerLauncher.ensureServerRunning(applicationContext) }
                 .onFailure { AppLogger.w(TAG, "keep-alive relaunch failed: ${it.message}") }
+                .getOrDefault(false)
             rewarming = false
+            // Flip the notification to "ready" the INSTANT the relaunch succeeds — don't wait for the next
+            // 60s watchdog tick. Without this the daemon reconnects in seconds but the user would still see
+            // "starting up" for up to a minute (a perceived-but-false slow recovery).
+            if (ok) watchdogHandler.post { lastReady = true; updateNotification(true) }
         }.apply { isDaemon = true; name = "cv-keepalive-rewarm" }.start()
     }
 
@@ -194,8 +204,13 @@ class DaemonKeepAliveService : Service() {
         /** How often the watchdog checks the daemon is alive. Cheap (a binder ping). */
         private const val WATCHDOG_INTERVAL_MS = 60_000L
 
-        /** Minimum gap between daemon relaunch attempts, so a persistently-down daemon isn't hammered. */
-        private const val REWARM_THROTTLE_MS = 90_000L
+        /**
+         * Minimum gap between UN-FORCED (watchdog) relaunch attempts, so a persistently-failing relaunch
+         * isn't hammered. A confirmed binder-death relaunches immediately via `maybeRewarm(force = true)`
+         * and ignores this. Kept modest (was 90s — which delayed real recoveries when the daemon died
+         * shortly after a prior relaunch, as it does on every OnePlus screen transition).
+         */
+        private const val REWARM_THROTTLE_MS = 20_000L
 
         /** Consecutive down reads before relaunching — debounces a transient binder blip into no action. */
         private const val DOWN_STREAK_THRESHOLD = 2

--- a/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
@@ -104,12 +104,30 @@ class DaemonKeepAliveService : Service() {
             stopSelf()
             return START_NOT_STICKY
         }
+        // Recover the INSTANT the daemon dies (binder linkToDeath) — don't wait for the next poll.
+        // On a real incoming call this is what races (and hopefully beats) the call after a long idle.
+        RecorderConnection.onDeath = { onDaemonDiedImmediate() }
         // Kick the watchdog now (first tick warms the daemon immediately if it's cold).
         lastReady = null
         watchdogHandler.removeCallbacks(watchdog)
         watchdogHandler.post(watchdog)
         // START_STICKY: if the OS kills us under pressure, restart so the daemon anchor comes back.
         return START_STICKY
+    }
+
+    /**
+     * Called from [RecorderConnection.onDeath] the moment the daemon binder dies — an authoritative
+     * "process gone" signal (linkToDeath only fires on real death). Relaunch immediately, skipping the
+     * poll interval AND the debounce. Posted to the handler so we're off the binder thread.
+     */
+    private fun onDaemonDiedImmediate() {
+        watchdogHandler.post {
+            AppLogger.i(TAG, "keep-alive: binder-death signal — relaunching immediately")
+            lastReady = false
+            updateNotification(false)
+            downStreak = DOWN_STREAK_THRESHOLD // death confirmed — no debounce needed
+            maybeRewarm()
+        }
     }
 
     /**
@@ -162,6 +180,7 @@ class DaemonKeepAliveService : Service() {
 
     override fun onDestroy() {
         watchdogHandler.removeCallbacks(watchdog)
+        RecorderConnection.onDeath = null
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/baba/callvault/system/updates/UpdatePackageReplacedReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/system/updates/UpdatePackageReplacedReceiver.kt
@@ -13,12 +13,25 @@ import android.content.Context
 import android.content.Intent
 import com.baba.callvault.BuildConfig
 import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.integrations.adb.AdbShell
+import com.baba.callvault.server.RecorderServerLauncher
 import com.baba.callvault.utils.AppLogger
 
 /**
  * Fires after THIS app was replaced by an update. When the updater initiated that install (the
  * pending tag is set), posts the success notification and clears all updater state. Updates
  * installed by other means (manual sideload, Obtainium) simply clear any stale state silently.
+ *
+ * **WRITE_SECURE_SETTINGS self-heal (the 1.4.0 incremental-update incident).** An install-over
+ * (Obtainium / manual sideload — NOT the in-app updater, which re-grants inline) DROPS the app's
+ * runtime WRITE_SECURE_SETTINGS grant. Without it the app can't re-enable Wireless debugging, so it
+ * can never reconnect ADB to relaunch the recorder daemon → recording silently dies until a clean
+ * reinstall. We recover WITHOUT a reinstall: right after replacement a transport often still
+ * survives — loopback (offline mode; `service.adb.tcp.port` persists) or Wireless debugging that
+ * wasn't turned off yet — and [RecorderServerLauncher.ensureServerRunning] → [AdbShell.ensureConnected]
+ * self-grants WRITE_SECURE_SETTINGS over that shell (`pm grant`) and relaunches the daemon. When no
+ * transport survives (WD off + offline mode off) the app can't self-heal here; Home then surfaces the
+ * `UPDATE_REGRANT_NEEDED` status telling the user to toggle Wireless debugging on once.
  */
 class UpdatePackageReplacedReceiver : BroadcastReceiver() {
 
@@ -36,6 +49,30 @@ class UpdatePackageReplacedReceiver : BroadcastReceiver() {
         preferences.setLastNotifiedUpdateTag(null)
         UpdateNotifications.cancelAvailable(context)
         UpdateManager.cleanupDownloadCache(context)
+
+        recoverAfterReplace(context.applicationContext)
+    }
+
+    /**
+     * Best-effort, off the broadcast thread: reconnect over any surviving transport so
+     * [AdbShell.ensureConnected] re-grants WRITE_SECURE_SETTINGS (`pm grant`) and the daemon relaunches.
+     * Skipped when the grant already survived (in-app updater re-grants inline). Harmless no-op when no
+     * transport survives — the Home `UPDATE_REGRANT_NEEDED` banner then guides the one-time WD toggle.
+     */
+    private fun recoverAfterReplace(context: Context) {
+        if (AdbShell.hasWriteSecureSettings(context)) {
+            AppLogger.d(TAG, "WRITE_SECURE_SETTINGS survived the update; no post-replace recovery needed")
+            return
+        }
+        AppLogger.i(TAG, "WRITE_SECURE_SETTINGS lost on update; attempting reconnect self-heal + daemon relaunch")
+        Thread {
+            runCatching { RecorderServerLauncher.ensureServerRunning(context) }
+                .onSuccess { ok ->
+                    val healed = AdbShell.hasWriteSecureSettings(context)
+                    AppLogger.i(TAG, "Post-replace recovery: daemon=$ok, WRITE_SECURE_SETTINGS regranted=$healed")
+                }
+                .onFailure { AppLogger.w(TAG, "Post-replace recovery failed (no surviving transport?): ${it.message}") }
+        }.apply { isDaemon = true; name = "cv-post-update-recover" }.start()
     }
 
     companion object {

--- a/app/src/main/java/com/baba/callvault/ui/common/OfflineRecordingDialog.kt
+++ b/app/src/main/java/com/baba/callvault/ui/common/OfflineRecordingDialog.kt
@@ -1,0 +1,143 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.ui.common
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.baba.callvault.R
+import com.baba.callvault.integrations.adb.OfflineRecording
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/** Whether the dialog is turning off-Wi-Fi recording ON (with a warning gate) or OFF. */
+enum class OfflineDialogMode { ENABLE, DISABLE }
+
+private enum class OfflinePhase { WARNING, WORKING, SUCCESS, FAILED }
+
+private const val SUCCESS_AUTO_CLOSE_MS = 3_000L
+
+/**
+ * Walks the user through enabling/disabling off-Wi-Fi (loopback) recording WITH live feedback, so the
+ * ADB work (arming/disarming — a few seconds, incl. a brief Wireless-Debugging blip) is never a silent
+ * wait. The dialog itself is the feedback — there is no toast.
+ *
+ *  - [OfflineDialogMode.ENABLE]:  security warning → a live "enabling…" spinner (no buttons, can't be
+ *    dismissed mid-arm) → "it's on" with a Confirm button that also **auto-closes after 3 s**; or a
+ *    failure message with OK.
+ *  - [OfflineDialogMode.DISABLE]: a live "turning off…" spinner, then it closes on its own.
+ *
+ * @param onResult Reports the final enabled state (true after a successful arm, false otherwise) so the
+ *                 caller can sync its toggle. Always called before the dialog closes.
+ * @param onClose  Dismisses the dialog (clear the caller's "show dialog" flag).
+ */
+@Composable
+fun OfflineRecordingDialog(
+    mode: OfflineDialogMode,
+    onResult: (enabled: Boolean) -> Unit,
+    onClose: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var phase by remember {
+        mutableStateOf(if (mode == OfflineDialogMode.ENABLE) OfflinePhase.WARNING else OfflinePhase.WORKING)
+    }
+
+    // DISABLE has no warning gate — start the work immediately and close when it's done.
+    LaunchedEffect(Unit) {
+        if (mode == OfflineDialogMode.DISABLE) {
+            withContext(Dispatchers.IO) { OfflineRecording.disable(context) }
+            onResult(false)
+            onClose()
+        }
+    }
+
+    // Auto-close a short moment after a successful enable; the Confirm button can close it sooner.
+    LaunchedEffect(phase) {
+        if (phase == OfflinePhase.SUCCESS) {
+            delay(SUCCESS_AUTO_CLOSE_MS)
+            onClose()
+        }
+    }
+
+    val titleContent: (@Composable () -> Unit)? =
+        if (phase == OfflinePhase.WARNING) {
+            { Text(stringResource(R.string.offline_recording_warning_title)) }
+        } else {
+            null
+        }
+
+    // While WORKING the dialog is not dismissable — the arm/disarm must not be interrupted.
+    val dismissable = phase != OfflinePhase.WORKING
+
+    AlertDialog(
+        onDismissRequest = { if (dismissable) onClose() },
+        title = titleContent,
+        text = {
+            when (phase) {
+                OfflinePhase.WARNING -> Text(stringResource(R.string.offline_recording_warning_message))
+                OfflinePhase.WORKING -> WorkingRow(
+                    if (mode == OfflineDialogMode.ENABLE) R.string.home_whatsnew_offline_enabling
+                    else R.string.offline_recording_disabling,
+                )
+                OfflinePhase.SUCCESS -> Text(stringResource(R.string.offline_recording_on))
+                OfflinePhase.FAILED -> Text(stringResource(R.string.home_whatsnew_offline_failed))
+            }
+        },
+        confirmButton = {
+            when (phase) {
+                OfflinePhase.WARNING -> TextButton(onClick = {
+                    phase = OfflinePhase.WORKING
+                    scope.launch {
+                        val armed = withContext(Dispatchers.IO) { OfflineRecording.enable(context) }
+                        onResult(armed)
+                        phase = if (armed) OfflinePhase.SUCCESS else OfflinePhase.FAILED
+                    }
+                }) { Text(stringResource(R.string.offline_recording_warning_continue)) }
+                OfflinePhase.SUCCESS, OfflinePhase.FAILED ->
+                    TextButton(onClick = onClose) { Text(stringResource(R.string.general_ok)) }
+                OfflinePhase.WORKING -> Unit // no button while the work is in flight
+            }
+        },
+        dismissButton = {
+            if (phase == OfflinePhase.WARNING) {
+                TextButton(onClick = onClose) { Text(stringResource(R.string.general_cancel)) }
+            }
+        },
+    )
+}
+
+@Composable
+private fun WorkingRow(@StringRes textRes: Int) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+        Spacer(Modifier.width(12.dp))
+        Text(stringResource(textRes))
+    }
+}

--- a/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
@@ -69,6 +69,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.baba.callvault.ui.common.OfflineDialogMode
+import com.baba.callvault.ui.common.OfflineRecordingDialog
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -124,6 +126,11 @@ fun HomeScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val playback by viewModel.playback.collectAsState()
+    // Show the "What's new" note once after an update lands (driven by the same signal as the banner).
+    var showWhatsNew by remember { mutableStateOf(false) }
+    LaunchedEffect(uiState.updatedToVersion) {
+        if (uiState.updatedToVersion != null) showWhatsNew = true
+    }
 
     // Refresh status + recordings whenever the user returns to the screen (e.g. after a new call).
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -156,6 +163,14 @@ fun HomeScreen(
             }
         }
     ) { innerPadding ->
+        if (showWhatsNew) {
+            WhatsNewDialog(
+                onDismiss = {
+                    showWhatsNew = false
+                    viewModel.dismissUpdatedBanner()
+                },
+            )
+        }
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(
@@ -235,6 +250,7 @@ fun HomeScreen(
                     RecordingRow(
                         item = item,
                         playback = playback,
+                        deleting = item.uri in uiState.deletingUris,
                         onPlayUri = { uri -> viewModel.play(uri) },
                         onPause = { viewModel.pausePlayback() },
                         onResume = { viewModel.resumePlayback() },
@@ -245,6 +261,39 @@ fun HomeScreen(
                 }
             }
         }
+    }
+}
+
+/**
+ * Post-update "What's new" note — plain-language highlights of the release, with a one-tap opt-in to
+ * enable off-Wi-Fi (loopback) recording behind the same security warning as the Settings toggle.
+ * [onDismiss] closes the note AND clears the updated-banner so it doesn't reappear.
+ */
+@Composable
+private fun WhatsNewDialog(onDismiss: () -> Unit) {
+    var showOfflineDialog by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.home_whatsnew_title)) },
+        text = { Text(stringResource(R.string.home_whatsnew_body)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.general_ok)) }
+        },
+        dismissButton = {
+            TextButton(onClick = { showOfflineDialog = true }) {
+                Text(stringResource(R.string.home_whatsnew_offline_cta))
+            }
+        },
+    )
+    if (showOfflineDialog) {
+        // Shared enable flow: security warning → live spinner → "it's on" (auto-closes). The What's New
+        // note stays open behind it, so the user lands back on it and taps OK to dismiss.
+        OfflineRecordingDialog(
+            mode = OfflineDialogMode.ENABLE,
+            onResult = { },
+            onClose = { showOfflineDialog = false },
+        )
     }
 }
 
@@ -715,6 +764,7 @@ private sealed interface DeleteTarget {
 private fun RecordingRow(
     item: RecordingItem,
     playback: RecordingPlaybackController.PlaybackState,
+    deleting: Boolean,
     onPlayUri: (Uri) -> Unit,
     onPause: () -> Unit,
     onResume: () -> Unit,
@@ -831,17 +881,25 @@ private fun RecordingRow(
                 }
             }
             // Main-row delete: BOTH rows delete every copy; single-source rows delete their one file.
-            IconButton(
-                onClick = {
-                    deleteTarget = if (isBoth) DeleteTarget.All else DeleteTarget.Single(item.uri)
+            // While the delete (and any cloud-copy removal) is in flight, show a live spinner in the
+            // delete button's place — the row then vanishes on the list refresh. No modal.
+            if (deleting) {
+                Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
                 }
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Delete,
-                    contentDescription = stringResource(R.string.home_delete),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(20.dp)
-                )
+            } else {
+                IconButton(
+                    onClick = {
+                        deleteTarget = if (isBoth) DeleteTarget.All else DeleteTarget.Single(item.uri)
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = stringResource(R.string.home_delete),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
@@ -12,6 +12,8 @@ import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.ui.platform.LocalContext
+import com.baba.callvault.system.openWirelessDebugging
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.input.pointer.pointerInput
@@ -124,6 +126,7 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = viewModel()
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
     val playback by viewModel.playback.collectAsState()
     // Show the "What's new" note once after an update lands (driven by the same signal as the banner).
@@ -181,7 +184,16 @@ fun HomeScreen(
             ),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            item { HeroStatusCard(status = uiState.status) }
+            item {
+                HeroStatusCard(
+                    status = uiState.status,
+                    onAction = if (uiState.status == HomeViewModel.HomeStatus.UPDATE_REGRANT_NEEDED) {
+                        { context.openWirelessDebugging() }
+                    } else {
+                        null
+                    },
+                )
+            }
 
             uiState.updatedToVersion?.let { version ->
                 item {
@@ -406,7 +418,10 @@ private fun UpdateBannerCard(
  * unmistakable.
  */
 @Composable
-private fun HeroStatusCard(status: HomeViewModel.HomeStatus) {
+private fun HeroStatusCard(
+    status: HomeViewModel.HomeStatus,
+    onAction: (() -> Unit)? = null,
+) {
     val brand = LocalCvBrand.current
     val accent: Color = if (status.isReady) MaterialTheme.colorScheme.primary else brand.warning
     val icon: ImageVector = if (status.isReady) Icons.Filled.CheckCircle else Icons.Filled.WarningAmber
@@ -415,18 +430,20 @@ private fun HeroStatusCard(status: HomeViewModel.HomeStatus) {
         HomeViewModel.HomeStatus.NOT_PAIRED -> CvTone.Warning
         HomeViewModel.HomeStatus.NO_FOLDER -> CvTone.Error
         HomeViewModel.HomeStatus.DEV_OPTIONS_OFF -> CvTone.Error
+        HomeViewModel.HomeStatus.UPDATE_REGRANT_NEEDED -> CvTone.Warning
     }
     val pillText = when (status) {
         HomeViewModel.HomeStatus.READY -> stringResource(R.string.home_hero_pill_ready)
         HomeViewModel.HomeStatus.NOT_PAIRED -> stringResource(R.string.home_hero_pill_not_paired)
         HomeViewModel.HomeStatus.NO_FOLDER -> stringResource(R.string.home_hero_pill_no_folder)
         HomeViewModel.HomeStatus.DEV_OPTIONS_OFF -> stringResource(R.string.home_hero_pill_dev_options_off)
+        HomeViewModel.HomeStatus.UPDATE_REGRANT_NEEDED -> stringResource(R.string.home_hero_pill_update_regrant)
     }
 
     // Subtle accent-tinted surface so the banner reads as a confident state, not a stock card.
     val tinted = accent.copy(alpha = 0.10f).compositeOver(MaterialTheme.colorScheme.surface)
 
-    CvCard(color = tinted, contentPadding = PaddingValues(20.dp)) {
+    CvCard(color = tinted, onClick = onAction, contentPadding = PaddingValues(20.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -94,6 +94,9 @@ import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Vibration
+import androidx.compose.material.icons.filled.WifiOff
+import com.baba.callvault.integrations.adb.AdbShell
+import com.baba.callvault.server.RecorderServerLauncher
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalResources
 import org.xmlpull.v1.XmlPullParser
@@ -985,6 +988,85 @@ private fun BugReportSection(
                 Spacer(modifier = Modifier.height(4.dp))
             }
         }
+
+        OfflineRecordingToggle()
+    }
+}
+
+/**
+ * Opt-in "Offline recording (no Wi-Fi)" toggle. Turning it ON pops a security-warning modal
+ * (Cancel / Continue anyway) because it arms a local `adb tcpip` debugging port; only on "Continue"
+ * do we persist the opt-in, arm the loopback listener, and re-warm the daemon. Turning it OFF clears
+ * the opt-in and best-effort closes the port (reverts adbd to USB mode).
+ */
+@Composable
+private fun OfflineRecordingToggle() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val prefs = remember { AppPreferences(context) }
+    var enabled by remember { mutableStateOf(prefs.isOfflineRecordingEnabled()) }
+    var showWarning by remember { mutableStateOf(false) }
+    var busy by remember { mutableStateOf(false) }
+
+    SettingsToggleRow(
+        icon = Icons.Filled.WifiOff,
+        label = stringResource(R.string.settings_offline_recording_label),
+        description = stringResource(R.string.settings_offline_recording_desc),
+        checked = enabled,
+        enabled = !busy,
+        onCheckedChange = { turnOn ->
+            if (turnOn) {
+                // Don't enable yet — confirm the security tradeoff first.
+                showWarning = true
+            } else {
+                enabled = false
+                prefs.setOfflineRecordingEnabled(false)
+                busy = true
+                scope.launch {
+                    withContext(Dispatchers.IO) { runCatching { AdbShell.disarmLoopback(context) } }
+                    busy = false
+                    Toast.makeText(context, "Offline recording disabled", Toast.LENGTH_SHORT).show()
+                }
+            }
+        },
+    )
+
+    if (showWarning) {
+        AlertDialog(
+            onDismissRequest = { showWarning = false },
+            title = { Text(stringResource(R.string.offline_recording_warning_title)) },
+            text = { Text(stringResource(R.string.offline_recording_warning_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showWarning = false
+                    enabled = true
+                    prefs.setOfflineRecordingEnabled(true)
+                    busy = true
+                    scope.launch {
+                        val armed = withContext(Dispatchers.IO) {
+                            val ok = AdbShell.armLoopbackIfNeeded(context)
+                            // Arming restarts adbd and kills the daemon — re-warm so the first off-WiFi call records.
+                            if (ok) runCatching { RecorderServerLauncher.ensureServerRunning(context) }
+                            ok
+                        }
+                        busy = false
+                        if (armed) {
+                            Toast.makeText(context, "Offline recording enabled", Toast.LENGTH_SHORT).show()
+                        } else {
+                            // Couldn't arm (needs Wi-Fi + Wireless debugging once) — revert the opt-in.
+                            enabled = false
+                            prefs.setOfflineRecordingEnabled(false)
+                            Toast.makeText(context, "Couldn't enable — connect on Wi-Fi once, then retry", Toast.LENGTH_LONG).show()
+                        }
+                    }
+                }) { Text(stringResource(R.string.offline_recording_warning_continue)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showWarning = false /* leave the toggle OFF */ }) {
+                    Text(stringResource(R.string.general_cancel))
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -95,8 +95,8 @@ import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.WifiOff
-import com.baba.callvault.integrations.adb.AdbShell
-import com.baba.callvault.server.RecorderServerLauncher
+import com.baba.callvault.ui.common.OfflineDialogMode
+import com.baba.callvault.ui.common.OfflineRecordingDialog
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalResources
 import org.xmlpull.v1.XmlPullParser
@@ -1002,70 +1002,27 @@ private fun BugReportSection(
 @Composable
 private fun OfflineRecordingToggle() {
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
     val prefs = remember { AppPreferences(context) }
     var enabled by remember { mutableStateOf(prefs.isOfflineRecordingEnabled()) }
-    var showWarning by remember { mutableStateOf(false) }
-    var busy by remember { mutableStateOf(false) }
+    // Non-null while the enable/disable dialog is walking the user through the ADB work with live feedback.
+    var dialogMode by remember { mutableStateOf<OfflineDialogMode?>(null) }
 
     SettingsToggleRow(
         icon = Icons.Filled.WifiOff,
         label = stringResource(R.string.settings_offline_recording_label),
         description = stringResource(R.string.settings_offline_recording_desc),
         checked = enabled,
-        enabled = !busy,
+        enabled = dialogMode == null,
         onCheckedChange = { turnOn ->
-            if (turnOn) {
-                // Don't enable yet — confirm the security tradeoff first.
-                showWarning = true
-            } else {
-                enabled = false
-                prefs.setOfflineRecordingEnabled(false)
-                busy = true
-                scope.launch {
-                    withContext(Dispatchers.IO) { runCatching { AdbShell.disarmLoopback(context) } }
-                    busy = false
-                    Toast.makeText(context, "Offline recording disabled", Toast.LENGTH_SHORT).show()
-                }
-            }
+            dialogMode = if (turnOn) OfflineDialogMode.ENABLE else OfflineDialogMode.DISABLE
         },
     )
 
-    if (showWarning) {
-        AlertDialog(
-            onDismissRequest = { showWarning = false },
-            title = { Text(stringResource(R.string.offline_recording_warning_title)) },
-            text = { Text(stringResource(R.string.offline_recording_warning_message)) },
-            confirmButton = {
-                TextButton(onClick = {
-                    showWarning = false
-                    enabled = true
-                    prefs.setOfflineRecordingEnabled(true)
-                    busy = true
-                    scope.launch {
-                        val armed = withContext(Dispatchers.IO) {
-                            val ok = AdbShell.armLoopbackIfNeeded(context)
-                            // Arming restarts adbd and kills the daemon — re-warm so the first off-WiFi call records.
-                            if (ok) runCatching { RecorderServerLauncher.ensureServerRunning(context) }
-                            ok
-                        }
-                        busy = false
-                        if (armed) {
-                            Toast.makeText(context, "Offline recording enabled", Toast.LENGTH_SHORT).show()
-                        } else {
-                            // Couldn't arm (needs Wi-Fi + Wireless debugging once) — revert the opt-in.
-                            enabled = false
-                            prefs.setOfflineRecordingEnabled(false)
-                            Toast.makeText(context, "Couldn't enable — connect on Wi-Fi once, then retry", Toast.LENGTH_LONG).show()
-                        }
-                    }
-                }) { Text(stringResource(R.string.offline_recording_warning_continue)) }
-            },
-            dismissButton = {
-                TextButton(onClick = { showWarning = false /* leave the toggle OFF */ }) {
-                    Text(stringResource(R.string.general_cancel))
-                }
-            },
+    dialogMode?.let { mode ->
+        OfflineRecordingDialog(
+            mode = mode,
+            onResult = { nowEnabled -> enabled = nowEnabled },
+            onClose = { dialogMode = null },
         )
     }
 }

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
@@ -22,6 +22,7 @@ import com.baba.callvault.utils.AppLogger
 import com.baba.callvault.data.recordings.RecordingsRepository
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingItem
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingSource
+import com.baba.callvault.integrations.adb.AdbShell
 import com.baba.callvault.integrations.adb.DeveloperOptions
 import com.baba.callvault.system.updates.UpdateInstallWorker
 import com.baba.callvault.system.updates.UpdateScheduler
@@ -70,6 +71,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         NO_FOLDER(R.string.home_status_no_folder_title, R.string.home_status_no_folder_suggestion),
         NOT_PAIRED(R.string.home_status_not_paired_title, R.string.home_status_not_paired_suggestion),
         DEV_OPTIONS_OFF(R.string.home_status_dev_options_off_title, R.string.home_status_dev_options_off_suggestion),
+        UPDATE_REGRANT_NEEDED(R.string.home_status_update_regrant_title, R.string.home_status_update_regrant_suggestion),
         READY(R.string.home_status_ready_title, R.string.home_status_ready_suggestion, isReady = true)
     }
 
@@ -373,6 +375,12 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         // isExplicitlyDisabled (not !isEnabled): an absent/unreadable global must not paint a
         // permanent red banner on ROMs that don't expose the setting.
         if (DeveloperOptions.isExplicitlyDisabled(appContext)) return HomeStatus.DEV_OPTIONS_OFF
+        // Paired + dev options on, but WRITE_SECURE_SETTINGS is gone → an install-over (Obtainium /
+        // manual sideload) dropped the grant and no transport survived to self-heal it. The app can't
+        // re-enable Wireless debugging, so the daemon can't be relaunched: recording is dead until the
+        // user toggles Wireless debugging on once (which lets ensureConnected re-grant it). Once granted
+        // the permission persists, so "paired but missing" reliably means "an update cleared it".
+        if (!AdbShell.hasWriteSecureSettings(appContext)) return HomeStatus.UPDATE_REGRANT_NEEDED
         return HomeStatus.READY
     }
 

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
@@ -16,6 +16,9 @@ import androidx.lifecycle.viewModelScope
 import com.baba.callvault.R
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.data.recordings.RecordingDirection
+import androidx.documentfile.provider.DocumentFile
+import com.baba.callvault.data.recordings.RecordingCatalog
+import com.baba.callvault.utils.AppLogger
 import com.baba.callvault.data.recordings.RecordingsRepository
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingItem
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingSource
@@ -118,7 +121,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         /** Download percentage (0-100) while installing, or -1 before the download reports. */
         val updateProgressPercent: Int = -1,
         /** Version name to show a dismissable "updated successfully" banner for, or null. */
-        val updatedToVersion: String? = null
+        val updatedToVersion: String? = null,
+        /** Uris of recordings currently being deleted — drives an inline spinner on their row. */
+        val deletingUris: Set<Uri> = emptySet()
     ) {
         /**
          * The distinct contact keys present in [recordings], sorted A→Z case-insensitively. Each
@@ -196,7 +201,47 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         detectJustUpdated()
         refresh()
         observeInstallWork()
+        observePlaybackErrors()
         preferences.registerChangeListener(prefsListener)
+    }
+
+    /** The last uri whose playback ERROR we handled, so we prune it at most once per failure. */
+    private var lastHandledErrorUri: Uri? = null
+
+    /**
+     * When a recording fails to play, verify the file still exists; if it was deleted OUTSIDE the app
+     * (e.g. removed directly in Google Drive, or a device file cleaned up externally), prune the now-stale
+     * catalog entry and refresh so the dead row disappears instead of lingering with a "couldn't play"
+     * error. Only prunes on a CONFIRMED-missing file — a transient/network error (exists() throws) leaves
+     * the entry untouched, so a valid recording is never removed by a hiccup.
+     */
+    private fun observePlaybackErrors() {
+        viewModelScope.launch {
+            playbackController.state.collect { state ->
+                val uri = state.activeUri
+                if (state.phase == RecordingPlaybackController.Phase.ERROR && uri != null) {
+                    if (uri != lastHandledErrorUri) {
+                        lastHandledErrorUri = uri
+                        pruneIfMissing(uri)
+                    }
+                } else {
+                    lastHandledErrorUri = null // a fresh play — re-arm handling for a later failure
+                }
+            }
+        }
+    }
+
+    private fun pruneIfMissing(uri: Uri) {
+        viewModelScope.launch {
+            val missing = withContext(Dispatchers.IO) {
+                runCatching { DocumentFile.fromSingleUri(appContext, uri)?.exists() == false }.getOrDefault(false)
+            }
+            if (missing) {
+                AppLogger.i("CV:HomeViewModel", "Recording gone (deleted outside the app); pruning stale entry: $uri")
+                withContext(Dispatchers.IO) { RecordingCatalog.removeCopyByUri(appContext, uri) }
+                refresh()
+            }
+        }
     }
 
     /**
@@ -343,9 +388,11 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         if (active == item.uri || active == item.localUri || active == item.driveUri) {
             playbackController.stop()
         }
+        _uiState.update { it.copy(deletingUris = it.deletingUris + item.uri) }
         viewModelScope.launch {
             withContext(Dispatchers.IO) { RecordingsRepository.deleteRecording(appContext, item) }
             refresh()
+            _uiState.update { it.copy(deletingUris = it.deletingUris - item.uri) }
         }
     }
 
@@ -356,9 +403,11 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
      */
     fun deleteUri(uri: Uri) {
         if (playback.value.activeUri == uri) playbackController.stop()
+        _uiState.update { it.copy(deletingUris = it.deletingUris + uri) }
         viewModelScope.launch {
             withContext(Dispatchers.IO) { RecordingsRepository.deleteFile(appContext, uri) }
             refresh()
+            _uiState.update { it.copy(deletingUris = it.deletingUris - uri) }
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -158,6 +158,11 @@
     <string name="settings_recording_folder_label">Aufnahmeordner</string>
     <string name="folder_cloud_rejected">Cloud-Ordner (wie Google Drive) können nicht für Aufnahmen verwendet werden. Wählen Sie einen Speicherort auf dem Gerät – nutzen Sie die Google Drive-Backup-Option für Cloud-Kopien.</string>
     <string name="folder_cloud_warning">⚠ Dieser Aufnahmeordner liegt in der Cloud, was für die Aufnahme unzuverlässig ist. Wählen Sie einen Ordner auf dem Gerät.</string>
+    <string name="settings_offline_recording_label">Offline-Aufnahme (ohne Wi-Fi)</string>
+    <string name="settings_offline_recording_desc">Anrufe auch dann aufnehmen, wenn kein Wi-Fi-Netzwerk verfügbar ist.</string>
+    <string name="offline_recording_warning_title">Offline-Aufnahme aktivieren?</string>
+    <string name="offline_recording_warning_message">Dadurch wird ein lokaler Debugging-Port auf Ihrem Telefon geöffnet, damit Anrufe ohne Wi-Fi aufgenommen werden können. Er ist durch den Schlüssel Ihres Geräts geschützt, stellt aber einen kleinen Sicherheitskompromiss dar. Aktivieren Sie ihn nur, wenn Sie Anrufe ohne Wi-Fi aufnehmen müssen.</string>
+    <string name="offline_recording_warning_continue">Trotzdem fortfahren</string>
     <string name="settings_section_about">Über</string>
     <string name="settings_section_audio">Tonkonfiguration</string>
     <string name="settings_section_debug">Debug-Optionen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -57,6 +57,8 @@
     <string name="home_status_not_paired_suggestion">Schließen Sie die Kopplung für drahtloses Debugging in der Einrichtung ab.</string>
     <string name="home_status_not_paired_title">Einrichtung nicht abgeschlossen</string>
     <string name="home_status_ready_suggestion">CallVault zeichnet Anrufe automatisch gemäß Ihren Einstellungen auf.</string>
+    <string name="home_status_update_regrant_title">Aufnahme nach Update pausiert</string>
+    <string name="home_status_update_regrant_suggestion">Das Update hat eine von CallVault benötigte Berechtigung entfernt. Tippe hier und aktiviere das WLAN-Debugging einmal – die Aufnahme stellt sich von selbst wieder her. Keine Neuinstallation nötig.</string>
     <string name="home_status_ready_title">Bereit zur Aufnahme</string>
     <string name="permission_adb_description">Erforderlich, um Anruf-Audio aufzuzeichnen. Einmal über die Benachrichtigung koppeln, danach verbindet es sich automatisch.</string>
     <string name="permission_adb_not_connected">Nicht verbunden — zum Einrichten tippen</string>

--- a/app/src/main/res/values-de/strings_home.xml
+++ b/app/src/main/res/values-de/strings_home.xml
@@ -10,6 +10,7 @@
     <string name="home_recordings_empty_hint">Wenn CallVault einen Anruf aufzeichnet, erscheint er hier. Tätigen oder nehmen Sie einen Anruf an, um zu beginnen.</string>
     <string name="home_recordings_empty_title">Noch keine Aufnahmen</string>
     <string name="home_hero_pill_dev_options_off">Aufnahme nicht möglich</string>
+    <string name="home_hero_pill_update_regrant">Aktion erforderlich</string>
     <string name="home_update_banner_title">Update verfügbar: %1$s</string>
     <string name="home_update_banner_text">Eine neue Version steht auf GitHub zum Download bereit.</string>
     <string name="home_update_banner_button">Aktualisieren</string>

--- a/app/src/main/res/values-de/strings_home.xml
+++ b/app/src/main/res/values-de/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">Wird heruntergeladen… %1$d%%</string>
     <string name="home_update_banner_installing">Wird installiert…</string>
     <string name="home_updated_banner_text">CallVault wurde auf %1$s aktualisiert</string>
+    <string name="home_whatsnew_title">Neu</string>
+    <string name="home_whatsnew_body">• Anrufe auch ohne Wi-Fi aufzeichnen (unten aktivieren)\n• Die Aufnahme ist schneller bereit, nachdem Ihr Telefon im Leerlauf war\n• Eine neue, leichtere Audio-Engine — keine abgeschnittenen Anrufanfänge mehr</string>
+    <string name="home_whatsnew_offline_cta">Aufnahme ohne Wi-Fi aktivieren</string>
+    <string name="home_whatsnew_offline_enabled">Offline-Aufnahme aktiviert.</string>
+    <string name="home_whatsnew_offline_failed">Aktivierung fehlgeschlagen — verbinden Sie sich einmal mit Wi-Fi und versuchen Sie es dann in den Einstellungen.</string>
+    <string name="home_whatsnew_offline_enabling">Aufnahme ohne Wi-Fi wird aktiviert…</string>
+    <string name="offline_recording_on">Aufnahme ohne Wi-Fi ist aktiv.</string>
+    <string name="offline_recording_disabling">Aufnahme ohne Wi-Fi wird deaktiviert…</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -57,6 +57,8 @@
     <string name="home_status_not_paired_suggestion">Complete el emparejamiento de la Depuración inalámbrica en la configuración.</string>
     <string name="home_status_not_paired_title">Configuración incompleta</string>
     <string name="home_status_ready_suggestion">CallVault graba las llamadas automáticamente según sus ajustes.</string>
+    <string name="home_status_update_regrant_title">Grabación en pausa tras la actualización</string>
+    <string name="home_status_update_regrant_suggestion">La actualización eliminó un permiso que CallVault necesita. Toca aquí y activa la depuración inalámbrica una vez: la grabación se restaura sola. No hace falta reinstalar.</string>
     <string name="home_status_ready_title">Listo para grabar</string>
     <string name="permission_adb_description">Necesario para capturar el audio de las llamadas. Empareje una vez mediante la notificación y luego se conecta automáticamente.</string>
     <string name="permission_adb_not_connected">Sin conexión — toque para configurar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -158,6 +158,11 @@
     <string name="settings_recording_folder_label">Carpeta de grabaciones</string>
     <string name="folder_cloud_rejected">Las carpetas en la nube (como Google Drive) no se pueden usar para grabar. Elige un almacenamiento en el dispositivo; usa la opción de copia de seguridad de Google Drive para las copias en la nube.</string>
     <string name="folder_cloud_warning">⚠ Esta carpeta de grabación está en la nube, lo que no es fiable para la captura. Elige una carpeta en el dispositivo.</string>
+    <string name="settings_offline_recording_label">Grabación sin conexión (sin Wi-Fi)</string>
+    <string name="settings_offline_recording_desc">Graba llamadas incluso cuando no hay red Wi-Fi.</string>
+    <string name="offline_recording_warning_title">¿Activar la grabación sin conexión?</string>
+    <string name="offline_recording_warning_message">Esto abre un puerto de depuración local en tu teléfono para que las llamadas puedan grabarse sin Wi-Fi. Está protegido por la clave de tu dispositivo, pero supone una pequeña concesión de seguridad. Actívalo solo si necesitas grabar llamadas sin Wi-Fi.</string>
+    <string name="offline_recording_warning_continue">Continuar de todos modos</string>
     <string name="settings_section_about">Acerca de</string>
     <string name="settings_section_audio">Configuración de audio</string>
     <string name="settings_section_debug">Opciones de depuración</string>

--- a/app/src/main/res/values-es/strings_home.xml
+++ b/app/src/main/res/values-es/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">Descargando… %1$d%%</string>
     <string name="home_update_banner_installing">Instalando…</string>
     <string name="home_updated_banner_text">CallVault se actualizó a %1$s</string>
+    <string name="home_whatsnew_title">Novedades</string>
+    <string name="home_whatsnew_body">• Graba llamadas incluso sin Wi-Fi (actívalo abajo)\n• La grabación está lista más rápido después de que el teléfono haya estado inactivo\n• Un nuevo motor de audio más ligero — se acabaron los inicios de llamada cortados</string>
+    <string name="home_whatsnew_offline_cta">Activar grabación sin Wi-Fi</string>
+    <string name="home_whatsnew_offline_enabled">Grabación sin conexión activada.</string>
+    <string name="home_whatsnew_offline_failed">No se pudo activar — conéctate una vez a Wi-Fi y luego inténtalo desde Ajustes.</string>
+    <string name="home_whatsnew_offline_enabling">Activando la grabación sin Wi-Fi…</string>
+    <string name="offline_recording_on">La grabación sin Wi-Fi está activada.</string>
+    <string name="offline_recording_disabling">Desactivando la grabación sin Wi-Fi…</string>
 </resources>

--- a/app/src/main/res/values-es/strings_home.xml
+++ b/app/src/main/res/values-es/strings_home.xml
@@ -10,6 +10,7 @@
     <string name="home_recordings_empty_hint">Cuando CallVault grabe una llamada, aparecerá aquí. Haga o reciba una llamada para empezar.</string>
     <string name="home_recordings_empty_title">Aún no hay grabaciones</string>
     <string name="home_hero_pill_dev_options_off">Grabación no disponible</string>
+    <string name="home_hero_pill_update_regrant">Acción necesaria</string>
     <string name="home_update_banner_title">Actualización disponible: %1$s</string>
     <string name="home_update_banner_text">Hay una nueva versión lista para descargar desde GitHub.</string>
     <string name="home_update_banner_button">Actualizar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -163,6 +163,11 @@
     <string name="settings_recording_folder_label">Dossier d\'enregistrement</string>
     <string name="folder_cloud_rejected">Les dossiers cloud (comme Google Drive) ne peuvent pas être utilisés pour l\'enregistrement. Choisissez un stockage sur l\'appareil — utilisez l\'option de sauvegarde Google Drive pour les copies dans le cloud.</string>
     <string name="folder_cloud_warning">⚠ Ce dossier d\'enregistrement se trouve dans le cloud, ce qui n\'est pas fiable pour la capture. Choisissez un dossier sur l\'appareil.</string>
+    <string name="settings_offline_recording_label">Enregistrement hors ligne (sans Wi-Fi)</string>
+    <string name="settings_offline_recording_desc">Enregistrer les appels même en l\'absence de réseau Wi-Fi.</string>
+    <string name="offline_recording_warning_title">Activer l\'enregistrement hors ligne ?</string>
+    <string name="offline_recording_warning_message">Cela ouvre un port de débogage local sur votre téléphone afin que les appels puissent être enregistrés sans Wi-Fi. Il est protégé par la clé de votre appareil, mais cela représente un léger compromis de sécurité. Ne l\'activez que si vous avez besoin d\'enregistrer des appels sans Wi-Fi.</string>
+    <string name="offline_recording_warning_continue">Continuer quand même</string>
     <string name="settings_section_about">À propos</string>
     <string name="settings_section_audio">Configuration audio</string>
     <string name="settings_section_debug">Options de débogage</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -60,6 +60,8 @@
     <string name="home_status_dev_options_off_title">Options pour les développeurs désactivées</string>
     <string name="home_status_dev_options_off_suggestion">CallVault enregistre via le débogage sans fil, qui nécessite les options pour les développeurs. L\'enregistrement ne peut pas fonctionner tant que vous ne réactivez pas les options pour les développeurs (et le débogage sans fil) dans les paramètres du système.</string>
     <string name="home_status_ready_suggestion">CallVault enregistre les appels automatiquement selon vos paramètres.</string>
+    <string name="home_status_update_regrant_title">Enregistrement suspendu après la mise à jour</string>
+    <string name="home_status_update_regrant_suggestion">La mise à jour a supprimé une autorisation dont CallVault a besoin. Appuie ici, puis active le débogage sans fil une fois — l\'enregistrement se rétablit tout seul. Aucune réinstallation nécessaire.</string>
     <string name="home_status_ready_title">Prêt à enregistrer</string>
     <string name="permission_adb_description">Nécessaire pour capturer l\'audio des appels. Associez une fois via la notification, puis la connexion se fait automatiquement.</string>
     <string name="permission_adb_not_connected">Non connecté — touchez pour configurer</string>

--- a/app/src/main/res/values-fr/strings_home.xml
+++ b/app/src/main/res/values-fr/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">Téléchargement… %1$d%%</string>
     <string name="home_update_banner_installing">Installation…</string>
     <string name="home_updated_banner_text">CallVault a été mis à jour vers %1$s</string>
+    <string name="home_whatsnew_title">Nouveautés</string>
+    <string name="home_whatsnew_body">• Enregistrez les appels même sans Wi-Fi (activez-le ci-dessous)\n• L\'enregistrement est prêt plus vite après une période d\'inactivité du téléphone\n• Un nouveau moteur audio plus léger — fini les débuts d\'appel coupés</string>
+    <string name="home_whatsnew_offline_cta">Activer l\'enregistrement sans Wi-Fi</string>
+    <string name="home_whatsnew_offline_enabled">Enregistrement hors ligne activé.</string>
+    <string name="home_whatsnew_offline_failed">Activation impossible — connectez-vous une fois au Wi-Fi, puis réessayez depuis les Paramètres.</string>
+    <string name="home_whatsnew_offline_enabling">Activation de l\'enregistrement sans Wi-Fi…</string>
+    <string name="offline_recording_on">L\'enregistrement sans Wi-Fi est activé.</string>
+    <string name="offline_recording_disabling">Désactivation de l\'enregistrement sans Wi-Fi…</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_home.xml
+++ b/app/src/main/res/values-fr/strings_home.xml
@@ -3,6 +3,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="home_hero_pill_no_folder">Action requise</string>
     <string name="home_hero_pill_dev_options_off">Enregistrement impossible</string>
+    <string name="home_hero_pill_update_regrant">Action requise</string>
     <string name="home_hero_pill_not_paired">Action requise</string>
     <string name="home_hero_pill_ready">Actif</string>
     <string name="home_hero_status_label">État</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -57,6 +57,8 @@
     <string name="home_status_not_paired_suggestion">Fejezze be a vezeték nélküli hibakeresés párosítását a beállításban.</string>
     <string name="home_status_not_paired_title">A beállítás nem fejeződött be</string>
     <string name="home_status_ready_suggestion">A CallVault a beállításai szerint automatikusan rögzíti a hívásokat.</string>
+    <string name="home_status_update_regrant_title">A rögzítés szünetel a frissítés után</string>
+    <string name="home_status_update_regrant_suggestion">A frissítés törölt egy engedélyt, amelyre a CallVaultnak szüksége van. Koppints ide, majd kapcsold be egyszer a vezeték nélküli hibakeresést – a rögzítés magától helyreáll. Nincs szükség újratelepítésre.</string>
     <string name="home_status_ready_title">Készen áll a rögzítésre</string>
     <string name="permission_adb_description">A hívás hangjának rögzítéséhez szükséges. Párosítsa egyszer az értesítésen keresztül, ezután automatikusan csatlakozik.</string>
     <string name="permission_adb_not_connected">Nincs csatlakoztatva — koppintson a beállításhoz</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -158,6 +158,11 @@
     <string name="settings_recording_folder_label">Felvételek mappája</string>
     <string name="folder_cloud_rejected">A felhőmappák (például a Google Drive) nem használhatók rögzítésre. Válasszon eszközön lévő tárhelyet – a felhőben tárolt másolatokhoz használja a Google Drive biztonsági mentés lehetőséget.</string>
     <string name="folder_cloud_warning">⚠ Ez a rögzítési mappa a felhőben van, ami megbízhatatlan a rögzítéshez. Válasszon egy eszközön lévő mappát.</string>
+    <string name="settings_offline_recording_label">Offline rögzítés (Wi-Fi nélkül)</string>
+    <string name="settings_offline_recording_desc">Hívások rögzítése akkor is, ha nincs Wi-Fi hálózat.</string>
+    <string name="offline_recording_warning_title">Engedélyezi az offline rögzítést?</string>
+    <string name="offline_recording_warning_message">Ez megnyit egy helyi hibakeresési portot a telefonján, hogy a hívások Wi-Fi nélkül is rögzíthetők legyenek. Az eszköz kulcsa védi, de kis biztonsági kompromisszumot jelent. Csak akkor engedélyezze, ha Wi-Fi nélkül kell hívásokat rögzítenie.</string>
+    <string name="offline_recording_warning_continue">Folytatás mindenképp</string>
     <string name="settings_section_about">Névjegy</string>
     <string name="settings_section_audio">Hangbeállítások</string>
     <string name="settings_section_debug">Debug beállítások</string>

--- a/app/src/main/res/values-hu/strings_home.xml
+++ b/app/src/main/res/values-hu/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">Letöltés… %1$d%%</string>
     <string name="home_update_banner_installing">Telepítés…</string>
     <string name="home_updated_banner_text">A CallVault frissült erre: %1$s</string>
+    <string name="home_whatsnew_title">Újdonságok</string>
+    <string name="home_whatsnew_body">• Hívások rögzítése Wi-Fi nélkül is (kapcsolja be lent)\n• A felvétel gyorsabban áll készen, miután a telefon tétlen volt\n• Új, könnyebb hangmotor — nincs több levágott híváskezdet</string>
+    <string name="home_whatsnew_offline_cta">Wi-Fi nélküli rögzítés bekapcsolása</string>
+    <string name="home_whatsnew_offline_enabled">Offline rögzítés bekapcsolva.</string>
+    <string name="home_whatsnew_offline_failed">Nem sikerült bekapcsolni — csatlakozzon egyszer Wi-Fi-hez, majd próbálja meg a Beállításokban.</string>
+    <string name="home_whatsnew_offline_enabling">Wi-Fi nélküli rögzítés bekapcsolása…</string>
+    <string name="offline_recording_on">A Wi-Fi nélküli rögzítés be van kapcsolva.</string>
+    <string name="offline_recording_disabling">Wi-Fi nélküli rögzítés kikapcsolása…</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_home.xml
+++ b/app/src/main/res/values-hu/strings_home.xml
@@ -10,6 +10,7 @@
     <string name="home_recordings_empty_hint">Amikor a CallVault rögzít egy hívást, az itt jelenik meg. Kezdje el egy hívás indításával vagy fogadásával.</string>
     <string name="home_recordings_empty_title">Még nincsenek felvételek</string>
     <string name="home_hero_pill_dev_options_off">A rögzítés nem működik</string>
+    <string name="home_hero_pill_update_regrant">Beavatkozás szükséges</string>
     <string name="home_update_banner_title">Frissítés érhető el: %1$s</string>
     <string name="home_update_banner_text">Új verzió tölthető le a GitHubról.</string>
     <string name="home_update_banner_button">Frissítés</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -57,6 +57,8 @@
     <string name="home_status_not_paired_suggestion">Completi l\'abbinamento del Debug wireless nella configurazione.</string>
     <string name="home_status_not_paired_title">Configurazione non completata</string>
     <string name="home_status_ready_suggestion">CallVault registra le chiamate automaticamente in base alle Sue impostazioni.</string>
+    <string name="home_status_update_regrant_title">Registrazione in pausa dopo l\'aggiornamento</string>
+    <string name="home_status_update_regrant_suggestion">L\'aggiornamento ha rimosso un\'autorizzazione necessaria a CallVault. Tocca qui, poi attiva una volta il debug wireless: la registrazione si ripristina da sola. Nessuna reinstallazione necessaria.</string>
     <string name="home_status_ready_title">Pronto a registrare</string>
     <string name="permission_adb_description">Necessario per registrare l\'audio delle chiamate. Abbini una sola volta tramite la notifica, poi si connetterà automaticamente.</string>
     <string name="permission_adb_not_connected">Non connesso — tocchi per configurare</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -158,6 +158,11 @@
     <string name="settings_recording_folder_label">Cartella di registrazione</string>
     <string name="folder_cloud_rejected">Le cartelle nel cloud (come Google Drive) non possono essere usate per la registrazione. Scelga un\'archiviazione sul dispositivo; usi l\'opzione di backup su Google Drive per le copie nel cloud.</string>
     <string name="folder_cloud_warning">⚠ Questa cartella di registrazione si trova nel cloud, il che non è affidabile per l\'acquisizione. Scelga una cartella sul dispositivo.</string>
+    <string name="settings_offline_recording_label">Registrazione offline (senza Wi-Fi)</string>
+    <string name="settings_offline_recording_desc">Registra le chiamate anche quando non è disponibile una rete Wi-Fi.</string>
+    <string name="offline_recording_warning_title">Abilitare la registrazione offline?</string>
+    <string name="offline_recording_warning_message">Questa opzione apre una porta di debug locale sul telefono affinché le chiamate possano essere registrate senza Wi-Fi. È protetta dalla chiave del dispositivo, ma rappresenta un piccolo compromesso in termini di sicurezza. Abilitala solo se hai bisogno di registrare chiamate senza Wi-Fi.</string>
+    <string name="offline_recording_warning_continue">Continua comunque</string>
     <string name="settings_section_about">Info</string>
     <string name="settings_section_audio">Configurazione audio</string>
     <string name="settings_section_debug">Opzioni di debug</string>

--- a/app/src/main/res/values-it/strings_home.xml
+++ b/app/src/main/res/values-it/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">Download… %1$d%%</string>
     <string name="home_update_banner_installing">Installazione…</string>
     <string name="home_updated_banner_text">CallVault è stato aggiornato alla %1$s</string>
+    <string name="home_whatsnew_title">Novità</string>
+    <string name="home_whatsnew_body">• Registra le chiamate anche senza Wi-Fi (attivalo qui sotto)\n• La registrazione è pronta più velocemente dopo che il telefono è rimasto inattivo\n• Un nuovo motore audio più leggero — niente più inizi di chiamata tagliati</string>
+    <string name="home_whatsnew_offline_cta">Attiva la registrazione senza Wi-Fi</string>
+    <string name="home_whatsnew_offline_enabled">Registrazione offline attivata.</string>
+    <string name="home_whatsnew_offline_failed">Attivazione non riuscita — collegati una volta al Wi-Fi, poi riprova dalle Impostazioni.</string>
+    <string name="home_whatsnew_offline_enabling">Attivazione della registrazione senza Wi-Fi…</string>
+    <string name="offline_recording_on">La registrazione senza Wi-Fi è attiva.</string>
+    <string name="offline_recording_disabling">Disattivazione della registrazione senza Wi-Fi…</string>
 </resources>

--- a/app/src/main/res/values-it/strings_home.xml
+++ b/app/src/main/res/values-it/strings_home.xml
@@ -10,6 +10,7 @@
     <string name="home_recordings_empty_hint">Quando CallVault registra una chiamata, comparirà qui. Effettui o riceva una chiamata per iniziare.</string>
     <string name="home_recordings_empty_title">Ancora nessuna registrazione</string>
     <string name="home_hero_pill_dev_options_off">Registrazione non disponibile</string>
+    <string name="home_hero_pill_update_regrant">Azione richiesta</string>
     <string name="home_update_banner_title">Aggiornamento disponibile: %1$s</string>
     <string name="home_update_banner_text">Una nuova versione è pronta per il download da GitHub.</string>
     <string name="home_update_banner_button">Aggiorna</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -57,6 +57,8 @@
     <string name="home_status_not_paired_suggestion">Dokończ parowanie Debugowania bezprzewodowego w konfiguracji.</string>
     <string name="home_status_not_paired_title">Konfiguracja nieukończona</string>
     <string name="home_status_ready_suggestion">CallVault nagrywa rozmowy automatycznie zgodnie z Twoimi ustawieniami.</string>
+    <string name="home_status_update_regrant_title">Nagrywanie wstrzymane po aktualizacji</string>
+    <string name="home_status_update_regrant_suggestion">Aktualizacja usunęła uprawnienie, którego potrzebuje CallVault. Dotknij tutaj, a następnie włącz raz debugowanie bezprzewodowe — nagrywanie przywróci się samo. Nie trzeba instalować ponownie.</string>
     <string name="home_status_ready_title">Gotowy do nagrywania</string>
     <string name="permission_adb_description">Wymagane do nagrywania dźwięku rozmów. Sparuj raz przez powiadomienie, a następnie połączenie nastąpi automatycznie.</string>
     <string name="permission_adb_not_connected">Brak połączenia — dotknij, aby skonfigurować</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -158,6 +158,11 @@
     <string name="settings_recording_folder_label">Folder nagrań</string>
     <string name="folder_cloud_rejected">Folderów w chmurze (takich jak Google Drive) nie można używać do nagrywania. Wybierz pamięć na urządzeniu — do kopii w chmurze użyj opcji kopii zapasowej Google Drive.</string>
     <string name="folder_cloud_warning">⚠ Ten folder nagrań znajduje się w chmurze, co jest zawodne przy nagrywaniu. Wybierz folder na urządzeniu.</string>
+    <string name="settings_offline_recording_label">Nagrywanie offline (bez Wi-Fi)</string>
+    <string name="settings_offline_recording_desc">Nagrywaj połączenia nawet wtedy, gdy nie ma sieci Wi-Fi.</string>
+    <string name="offline_recording_warning_title">Włączyć nagrywanie offline?</string>
+    <string name="offline_recording_warning_message">Spowoduje to otwarcie lokalnego portu debugowania w telefonie, aby połączenia mogły być nagrywane bez Wi-Fi. Jest on chroniony kluczem urządzenia, ale stanowi niewielki kompromis w zakresie bezpieczeństwa. Włącz tę opcję tylko wtedy, gdy musisz nagrywać połączenia bez Wi-Fi.</string>
+    <string name="offline_recording_warning_continue">Kontynuuj mimo to</string>
     <string name="settings_section_about">O nas</string>
     <string name="settings_section_audio">Ustawienia dźwięku</string>
     <string name="settings_section_debug">Opcje debugowania</string>

--- a/app/src/main/res/values-pl/strings_home.xml
+++ b/app/src/main/res/values-pl/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">Pobieranie… %1$d%%</string>
     <string name="home_update_banner_installing">Instalowanie…</string>
     <string name="home_updated_banner_text">CallVault zaktualizowano do %1$s</string>
+    <string name="home_whatsnew_title">Nowości</string>
+    <string name="home_whatsnew_body">• Nagrywaj rozmowy nawet bez Wi-Fi (włącz to poniżej)\n• Nagrywanie jest gotowe szybciej, gdy telefon był bezczynny\n• Nowy, lżejszy silnik audio — koniec z ucinanymi początkami rozmów</string>
+    <string name="home_whatsnew_offline_cta">Włącz nagrywanie bez Wi-Fi</string>
+    <string name="home_whatsnew_offline_enabled">Nagrywanie offline włączone.</string>
+    <string name="home_whatsnew_offline_failed">Nie udało się włączyć — połącz się raz z Wi-Fi, a następnie spróbuj w Ustawieniach.</string>
+    <string name="home_whatsnew_offline_enabling">Włączanie nagrywania bez Wi-Fi…</string>
+    <string name="offline_recording_on">Nagrywanie bez Wi-Fi jest włączone.</string>
+    <string name="offline_recording_disabling">Wyłączanie nagrywania bez Wi-Fi…</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_home.xml
+++ b/app/src/main/res/values-pl/strings_home.xml
@@ -10,6 +10,7 @@
     <string name="home_recordings_empty_hint">Gdy CallVault nagra rozmowę, pojawi się ona tutaj. Wykonaj lub odbierz połączenie, aby rozpocząć.</string>
     <string name="home_recordings_empty_title">Brak nagrań</string>
     <string name="home_hero_pill_dev_options_off">Nagrywanie niemożliwe</string>
+    <string name="home_hero_pill_update_regrant">Wymagane działanie</string>
     <string name="home_update_banner_title">Dostępna aktualizacja: %1$s</string>
     <string name="home_update_banner_text">Nowa wersja jest gotowa do pobrania z GitHuba.</string>
     <string name="home_update_banner_button">Aktualizuj</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -158,6 +158,11 @@
     <string name="settings_recording_folder_label">Папка для записей</string>
     <string name="folder_cloud_rejected">Облачные папки (например, Google Drive) нельзя использовать для записи. Выберите хранилище на устройстве — для копий в облаке используйте функцию резервного копирования в Google Drive.</string>
     <string name="folder_cloud_warning">⚠ Эта папка для записей находится в облаке, что ненадёжно для записи. Выберите папку на устройстве.</string>
+    <string name="settings_offline_recording_label">Запись без сети (без Wi-Fi)</string>
+    <string name="settings_offline_recording_desc">Записывать звонки даже при отсутствии сети Wi-Fi.</string>
+    <string name="offline_recording_warning_title">Включить запись без Wi-Fi?</string>
+    <string name="offline_recording_warning_message">При этом на телефоне открывается локальный порт отладки, чтобы звонки можно было записывать без Wi-Fi. Он защищён ключом вашего устройства, но представляет собой небольшой компромисс в плане безопасности. Включайте эту функцию только в том случае, если вам нужно записывать звонки без Wi-Fi.</string>
+    <string name="offline_recording_warning_continue">Всё равно продолжить</string>
     <string name="settings_section_about">О приложении</string>
     <string name="settings_section_audio">Настройки аудио</string>
     <string name="settings_section_debug">Настройки отладки</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -57,6 +57,8 @@
     <string name="home_status_not_paired_suggestion">Завершите сопряжение для отладки по Wi-Fi в настройке.</string>
     <string name="home_status_not_paired_title">Настройка не завершена</string>
     <string name="home_status_ready_suggestion">CallVault записывает звонки автоматически согласно вашим настройкам.</string>
+    <string name="home_status_update_regrant_title">Запись приостановлена после обновления</string>
+    <string name="home_status_update_regrant_suggestion">Обновление сбросило разрешение, необходимое CallVault. Нажмите здесь и один раз включите беспроводную отладку — запись восстановится сама. Переустановка не нужна.</string>
     <string name="home_status_ready_title">Готово к записи</string>
     <string name="permission_adb_description">Требуется для записи звука звонков. Выполните сопряжение один раз через уведомление, далее подключение будет происходить автоматически.</string>
     <string name="permission_adb_not_connected">Не подключено — нажмите, чтобы настроить</string>

--- a/app/src/main/res/values-ru/strings_home.xml
+++ b/app/src/main/res/values-ru/strings_home.xml
@@ -10,6 +10,7 @@
     <string name="home_recordings_empty_hint">Когда CallVault запишет звонок, он появится здесь. Совершите или примите звонок, чтобы начать.</string>
     <string name="home_recordings_empty_title">Записей пока нет</string>
     <string name="home_hero_pill_dev_options_off">Запись невозможна</string>
+    <string name="home_hero_pill_update_regrant">Требуется действие</string>
     <string name="home_update_banner_title">Доступно обновление: %1$s</string>
     <string name="home_update_banner_text">Новая версия готова к загрузке с GitHub.</string>
     <string name="home_update_banner_button">Обновить</string>

--- a/app/src/main/res/values-ru/strings_home.xml
+++ b/app/src/main/res/values-ru/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">Загрузка… %1$d%%</string>
     <string name="home_update_banner_installing">Установка…</string>
     <string name="home_updated_banner_text">CallVault обновлён до %1$s</string>
+    <string name="home_whatsnew_title">Что нового</string>
+    <string name="home_whatsnew_body">• Запись звонков даже без Wi-Fi (включите ниже)\n• Запись готова быстрее после простоя телефона\n• Новый, более лёгкий аудиодвижок — больше никаких обрезанных начал звонков</string>
+    <string name="home_whatsnew_offline_cta">Включить запись без Wi-Fi</string>
+    <string name="home_whatsnew_offline_enabled">Офлайн-запись включена.</string>
+    <string name="home_whatsnew_offline_failed">Не удалось включить — подключитесь один раз к Wi-Fi, затем попробуйте в Настройках.</string>
+    <string name="home_whatsnew_offline_enabling">Включение записи без Wi-Fi…</string>
+    <string name="offline_recording_on">Запись без Wi-Fi включена.</string>
+    <string name="offline_recording_disabling">Выключение записи без Wi-Fi…</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -158,6 +158,11 @@
     <string name="settings_recording_folder_label">Thư mục ghi âm</string>
     <string name="folder_cloud_rejected">Không thể dùng thư mục trên đám mây (như Google Drive) để ghi âm. Hãy chọn bộ nhớ trên thiết bị — dùng tùy chọn sao lưu Google Drive để tạo bản sao trên đám mây.</string>
     <string name="folder_cloud_warning">⚠ Thư mục ghi âm này nằm trên đám mây, vốn không đáng tin cậy cho việc ghi âm. Hãy chọn một thư mục trên thiết bị.</string>
+    <string name="settings_offline_recording_label">Ghi âm ngoại tuyến (không có Wi-Fi)</string>
+    <string name="settings_offline_recording_desc">Ghi âm cuộc gọi ngay cả khi không có mạng Wi-Fi.</string>
+    <string name="offline_recording_warning_title">Bật ghi âm ngoại tuyến?</string>
+    <string name="offline_recording_warning_message">Thao tác này mở một cổng gỡ lỗi cục bộ trên điện thoại của bạn để có thể ghi âm cuộc gọi mà không cần Wi-Fi. Cổng này được bảo vệ bằng khóa của thiết bị, nhưng đây là một sự đánh đổi nhỏ về bảo mật. Chỉ bật khi bạn cần ghi âm cuộc gọi mà không có Wi-Fi.</string>
+    <string name="offline_recording_warning_continue">Vẫn tiếp tục</string>
     <string name="settings_section_about">Về</string>
     <string name="settings_section_audio">Cấu hình âm thanh</string>
     <string name="settings_section_debug">Tùy chọn gỡ lỗi</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -57,6 +57,8 @@
     <string name="home_status_not_paired_suggestion">Hoàn tất việc ghép nối Gỡ lỗi không dây trong phần thiết lập.</string>
     <string name="home_status_not_paired_title">Thiết lập chưa hoàn tất</string>
     <string name="home_status_ready_suggestion">CallVault tự động ghi âm cuộc gọi theo cài đặt của bạn.</string>
+    <string name="home_status_update_regrant_title">Ghi âm tạm dừng sau khi cập nhật</string>
+    <string name="home_status_update_regrant_suggestion">Bản cập nhật đã xóa một quyền mà CallVault cần. Nhấn vào đây, rồi bật gỡ lỗi không dây một lần — bản ghi sẽ tự khôi phục. Không cần cài đặt lại.</string>
     <string name="home_status_ready_title">Sẵn sàng ghi âm</string>
     <string name="permission_adb_description">Bắt buộc để ghi âm cuộc gọi. Ghép nối một lần qua thông báo, sau đó nó sẽ tự động kết nối.</string>
     <string name="permission_adb_not_connected">Chưa kết nối — nhấn để thiết lập</string>

--- a/app/src/main/res/values-vi/strings_home.xml
+++ b/app/src/main/res/values-vi/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">Đang tải… %1$d%%</string>
     <string name="home_update_banner_installing">Đang cài đặt…</string>
     <string name="home_updated_banner_text">CallVault đã cập nhật lên %1$s</string>
+    <string name="home_whatsnew_title">Có gì mới</string>
+    <string name="home_whatsnew_body">• Ghi âm cuộc gọi ngay cả khi không có Wi-Fi (bật bên dưới)\n• Bản ghi âm sẵn sàng nhanh hơn sau khi điện thoại ở trạng thái nhàn rỗi\n• Công cụ âm thanh mới, nhẹ hơn — không còn cắt mất phần đầu cuộc gọi</string>
+    <string name="home_whatsnew_offline_cta">Bật ghi âm khi không có Wi-Fi</string>
+    <string name="home_whatsnew_offline_enabled">Đã bật ghi âm ngoại tuyến.</string>
+    <string name="home_whatsnew_offline_failed">Không thể bật — hãy kết nối Wi-Fi một lần, sau đó thử lại từ Cài đặt.</string>
+    <string name="home_whatsnew_offline_enabling">Đang bật ghi âm không cần Wi-Fi…</string>
+    <string name="offline_recording_on">Ghi âm không cần Wi-Fi đang bật.</string>
+    <string name="offline_recording_disabling">Đang tắt ghi âm không cần Wi-Fi…</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_home.xml
+++ b/app/src/main/res/values-vi/strings_home.xml
@@ -10,6 +10,7 @@
     <string name="home_recordings_empty_hint">Khi CallVault ghi âm một cuộc gọi, nó sẽ hiển thị ở đây. Hãy thực hiện hoặc nhận một cuộc gọi để bắt đầu.</string>
     <string name="home_recordings_empty_title">Chưa có bản ghi âm nào</string>
     <string name="home_hero_pill_dev_options_off">Không thể ghi âm</string>
+    <string name="home_hero_pill_update_regrant">Cần thao tác</string>
     <string name="home_update_banner_title">Có bản cập nhật: %1$s</string>
     <string name="home_update_banner_text">Phiên bản mới đã sẵn sàng tải xuống từ GitHub.</string>
     <string name="home_update_banner_button">Cập nhật</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -158,6 +158,11 @@
     <string name="settings_recording_folder_label">选取保存目录</string>
     <string name="folder_cloud_rejected">云端文件夹（如 Google Drive）无法用于录音。请选择设备本地存储——如需云端副本，请使用 Google Drive 备份选项。</string>
     <string name="folder_cloud_warning">⚠ 此录音文件夹位于云端，用于录音并不可靠。请选择设备本地的文件夹。</string>
+    <string name="settings_offline_recording_label">离线录音（无 Wi-Fi）</string>
+    <string name="settings_offline_recording_desc">即使没有 Wi-Fi 网络也能录制通话。</string>
+    <string name="offline_recording_warning_title">启用离线录音？</string>
+    <string name="offline_recording_warning_message">此操作会在您的手机上开启一个本地调试端口，以便在没有 Wi-Fi 的情况下录制通话。它受设备密钥保护，但会带来轻微的安全权衡。仅在您需要在没有 Wi-Fi 的情况下录制通话时才启用。</string>
+    <string name="offline_recording_warning_continue">仍然继续</string>
     <string name="settings_section_about">关于</string>
     <string name="settings_section_audio">音源选项</string>
     <string name="settings_section_debug">调试选项</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -57,6 +57,8 @@
     <string name="home_status_not_paired_suggestion">请在设置中完成无线调试配对。</string>
     <string name="home_status_not_paired_title">设置未完成</string>
     <string name="home_status_ready_suggestion">CallVault 会根据你的设置自动录制通话。</string>
+    <string name="home_status_update_regrant_title">更新后录音已暂停</string>
+    <string name="home_status_update_regrant_suggestion">此次更新清除了 CallVault 所需的一项权限。点按这里，然后开启一次无线调试——录音会自动恢复。无需重新安装。</string>
     <string name="home_status_ready_title">准备就绪</string>
     <string name="permission_adb_description">录制通话音频所必需。通过通知配对一次后，即可自动连接。</string>
     <string name="permission_adb_not_connected">未连接——点按进行设置</string>

--- a/app/src/main/res/values-zh-rCN/strings_home.xml
+++ b/app/src/main/res/values-zh-rCN/strings_home.xml
@@ -10,6 +10,7 @@
     <string name="home_recordings_empty_hint">当 CallVault 录制通话后，会显示在这里。拨打或接听一通电话即可开始。</string>
     <string name="home_recordings_empty_title">暂无录音</string>
     <string name="home_hero_pill_dev_options_off">无法录音</string>
+    <string name="home_hero_pill_update_regrant">需要操作</string>
     <string name="home_update_banner_title">有可用更新：%1$s</string>
     <string name="home_update_banner_text">新版本已可从 GitHub 下载。</string>
     <string name="home_update_banner_button">更新</string>

--- a/app/src/main/res/values-zh-rCN/strings_home.xml
+++ b/app/src/main/res/values-zh-rCN/strings_home.xml
@@ -16,4 +16,12 @@
     <string name="home_update_banner_downloading">正在下载… %1$d%%</string>
     <string name="home_update_banner_installing">正在安装…</string>
     <string name="home_updated_banner_text">CallVault 已更新到 %1$s</string>
+    <string name="home_whatsnew_title">新功能</string>
+    <string name="home_whatsnew_body">• 即使没有 Wi-Fi 也能录制通话（在下方开启）\n• 手机闲置后，录音准备就绪更快\n• 全新、更轻量的音频引擎 — 通话开头不再被截断</string>
+    <string name="home_whatsnew_offline_cta">开启无 Wi-Fi 录音</string>
+    <string name="home_whatsnew_offline_enabled">已启用离线录音。</string>
+    <string name="home_whatsnew_offline_failed">无法启用 — 请先连接一次 Wi-Fi，然后在设置中重试。</string>
+    <string name="home_whatsnew_offline_enabling">正在启用无 Wi-Fi 录音…</string>
+    <string name="offline_recording_on">无 Wi-Fi 录音已开启。</string>
+    <string name="offline_recording_disabling">正在关闭无 Wi-Fi 录音…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,6 +348,8 @@
     <string name="home_status_not_paired_suggestion">Finish Wireless Debugging pairing in setup.</string>
     <string name="home_status_dev_options_off_title">Developer options is off</string>
     <string name="home_status_dev_options_off_suggestion">CallVault records through Wireless debugging, which needs Developer options. Recording cannot work until you re-enable Developer options (and Wireless debugging) in system settings.</string>
+    <string name="home_status_update_regrant_title">Recording paused after update</string>
+    <string name="home_status_update_regrant_suggestion">The update cleared a permission CallVault needs. Tap here, then turn Wireless debugging on once — recording restores itself. No reinstall needed.</string>
     <string name="home_status_ready_title">Ready to record</string>
     <string name="home_status_ready_suggestion">CallVault records calls automatically per your settings.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,13 @@
     <string name="folder_cloud_rejected">Cloud folders (like Google Drive) can\'t be used for recording. Pick on-device storage — use the Google Drive backup option for cloud copies.</string>
     <string name="folder_cloud_warning">⚠ This recording folder is in the cloud, which is unreliable for capture. Choose an on-device folder.</string>
 
+    <!-- Offline recording (loopback) opt-in + security warning -->
+    <string name="settings_offline_recording_label">Offline recording (no Wi-Fi)</string>
+    <string name="settings_offline_recording_desc">Record calls even when there is no Wi-Fi network.</string>
+    <string name="offline_recording_warning_title">Enable offline recording?</string>
+    <string name="offline_recording_warning_message">This opens a local debugging port on your phone so calls can record with no Wi-Fi. It is protected by your device\'s key, but it is a small security tradeoff. Only enable it if you need to record calls without Wi-Fi.</string>
+    <string name="offline_recording_warning_continue">Continue anyway</string>
+
     <string name="settings_file_name_template">File Name Template</string>
     <string name="settings_file_name_template_preset">Preset</string>
     <string name="settings_file_name_preset_date_direction_number">Date · Direction · Number</string>

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -12,6 +12,7 @@
     <string name="home_hero_pill_not_paired">Action needed</string>
     <string name="home_hero_pill_no_folder">Action needed</string>
     <string name="home_hero_pill_dev_options_off">Recording broken</string>
+    <string name="home_hero_pill_update_regrant">Action needed</string>
 
     <!-- Recordings section -->
     <string name="home_recordings_count">%1$d saved</string>

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -26,4 +26,12 @@
     <string name="home_update_banner_downloading">Downloading… %1$d%%</string>
     <string name="home_update_banner_installing">Installing…</string>
     <string name="home_updated_banner_text">CallVault updated to %1$s</string>
+    <string name="home_whatsnew_title">What\'s new</string>
+    <string name="home_whatsnew_body">• Record calls even without Wi-Fi (turn it on below)\n• Recording is ready faster after your phone has been idle\n• A new, lighter audio engine — no more clipped call beginnings</string>
+    <string name="home_whatsnew_offline_cta">Turn on off-Wi-Fi recording</string>
+    <string name="home_whatsnew_offline_enabled">Offline recording enabled.</string>
+    <string name="home_whatsnew_offline_failed">Couldn\'t enable — connect to Wi-Fi once, then try from Settings.</string>
+    <string name="home_whatsnew_offline_enabling">Enabling off-Wi-Fi recording…</string>
+    <string name="offline_recording_on">Off-Wi-Fi recording is on.</string>
+    <string name="offline_recording_disabling">Turning off off-Wi-Fi recording…</string>
 </resources>

--- a/docs/dev-notes/2026-07-23-v1.4.0-offline-recording-and-fast-recovery.md
+++ b/docs/dev-notes/2026-07-23-v1.4.0-offline-recording-and-fast-recovery.md
@@ -1,0 +1,117 @@
+# v1.4.0 — Off-Wi-Fi recording, direct capture, and fast daemon recovery
+
+**Date:** 2026-07-23
+**Branch:** `feat/daemon-persistence-and-offline-optin`
+**Test device:** OnePlus (ColorOS / OxygenOS, Android 16) — an aggressive background-management OEM.
+
+This note records the investigation and the engineering decisions behind v1.4.0. The user-facing summary
+is in [CHANGELOG.md](../../CHANGELOG.md); this file is the "why" for maintainers.
+
+---
+
+## 1. The problem
+
+Three things, discovered from field use:
+
+1. **Recording fails with no Wi-Fi.** The privileged recorder daemon is (re)launched over Android's
+   **Wireless Debugging**, which needs a Wi-Fi network. On the road with no Wi-Fi, a call can't be recorded.
+2. **The daemon doesn't stay warm.** It's a detached shell-uid (2000) `app_process`; the OEM reaps it, so
+   a call after an idle period pays a long cold-start.
+3. **When it does recover, it's slow** — up to ~90 s of "starting up" that a ringing call can outrun.
+
+## 2. What actually kills the daemon (measured, not assumed)
+
+We shipped a temporary on-disk **heartbeat** (`DaemonHeartbeat`, since removed) that the daemon fsync'd
+every 10 s with wall-clock + monotonic clocks, plus `CVINSTR` logcat instrumentation. Reading it back
+after unplugged idle tests overturned two earlier assumptions:
+
+- **It's not (only) `com.oplus.athena`'s 30-min idle reaper.** Athena does reap it — including via a
+  **`abnormal_memory_periodic_clear` sweep that runs every ~60 s** on this device (`native=true`, so
+  shell processes are fair game; our *app* survives because it's a foreground service, the *daemon*
+  doesn't). But that's not the common case.
+- **The frequent killer was OUR OWN Wireless-Debugging churn.** Every daemon relaunch used to: enable WD
+  (🔔) → connect → launch → `applyWdPolicy` disables WD (🔔). Each `adb_wifi_enabled` write **restarts
+  adbd**, and when WD is the daemon's only transport (unplugged), that restart kills the daemon. The
+  "WD-only when needed" design was maximizing adbd churn = maximizing daemon death.
+
+**The shell-uid trap:** call-audio capture needs `CAPTURE_AUDIO_OUTPUT` + a privileged source
+(`VOICE_CALL`/`REMOTE_SUBMIX`), which is `signature|privileged` — an app-uid process can't hold it. So the
+daemon *must* be shell-uid, which is exactly why Athena won't protect it (protection is package-keyed). You
+can't have privileged capture and OEM protection in one process without root.
+
+## 3. The fixes
+
+### 3.1 Off-Wi-Fi recording via loopback (opt-in)
+`AdbShell.ensureConnected` now, **in offline mode, uses the classic-tcpip loopback transport ONLY and never
+enables WD on the hot path.** Loopback (`127.0.0.1:<port>`) needs no Wi-Fi and — unlike Wireless Debugging —
+isn't torn down by the OS on screen-off, so the daemon **persists across screen-off + deep doze** (measured
+19–30 min on one pid, frozen-and-resumed). The listener self-heals across an adbd restart because
+`service.adb.tcp.port` persists; `waitForShellReady`/`isLoopbackArmed` distinguish "adbd is mid-restart,
+wait" from "truly gone, re-arm." It stays **off by default** and is armed behind a security warning
+(arming opens a local, RSA-gated debugging port).
+
+### 3.2 Direct AudioRecord capture (replaces scrcpy)
+`DirectAudioRecorderSession` runs `AudioRecord(VOICE_CALL) → MediaCodec → MediaMuxer` **in the daemon** —
+no scrcpy child process, no jar extraction on boot, no socket handshake. It encodes to the user's selected
+codec/container (Opus/AAC), and **falls back to scrcpy** (`RecorderSession`, via the `RecordingSession`
+interface) when a device can't handle the source+codec — without consuming the output fd, so the fallback
+still works. Validated on a real call. Removing the jar extraction from `RecorderServer.main` also speeds
+the daemon's cold-boot.
+
+### 3.3 Fast recovery — four separate bottlenecks, in order of impact
+The daemon *itself* boots instantly (its own logs show `START → binder delivered` in the same second). The
+~90 s was everything around it:
+
+1. **`killStaleDaemons` took ~25 s.** The old `for d in /proc/[0-9]*; do grep … ; done` forked a `grep`
+   per process. Replaced with `pgrep -f` (~70 ms). Same self-exclusion trick (`Recorder[S]erver`).
+2. **A 90 s rewarm throttle blocked genuine recoveries.** A confirmed binder-death now relaunches
+   **immediately, bypassing the throttle** (`maybeRewarm(force = true)`); the throttle only guards the
+   speculative watchdog path, and was reduced 90 s → 20 s. Offline/loopback recovery no longer waits on
+   Wi-Fi.
+3. **The launch fired into a restarting adbd and ate an 8 s timeout.** `AdbShell.waitForShellReady` now
+   confirms the shell round-trips a trivial `echo` (bounded per-probe so a half-open connection can't
+   hang) **before** launching.
+4. **The notification lied.** The daemon reconnected in ~5–9 s but the "ready" notification only refreshed
+   on the 60 s watchdog tick, so the user saw "starting up" for up to a minute. It now flips to "ready"
+   the instant the relaunch succeeds.
+
+Net: ~90 s → **~5–10 s**, most of which is just OnePlus's adbd coming back after it restarts on screen-on.
+
+> **Measurement caveat for future work:** you can't measure clean recovery over USB — plugging in restarts
+> adbd and contaminates it. Use the on-device signals (or a stopwatch on a fully-detached phone).
+
+### 3.4 One consolidated readiness notification
+`DaemonKeepAliveService` (permanent), `CallMonitorService` (post-boot), and the old launch notifier all
+showed readiness → duplicates. Now there is one (`recorder_keepalive`, id 4720): `CallMonitorService`
+shares it and detaches on stop; the launch notifier was removed; a startup migration cancels the old ids.
+
+### 3.5 UX polish
+- **In-app "What's new"** (`WhatsNewDialog`) auto-shows once after an update (plain language, 9 locales),
+  with a one-tap **off-Wi-Fi opt-in**.
+- **Shared `OfflineRecordingDialog`** (Settings + What's New) with live feedback: warning → spinner (no
+  buttons mid-work) → "it's on" (Confirm + 3 s auto-close), and a spinner when turning it off. No toast.
+- **Inline delete spinner** on a recording's row while its delete (incl. a Drive copy) completes.
+- **Stale-recording self-heal:** a recording deleted *outside* the app (e.g. directly in Google Drive)
+  is pruned from the local catalog when a tap reveals the file is *confirmed* missing — a transient/
+  network error never removes a valid recording.
+
+## 4. Notable dead ends / non-obvious facts
+- Keeping a shell-uid process alive non-root is not possible on this OEM (Athena reaps it many ways;
+  `nohup`/`setsid` only defeat SIGHUP, not the SIGKILL-on-idle). The answer is fast recovery, not persistence.
+- `applyWdPolicy` disabling WD is a no-op in offline steady-state (WD already off), so it wasn't the churn
+  source — the **enable** on loopback-connect failure was.
+- The `WD_DISABLE_WHEN_IDLE` pref is effectively dead (an earlier abandoned toggle).
+- Two creative persistence levers were parked for later: (a) hold a silent output-capture stream so
+  Athena's `audio=true` protection spares the daemon; (b) create the privileged capture in shell and hand
+  the live handle to the always-alive app FGS. Both untested; deep AudioFlinger territory.
+
+## 5. New/changed files (high level)
+- **New:** `RecordingSession` (interface), `DirectAudioRecorderSession`, `OfflineRecording` (shared
+  enable/disable helper), `ui/common/OfflineRecordingDialog`.
+- **Changed (core):** `AdbShell` (loopback-only offline path, self-heal, `waitForShellReady`),
+  `RecorderServerLauncher` (pgrep kill, shell-ready gate, re-arm, timeout), `RecorderServer`
+  (direct-vs-scrcpy choice, no jar on boot), `DaemonKeepAliveService` (force-rewarm, notification flip),
+  `CallMonitorService` (shared notification), `CallVaultApplication` (drop dup notifier + migration).
+- **Changed (UI):** `HomeScreen` (What's new, delete spinner), `HomeViewModel` (deleting state, stale
+  prune), `SettingsScreen` (shared offline dialog).
+- **Docs/i18n:** CHANGELOG, README, this note, and the new strings translated to all 9 locales.


### PR DESCRIPTION
Ships **v1.4.0** and the **v1.4.1** follow-up fix on one branch.

## v1.4.0 — off-Wi-Fi recording, direct capture, fast recovery
- **Offline recording (opt-in):** loopback-only transport records with no Wi-Fi and persists across screen-off/doze; armed behind a security warning, off by default.
- **Direct AudioRecord capture** replaces scrcpy (no clipped beginnings, faster daemon boot; falls back to scrcpy when a device can't use it).
- **Fast recovery** (~90s → ~5–10s): pgrep stale-kill, force-rewarm on confirmed death, shell-ready gate before launch, notification flips to "ready" on relaunch.
- **One consolidated readiness notification**; in-app "What's new" (9 locales) with off-Wi-Fi opt-in; delete spinner; stale-recording (Drive-deleted) self-heal.

## v1.4.1 — update self-heal (field-bug fix)
An in-place update (Obtainium / sideloaded APK — not the in-app updater, which re-grants inline) drops the runtime `WRITE_SECURE_SETTINGS` grant, so the app can't re-enable Wireless debugging to relaunch the daemon → recording silently dies until a clean reinstall.
- `UpdatePackageReplacedReceiver` now reconnects off-thread after replacement; a surviving transport (loopback/WD-still-on) lets `ensureConnected` self-grant `WRITE_SECURE_SETTINGS` and relaunch the daemon — zero user action.
- When no transport survives, Home shows a new `UPDATE_REGRANT_NEEDED` "Recording paused after update" banner (tap → Wireless debugging; toggle on once to self-heal). Honest failure state, no reinstall.

## Test plan
- [x] `assembleRelease` builds clean (lint/translations pass), all 9 locales.
- [x] Installed 1.4.1 over 1.4.0 on-device (OnePlus, Android 16); app runs, What's new modal + new banner render correctly.
- [x] v1.4.1 GitHub release published (`CallVault.apk`, latest).
- [ ] Field validation of the Obtainium-path self-heal (adb install preserves the grant, so the drop can't be reproduced over USB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)