### PR TITLE
ci: fix CodeQL build — don't require release keystore for debug compiles

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,13 @@ val libphonenumberMetadataDir = layout.buildDirectory.dir("generated/libphonenum
 // Detect if we're running in a CI environment (e.g., GitHub Actions).
 val isEnvironmentGithubCI = providers.environmentVariable("GITHUB_ACTIONS").isPresent
 
+// True only when a release-producing task is in the requested task graph (assembleRelease,
+// bundleRelease, packageRelease, lintVitalRelease, …). The release keystore is required ONLY for
+// real release builds — so debug-only CI jobs (notably CodeQL's `compileDebugSources`) don't trip
+// the keystore check at configuration time, while `assembleRelease` still fails loudly on a missing
+// secret. `taskNames` reflects what was requested on the command line (":app:assembleRelease", etc.).
+val isReleaseBuildRequested = gradle.startParameter.taskNames.any { it.contains("release", ignoreCase = true) }
+
 abstract class DownloadAssetTask : DefaultTask() {
     @get:Input
     abstract val url: Property<String>
@@ -141,9 +148,11 @@ android {
     val localReleaseKeystore = rootProject.file("signing/callvault-signing.keystore")
 
     signingConfigs {
-        // Signing config for CI environments.
+        // Signing config for CI environments. Only demand the keystore env when a release build is
+        // actually requested — otherwise a debug-only CI job (e.g. CodeQL's `compileDebugSources`)
+        // would fail here at configuration time even though it never signs a release APK.
         create("ci-release") {
-            if (isEnvironmentGithubCI) {
+            if (isEnvironmentGithubCI && isReleaseBuildRequested) {
                 storeFile = file(System.getenv("KEYSTORE_FILE") ?: throw GradleException("Keystore file not provided for release signing. env variable: KEYSTORE_FILE"))
                 storePassword = System.getenv("KEYSTORE_PASSWORD") ?: throw GradleException("Keystore password not provided for release signing. env variable: KEYSTORE_PASSWORD")
                 keyAlias = System.getenv("KEY_ALIAS") ?: throw GradleException("Key alias not provided for release signing. env variable: KEY_ALIAS")


### PR DESCRIPTION
## Problem
The **CodeQL "Analyze Code"** check has been failing on every PR (it was red on both the v1.4.0 and v1.4.1 PRs). Its build step runs `./gradlew compileDebugSources`, but the `ci-release` signing config threw at **configuration time**:

```
Keystore file not provided for release signing. env variable: KEYSTORE_FILE
```

`signingConfigs {}` is evaluated for *every* Gradle invocation, so a debug-only compile — which never signs a release APK — still hit the `if (isEnvironmentGithubCI) { … throw … }` guard because CodeQL sets `GITHUB_ACTIONS` but (correctly) provides no signing secrets.

## Fix
Require the keystore env **only when a release build is actually requested** — gate on a new `isReleaseBuildRequested` (a task containing "release" is in the requested graph) in addition to `isEnvironmentGithubCI`.

- Debug-only CI jobs (CodeQL) now configure cleanly.
- The real release workflow (`assembleRelease`) still **fails loudly** on a missing secret — safety preserved.

## Test plan
- [x] Simulated CI (`GITHUB_ACTIONS=true`, no `KEYSTORE_FILE`): `compileDebugSources` **succeeds**.
- [x] Simulated CI release (`GITHUB_ACTIONS=true`, no `KEYSTORE_FILE`): `assembleRelease` **still fails** with the KEYSTORE_FILE error.
- [x] Local `assembleRelease` (keystore present) unaffected — uses `local-release`.
- [ ] This PR's own CodeQL check goes green (proves the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)