### PR TITLE
v1.4.2 — Ko-fi support button + one-time What's-new modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.4.2] — 2026-07-24
+
+### Added
+- **Support development.** An optional "♥ Support" button next to the app title on Home, and a
+  matching row in Settings → About, open the maintainer's Ko-fi page in your browser. Entirely
+  optional — CallVault stays fully free and open source.
+
+### Fixed
+- **The "What's new: off-Wi-Fi recording" note no longer pops up after every update.** It's a
+  one-time introduction now — shown once, then never again (a small "updated to …" banner still
+  confirms an update landed).
+
 ## [1.4.1] — 2026-07-24
 
 A focused fix for a problem some people hit after updating to 1.4.0.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,8 +120,8 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // (versionCode = the CI run number), but local builds and the in-app "About" version use these
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10427)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.1")
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10432)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.2")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
+++ b/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
@@ -177,6 +177,7 @@ class AppPreferences(context: Context) {
         UPDATE_INSTALL_ARMED("update_install_armed"),
         LAST_SEEN_VERSION_CODE("last_seen_version_code"),
         UPDATE_SUCCESS_BANNER_VERSION("update_success_banner_version"),
+        WHATS_NEW_OFFWIFI_SEEN("whats_new_offwifi_seen"),
         UPDATE_SOURCE_OVERRIDE_URL("update_source_override_url"),
 
         // --- Persistent recorder server (CallVault Plan 5) ---
@@ -391,6 +392,14 @@ class AppPreferences(context: Context) {
     /** Version name to show a dismissable "updated successfully" banner for, or null when none. */
     fun getUpdateSuccessBannerVersion() = getString(Key.UPDATE_SUCCESS_BANNER_VERSION)
     fun setUpdateSuccessBannerVersion(version: String?) = setString(Key.UPDATE_SUCCESS_BANNER_VERSION, version)
+
+    /**
+     * Whether the one-time "What's new: off-Wi-Fi recording" intro modal has already been shown. Set
+     * true the first time it is dismissed so it never reappears on later updates — the note is a
+     * one-time feature introduction, not a per-release changelog.
+     */
+    fun hasSeenOffWifiWhatsNew() = getBoolean(Key.WHATS_NEW_OFFWIFI_SEEN, false)
+    fun setSeenOffWifiWhatsNew(seen: Boolean) = setBoolean(Key.WHATS_NEW_OFFWIFI_SEEN, seen)
 
     /**
      * TEST-ONLY: a GitHub release API URL to fetch the update from instead of `/latest`. Not exposed

--- a/app/src/main/java/com/baba/callvault/system/SystemIntentHelpers.kt
+++ b/app/src/main/java/com/baba/callvault/system/SystemIntentHelpers.kt
@@ -42,6 +42,12 @@ private const val TAG = "CV:SystemIntentHelpers"
 const val ORIGINAL_PROJECT_URL = "https://github.com/kitsumed/ShizuCallRecorder"
 
 /**
+ * The maintainer's Ko-fi page. Surfaced as an optional "support development" link on Home and in
+ * About. Donations happen entirely on Ko-fi's site (opened in the browser) — no in-app payment SDK.
+ */
+const val KOFI_SUPPORT_URL = "https://ko-fi.com/madkongo"
+
+/**
  * A folder-picker that asks for long-term read and write access to the chosen folder.
  *
  * Android normally only grants temporary access to a folder. This contract also requests
@@ -150,6 +156,11 @@ fun Context.openWirelessDebugging() {
 /** Opens the upstream project repository (required fork attribution, GPLv3 §7). */
 fun Context.openOriginalProjectRepo() {
     launchSmartIntent(Intent(Intent.ACTION_VIEW).apply { data = ORIGINAL_PROJECT_URL.toUri() })
+}
+
+/** Opens the maintainer's Ko-fi page in the browser so the user can support development. */
+fun Context.openKofi() {
+    launchSmartIntent(Intent(Intent.ACTION_VIEW).apply { data = KOFI_SUPPORT_URL.toUri() })
 }
 
 /**

--- a/app/src/main/java/com/baba/callvault/ui/common/CvComponents.kt
+++ b/app/src/main/java/com/baba/callvault/ui/common/CvComponents.kt
@@ -61,6 +61,7 @@ fun CvScaffold(
     modifier: Modifier = Modifier,
     subtitle: String? = null,
     onBack: (() -> Unit)? = null,
+    titleTrailing: (@Composable () -> Unit)? = null,
     actions: @Composable RowScope.() -> Unit = {},
     bottomBar: @Composable () -> Unit = {},
     content: @Composable (PaddingValues) -> Unit,
@@ -82,11 +83,19 @@ fun CvScaffold(
                     }
                     Spacer(Modifier.width(2.dp))
                 }
-                Column(Modifier.weight(1f)) {
+                // When a [titleTrailing] element is present it sits right next to the title (a weighted
+                // spacer then pushes [actions] to the far edge); otherwise the title column itself takes
+                // the remaining width, preserving the original layout for every existing caller.
+                Column(if (titleTrailing == null) Modifier.weight(1f) else Modifier) {
                     Text(title, style = MaterialTheme.typography.titleLarge, color = MaterialTheme.colorScheme.onBackground)
                     if (subtitle != null) {
                         Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
+                }
+                if (titleTrailing != null) {
+                    Spacer(Modifier.width(10.dp))
+                    titleTrailing()
+                    Spacer(Modifier.weight(1f))
                 }
                 actions()
             }

--- a/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Surface
 import com.baba.callvault.system.openWirelessDebugging
+import com.baba.callvault.system.openKofi
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.input.pointer.pointerInput
@@ -129,11 +132,6 @@ fun HomeScreen(
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
     val playback by viewModel.playback.collectAsState()
-    // Show the "What's new" note once after an update lands (driven by the same signal as the banner).
-    var showWhatsNew by remember { mutableStateOf(false) }
-    LaunchedEffect(uiState.updatedToVersion) {
-        if (uiState.updatedToVersion != null) showWhatsNew = true
-    }
 
     // Refresh status + recordings whenever the user returns to the screen (e.g. after a new call).
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -156,6 +154,7 @@ fun HomeScreen(
     CvScaffold(
         modifier = modifier.fillMaxSize(),
         title = stringResource(R.string.app_name),
+        titleTrailing = { SupportPill(onClick = { context.openKofi() }) },
         actions = {
             IconButton(onClick = onOpenSettings) {
                 Icon(
@@ -166,10 +165,12 @@ fun HomeScreen(
             }
         }
     ) { innerPadding ->
-        if (showWhatsNew) {
+        if (uiState.showWhatsNew) {
             WhatsNewDialog(
                 onDismiss = {
-                    showWhatsNew = false
+                    // Persist "seen" so the one-time off-Wi-Fi intro never reappears on later updates,
+                    // and clear the small "updated" banner too.
+                    viewModel.markWhatsNewSeen()
                     viewModel.dismissUpdatedBanner()
                 },
             )
@@ -408,6 +409,40 @@ private fun UpdateBannerCard(
                     Text(stringResource(R.string.home_update_banner_button))
                 }
             }
+        }
+    }
+}
+
+/**
+ * A compact, tappable "♥ Support" pill shown next to the app title. Opens the maintainer's Ko-fi
+ * page in the browser — an optional, low-key donation entry point that keeps the status card and the
+ * recordings list uncluttered. The matching, more explicit ask lives in Settings → About.
+ */
+@Composable
+private fun SupportPill(onClick: () -> Unit) {
+    val accent = MaterialTheme.colorScheme.primary
+    Surface(
+        onClick = onClick,
+        shape = CircleShape,
+        color = accent.copy(alpha = 0.12f),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Favorite,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.size(15.dp),
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = stringResource(R.string.home_support_pill),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Medium,
+                color = accent,
+            )
         }
     }
 }

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -49,6 +49,7 @@ import com.baba.callvault.R
 import com.baba.callvault.system.PersistentFolderPickerContract
 import com.baba.callvault.system.copyToClipboard
 import com.baba.callvault.system.openOriginalProjectRepo
+import com.baba.callvault.system.openKofi
 import com.baba.callvault.system.shareLogFile
 import com.baba.callvault.utils.AppLogger
 import kotlinx.coroutines.Dispatchers
@@ -90,6 +91,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.material.icons.filled.DriveFileRenameOutline
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Save
@@ -1060,6 +1062,17 @@ private fun AboutSection(
             value = stringResource(R.string.settings_fork_attribution_supporting),
             supporting = stringResource(R.string.settings_ui_open_repo_hint),
             onClick = { context.openOriginalProjectRepo() }
+        )
+
+        SettingsDivider()
+
+        // Optional "support development" link. Opens the maintainer's Ko-fi page in the browser.
+        NavigationRow(
+            icon = Icons.Filled.Favorite,
+            label = stringResource(R.string.settings_support_label),
+            value = stringResource(R.string.settings_support_value),
+            supporting = stringResource(R.string.settings_support_supporting),
+            onClick = { context.openKofi() }
         )
 
         Row(

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
@@ -124,6 +124,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         val updateProgressPercent: Int = -1,
         /** Version name to show a dismissable "updated successfully" banner for, or null. */
         val updatedToVersion: String? = null,
+        /** Whether to show the one-time "What's new: off-Wi-Fi" intro modal (updated AND not seen yet). */
+        val showWhatsNew: Boolean = false,
         /** Uris of recordings currently being deleted — drives an inline spinner on their row. */
         val deletingUris: Set<Uri> = emptySet()
     ) {
@@ -269,16 +271,29 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
+     * Marks the one-time "What's new: off-Wi-Fi" intro modal as seen so it never reappears on later
+     * updates. Persists the flag; the small "updated successfully" banner is dismissed separately.
+     */
+    fun markWhatsNewSeen() {
+        preferences.setSeenOffWifiWhatsNew(true)
+        _uiState.update { it.copy(showWhatsNew = false) }
+    }
+
+    /**
      * Recomputes the [HomeStatus] (synchronous, cheap) and reloads the recordings list off the main
      * thread. Safe to call on first composition and on every ON_RESUME.
      */
     fun refresh() {
+        val updatedTo = preferences.getUpdateSuccessBannerVersion()
         _uiState.update {
             it.copy(
                 status = computeStatus(),
                 isLoading = true,
                 availableUpdateTag = preferences.getAvailableUpdateTag(),
-                updatedToVersion = preferences.getUpdateSuccessBannerVersion()
+                updatedToVersion = updatedTo,
+                // The off-Wi-Fi "What's new" is a ONE-TIME feature intro: show it only after an update
+                // AND only until it's been seen once, so it never recurs on every later release.
+                showWhatsNew = updatedTo != null && !preferences.hasSeenOffWifiWhatsNew()
             )
         }
         viewModelScope.launch {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">Zeichnet nur Ihre Seite eines Telefonats auf (Uplink).</string>
     <string name="audio_source_voice_comm_description">Optimiert für klare Sprachaufnahmen mit integrierter Echounterdrückung.</string>
     <string name="audio_source_voice_performance_description">Hochgeschwindigkeits-Mikrofonmodus, konzipiert für Live-Musik und Echtzeit-Audioanwendungen.</string>
+    <string name="settings_support_label">Entwicklung unterstützen</string>
+    <string name="settings_support_value">Spendier mir einen Kaffee auf Ko-fi</string>
+    <string name="settings_support_supporting">Öffnet Ko-fi im Browser</string>
     <string name="contact_search_hint">Nach Name oder Nummer suchen...</string>
     <string name="contact_select_all">Alle auswählen</string>
     <string name="contact_unselect_all">Auswahl aufheben</string>

--- a/app/src/main/res/values-de/strings_home.xml
+++ b/app/src/main/res/values-de/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">Aufnahme ohne Wi-Fi wird aktiviert…</string>
     <string name="offline_recording_on">Aufnahme ohne Wi-Fi ist aktiv.</string>
     <string name="offline_recording_disabling">Aufnahme ohne Wi-Fi wird deaktiviert…</string>
+    <string name="home_support_pill">Unterstützen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">Graba solo tu lado de la llamada telefónica (uplink).</string>
     <string name="audio_source_voice_comm_description">Fuente de audio del micrófono optimizada para comunicaciones de voz. Incluye cancelación de eco integrada.</string>
     <string name="audio_source_voice_performance_description">Modo de micrófono de alta velocidad diseñado para música en vivo y aplicaciones de audio en tiempo real.</string>
+    <string name="settings_support_label">Apoyar el desarrollo</string>
+    <string name="settings_support_value">Invítame a un café en Ko-fi</string>
+    <string name="settings_support_supporting">Abre Ko-fi en tu navegador</string>
     <string name="contact_search_hint">Buscar por nombre o número…</string>
     <string name="contact_select_all">Seleccionar todo</string>
     <string name="contact_unselect_all">Deseleccionar todo</string>

--- a/app/src/main/res/values-es/strings_home.xml
+++ b/app/src/main/res/values-es/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">Activando la grabación sin Wi-Fi…</string>
     <string name="offline_recording_on">La grabación sin Wi-Fi está activada.</string>
     <string name="offline_recording_disabling">Desactivando la grabación sin Wi-Fi…</string>
+    <string name="home_support_pill">Apoyar</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">Enregistre uniquement votre partie de l\'appel téléphonique (uplink).</string>
     <string name="audio_source_voice_comm_description">Source Microphone optimisée pour les communications vocales. Annulation d\'écho intégrée.</string>
     <string name="audio_source_voice_performance_description">Mode microphone haute vitesse conçu pour la musique en direct et les applications audio en temps réel.</string>
+    <string name="settings_support_label">Soutenir le développement</string>
+    <string name="settings_support_value">Offrez-moi un café sur Ko-fi</string>
+    <string name="settings_support_supporting">Ouvre Ko-fi dans votre navigateur</string>
     <string name="contact_search_hint">Recherche par nom ou numéro...</string>
     <string name="contact_select_all">Tout sélectionner</string>
     <string name="contact_unselect_all">Tout désélectionner</string>

--- a/app/src/main/res/values-fr/strings_home.xml
+++ b/app/src/main/res/values-fr/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">Activation de l\'enregistrement sans Wi-Fi…</string>
     <string name="offline_recording_on">L\'enregistrement sans Wi-Fi est activé.</string>
     <string name="offline_recording_disabling">Désactivation de l\'enregistrement sans Wi-Fi…</string>
+    <string name="home_support_pill">Soutenir</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">Csak a saját hangod rögzíti a telefonbeszélgetésből (kimenő irány).</string>
     <string name="audio_source_voice_comm_description">Mikrofon hangforrás beszédhangra hangolva - beépített visszhangszűréssel.</string>
     <string name="audio_source_voice_performance_description">Nagy sebességű mikrofon üzemmód - leginkább élő zenei előadásokhoz és valós idejű hangalkalmazásokhoz.</string>
+    <string name="settings_support_label">Fejlesztés támogatása</string>
+    <string name="settings_support_value">Hívj meg egy kávéra a Ko-fin</string>
+    <string name="settings_support_supporting">Megnyitja a Ko-fit a böngészőben</string>
     <string name="contact_search_hint">Keresés név vagy szám alapján...</string>
     <string name="contact_select_all">Összes kijelölése</string>
     <string name="contact_unselect_all">Összes kijelölés megszűntetése</string>

--- a/app/src/main/res/values-hu/strings_home.xml
+++ b/app/src/main/res/values-hu/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">Wi-Fi nélküli rögzítés bekapcsolása…</string>
     <string name="offline_recording_on">A Wi-Fi nélküli rögzítés be van kapcsolva.</string>
     <string name="offline_recording_disabling">Wi-Fi nélküli rögzítés kikapcsolása…</string>
+    <string name="home_support_pill">Támogatás</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">Registra solo il Suo lato di una telefonata (uplink).</string>
     <string name="audio_source_voice_comm_description">Sorgente audio del microfono ottimizzata per le comunicazioni vocali. Cancellazione dell\'eco integrata.</string>
     <string name="audio_source_voice_performance_description">Modalità microfono ad alta velocità progettata per la musica dal vivo e le app audio in tempo reale.</string>
+    <string name="settings_support_label">Sostieni lo sviluppo</string>
+    <string name="settings_support_value">Offrimi un caffè su Ko-fi</string>
+    <string name="settings_support_supporting">Apre Ko-fi nel browser</string>
     <string name="contact_search_hint">Cerca per nome o numero...</string>
     <string name="contact_select_all">Seleziona tutti</string>
     <string name="contact_unselect_all">Deseleziona tutti</string>

--- a/app/src/main/res/values-it/strings_home.xml
+++ b/app/src/main/res/values-it/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">Attivazione della registrazione senza Wi-Fi…</string>
     <string name="offline_recording_on">La registrazione senza Wi-Fi è attiva.</string>
     <string name="offline_recording_disabling">Disattivazione della registrazione senza Wi-Fi…</string>
+    <string name="home_support_pill">Sostieni</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">Nagrywa tylko Twoją część rozmowy telefonicznej (sygnał wychodzący).</string>
     <string name="audio_source_voice_comm_description">Źródło dźwięku z mikrofonu dostosowane do komunikacji głosowej. Wbudowana funkcja eliminacji echa.</string>
     <string name="audio_source_voice_performance_description">Tryb mikrofonu o dużej czułości przeznaczony do nagrywania muzyki na żywo i aplikacji audio działających w czasie rzeczywistym.</string>
+    <string name="settings_support_label">Wesprzyj rozwój</string>
+    <string name="settings_support_value">Postaw mi kawę na Ko-fi</string>
+    <string name="settings_support_supporting">Otwiera Ko-fi w przeglądarce</string>
     <string name="contact_search_hint">Wyszukaj według nazwy lub numeru...</string>
     <string name="contact_select_all">Zaznacz wszystko</string>
     <string name="contact_unselect_all">Odznacz wszystko</string>

--- a/app/src/main/res/values-pl/strings_home.xml
+++ b/app/src/main/res/values-pl/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">Włączanie nagrywania bez Wi-Fi…</string>
     <string name="offline_recording_on">Nagrywanie bez Wi-Fi jest włączone.</string>
     <string name="offline_recording_disabling">Wyłączanie nagrywania bez Wi-Fi…</string>
+    <string name="home_support_pill">Wesprzyj</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">Запись только вашего голоса во время телефонного разговора (исходящий канал).</string>
     <string name="audio_source_voice_comm_description">Источник звука микрофона оптимизирован для голосового общения. Встроена функция эхоподавления.</string>
     <string name="audio_source_voice_performance_description">Высокоскоростной режим микрофона для живой музыки и приложений для работы со звуком в реальном времени.</string>
+    <string name="settings_support_label">Поддержать разработку</string>
+    <string name="settings_support_value">Купить мне кофе на Ko-fi</string>
+    <string name="settings_support_supporting">Откроет Ko-fi в браузере</string>
     <string name="contact_search_hint">Искать по имени или номеру...</string>
     <string name="contact_select_all">Выбрать все</string>
     <string name="contact_unselect_all">Отменить выбор всех</string>

--- a/app/src/main/res/values-ru/strings_home.xml
+++ b/app/src/main/res/values-ru/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">Включение записи без Wi-Fi…</string>
     <string name="offline_recording_on">Запись без Wi-Fi включена.</string>
     <string name="offline_recording_disabling">Выключение записи без Wi-Fi…</string>
+    <string name="home_support_pill">Поддержать</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">Chỉ ghi âm phần cuộc gọi từ phía bạn (đường truyền lên).</string>
     <string name="audio_source_voice_comm_description">Nguồn âm thanh micro được tinh chỉnh cho giao tiếp bằng giọng nói. Tích hợp chức năng khử tiếng vọng.</string>
     <string name="audio_source_voice_performance_description">Chế độ micro tốc độ cao được thiết kế cho nhạc sống và các ứng dụng âm thanh thời gian thực.</string>
+    <string name="settings_support_label">Ủng hộ phát triển</string>
+    <string name="settings_support_value">Mời tôi một ly cà phê trên Ko-fi</string>
+    <string name="settings_support_supporting">Mở Ko-fi trong trình duyệt</string>
     <string name="contact_search_hint">Tìm kiếm theo tên hoặc số...</string>
     <string name="contact_select_all">Chọn tất cả</string>
     <string name="contact_unselect_all">Bỏ chọn tất cả</string>

--- a/app/src/main/res/values-vi/strings_home.xml
+++ b/app/src/main/res/values-vi/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">Đang bật ghi âm không cần Wi-Fi…</string>
     <string name="offline_recording_on">Ghi âm không cần Wi-Fi đang bật.</string>
     <string name="offline_recording_disabling">Đang tắt ghi âm không cần Wi-Fi…</string>
+    <string name="home_support_pill">Ủng hộ</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -12,6 +12,9 @@
     <string name="audio_source_voice_call_uplink_description">仅录制您的声音（仅上行）。</string>
     <string name="audio_source_voice_comm_description">麦克风音频源（本意是面向语音通话的系统接口），内置降噪功能。</string>
     <string name="audio_source_voice_performance_description">高速麦克风模式（此选项专为Live音乐和实时音频而设）。</string>
+    <string name="settings_support_label">支持开发</string>
+    <string name="settings_support_value">在 Ko-fi 上请我喝杯咖啡</string>
+    <string name="settings_support_supporting">在浏览器中打开 Ko-fi</string>
     <string name="contact_search_hint">输入姓名或电话号码来搜索…</string>
     <string name="contact_select_all">全选</string>
     <string name="contact_unselect_all">全不选</string>

--- a/app/src/main/res/values-zh-rCN/strings_home.xml
+++ b/app/src/main/res/values-zh-rCN/strings_home.xml
@@ -25,4 +25,5 @@
     <string name="home_whatsnew_offline_enabling">正在启用无 Wi-Fi 录音…</string>
     <string name="offline_recording_on">无 Wi-Fi 录音已开启。</string>
     <string name="offline_recording_disabling">正在关闭无 Wi-Fi 录音…</string>
+    <string name="home_support_pill">支持</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,6 +265,9 @@
     <string name="settings_scrcpy_server" translatable="false">Scrcpy-Server: %1$s</string>
     <string name="settings_fork_attribution" translatable="false">CallVault is a fork of ShizuCallRecorder</string>
     <string name="settings_fork_attribution_supporting" translatable="false">github.com/kitsumed/ShizuCallRecorder</string>
+    <string name="settings_support_label">Support development</string>
+    <string name="settings_support_value">Buy me a coffee on Ko-fi</string>
+    <string name="settings_support_supporting">Opens Ko-fi in your browser</string>
 
     <!-- ContactSelection Dialog -->
     <string name="contact_search_hint">Search by name or number...</string>

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -13,6 +13,7 @@
     <string name="home_hero_pill_no_folder">Action needed</string>
     <string name="home_hero_pill_dev_options_off">Recording broken</string>
     <string name="home_hero_pill_update_regrant">Action needed</string>
+    <string name="home_support_pill">Support</string>
 
     <!-- Recordings section -->
     <string name="home_recordings_count">%1$d saved</string>


### PR DESCRIPTION
## Added
- **Support development.** A compact **"♥ Support"** pill next to the app title on Home and a matching **"Support development"** row in Settings → About, both opening `ko-fi.com/madkongo` in the browser via the existing `launchSmartIntent` helper. No new dependencies, no payment SDK. Adds a `titleTrailing` slot to `CvScaffold` (existing screens untouched when unused).

## Fixed
- **The off-Wi-Fi "What's new" modal reappeared after every update.** It was driven purely by the generic "an update landed" signal. It's a one-time feature intro, so it's now gated behind a persisted `WHATS_NEW_OFFWIFI_SEEN` flag — shown once, then never again. The small dismissable "updated to X" banner is unchanged (kept as a deliberate "update succeeded" indicator).

## Test plan
- [x] `assembleRelease` builds clean (lint + translations pass), all 9 locales.
- [x] On-device (OnePlus, Android 16): "♥ Support" pill opens Ko-fi; About row opens Ko-fi.
- [x] Modal shown once, dismissed, then **two further** simulated updates — modal did **not** recur; "updated to 1.4.2" banner still shows.
- [ ] CodeQL check green (now that the signing-config gate is fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)