### PR TITLE
v1.4.3 — silently self-heal dropped WRITE_SECURE_SETTINGS (no false "paused" banner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.4.3] — 2026-07-24
+
+### Fixed
+- **No more false "recording paused" warning after an update.** When an update dropped a permission
+  but recording kept working (the recorder was still running), CallVault showed an alarming
+  "paused after update" banner anyway. It now **silently restores the permission** over the
+  connection that's already open — no action, no reinstall — and only shows a (reworded, honest)
+  prompt when it genuinely can't, telling you it may still be working and how to keep it that way.
+
 ## [1.4.2] — 2026-07-24
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,8 +120,8 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // (versionCode = the CI run number), but local builds and the in-app "About" version use these
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10432)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.2")
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10433)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.3")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
@@ -424,4 +424,31 @@ object AdbShell {
             AppLogger.i(TAG, "Requested self-grant of WRITE_SECURE_SETTINGS via ADB shell")
         }.onFailure { AppLogger.w(TAG, "Self-grant of WRITE_SECURE_SETTINGS failed: ${it.message}") }
     }
+
+    /**
+     * Silently re-grants WRITE_SECURE_SETTINGS after an install-over dropped it — but ONLY over a
+     * transport that is ALREADY up, so it never restarts adbd (which would kill a warm daemon). This is
+     * the common post-update state: the daemon survived the update (recording still flows over its
+     * binder) and Wireless debugging is still ON (it couldn't be turned off without the very grant we
+     * lost), so [ensureConnected] connects with NO `adb_wifi` write and self-grants via
+     * [grantSecureSettingsIfNeeded]. If nothing safe is up (WD off + loopback not armed), we do NOTHING
+     * here — enabling WD would churn adbd — and the Home banner asks the user to toggle WD once.
+     *
+     * Call OFF the main thread. Returns true if the grant is present afterwards.
+     */
+    fun tryHealWriteSecureSettings(context: Context): Boolean {
+        if (hasWriteSecureSettings(context)) return true
+        val offline = AppPreferences(context).isOfflineRecordingEnabled()
+        // Heal only over an already-live transport — never toggle WD here (adbd restart risks the daemon).
+        val transportUp = isWirelessDebuggingEnabled(context) || (offline && isLoopbackArmed(context))
+        if (!transportUp) {
+            AppLogger.i(TAG, "WRITE_SECURE_SETTINGS missing but no non-churning transport up; leaving for user WD toggle")
+            return false
+        }
+        AppLogger.i(TAG, "WRITE_SECURE_SETTINGS missing; healing over live transport (WD/loopback already up)")
+        ensureConnected(context)   // connects without a WD write and self-grants via grantSecureSettingsIfNeeded
+        val healed = hasWriteSecureSettings(context)
+        if (healed) AppLogger.i(TAG, "WRITE_SECURE_SETTINGS re-granted via live transport (no adbd churn)")
+        return healed
+    }
 }

--- a/app/src/main/java/com/baba/callvault/system/updates/UpdatePackageReplacedReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/system/updates/UpdatePackageReplacedReceiver.kt
@@ -54,24 +54,26 @@ class UpdatePackageReplacedReceiver : BroadcastReceiver() {
     }
 
     /**
-     * Best-effort, off the broadcast thread: reconnect over any surviving transport so
-     * [AdbShell.ensureConnected] re-grants WRITE_SECURE_SETTINGS (`pm grant`) and the daemon relaunches.
-     * Skipped when the grant already survived (in-app updater re-grants inline). Harmless no-op when no
-     * transport survives — the Home `UPDATE_REGRANT_NEEDED` banner then guides the one-time WD toggle.
+     * Best-effort, off the broadcast thread: re-grant WRITE_SECURE_SETTINGS that the install-over
+     * dropped, over any transport that's ALREADY up (WD still on / loopback armed) — no adbd churn.
+     *
+     * [AdbShell.tryHealWriteSecureSettings] is used INSTEAD of relying on the daemon launcher, because
+     * when the daemon survived the update [RecorderServerLauncher.ensureServerRunning] early-returns on
+     * the already-connected binder and never reaches the self-grant — which is exactly the common case
+     * (recording keeps working, but the grant stays lost). After healing we still ensure the daemon is
+     * up (a no-op when it's already connected). Skipped when the grant survived (in-app updater re-grants
+     * inline). Harmless no-op when no transport is up — Home's banner then guides the one-time WD toggle.
      */
     private fun recoverAfterReplace(context: Context) {
         if (AdbShell.hasWriteSecureSettings(context)) {
             AppLogger.d(TAG, "WRITE_SECURE_SETTINGS survived the update; no post-replace recovery needed")
             return
         }
-        AppLogger.i(TAG, "WRITE_SECURE_SETTINGS lost on update; attempting reconnect self-heal + daemon relaunch")
+        AppLogger.i(TAG, "WRITE_SECURE_SETTINGS lost on update; attempting non-churning self-heal")
         Thread {
+            val healed = runCatching { AdbShell.tryHealWriteSecureSettings(context) }.getOrDefault(false)
             runCatching { RecorderServerLauncher.ensureServerRunning(context) }
-                .onSuccess { ok ->
-                    val healed = AdbShell.hasWriteSecureSettings(context)
-                    AppLogger.i(TAG, "Post-replace recovery: daemon=$ok, WRITE_SECURE_SETTINGS regranted=$healed")
-                }
-                .onFailure { AppLogger.w(TAG, "Post-replace recovery failed (no surviving transport?): ${it.message}") }
+            AppLogger.i(TAG, "Post-replace recovery: WRITE_SECURE_SETTINGS regranted=$healed")
         }.apply { isDaemon = true; name = "cv-post-update-recover" }.start()
     }
 

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
@@ -285,9 +285,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
      */
     fun refresh() {
         val updatedTo = preferences.getUpdateSuccessBannerVersion()
+        val status = computeStatus()
         _uiState.update {
             it.copy(
-                status = computeStatus(),
+                status = status,
                 isLoading = true,
                 availableUpdateTag = preferences.getAvailableUpdateTag(),
                 updatedToVersion = updatedTo,
@@ -295,6 +296,15 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                 // AND only until it's been seen once, so it never recurs on every later release.
                 showWhatsNew = updatedTo != null && !preferences.hasSeenOffWifiWhatsNew()
             )
+        }
+        // An install-over can drop WRITE_SECURE_SETTINGS while the daemon stays warm (recording still
+        // works). Rather than nag with the banner, silently self-heal over any transport that's already
+        // up (WD still on / loopback armed) — no user action, no adbd churn. If it heals, drop the banner.
+        if (status == HomeStatus.UPDATE_REGRANT_NEEDED) {
+            viewModelScope.launch {
+                val healed = withContext(Dispatchers.IO) { AdbShell.tryHealWriteSecureSettings(appContext) }
+                if (healed) _uiState.update { it.copy(status = computeStatus()) }
+            }
         }
         viewModelScope.launch {
             val recordings = withContext(Dispatchers.IO) { RecordingsRepository.listRecordings(appContext) }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -60,8 +60,8 @@
     <string name="home_status_not_paired_suggestion">Schließen Sie die Kopplung für drahtloses Debugging in der Einrichtung ab.</string>
     <string name="home_status_not_paired_title">Einrichtung nicht abgeschlossen</string>
     <string name="home_status_ready_suggestion">CallVault zeichnet Anrufe automatisch gemäß Ihren Einstellungen auf.</string>
-    <string name="home_status_update_regrant_title">Aufnahme nach Update pausiert</string>
-    <string name="home_status_update_regrant_suggestion">Das Update hat eine von CallVault benötigte Berechtigung entfernt. Tippe hier und aktiviere das WLAN-Debugging einmal – die Aufnahme stellt sich von selbst wieder her. Keine Neuinstallation nötig.</string>
+    <string name="home_status_update_regrant_title">Verbindung für Aufnahme wiederherstellen</string>
+    <string name="home_status_update_regrant_suggestion">Ein Update hat eine Berechtigung entfernt, die CallVault zum Neustarten der Aufnahme braucht. Es funktioniert vielleicht noch – tippe hier und aktiviere das WLAN-Debugging einmal, um sie wiederherzustellen. Keine Neuinstallation nötig.</string>
     <string name="home_status_ready_title">Bereit zur Aufnahme</string>
     <string name="permission_adb_description">Erforderlich, um Anruf-Audio aufzuzeichnen. Einmal über die Benachrichtigung koppeln, danach verbindet es sich automatisch.</string>
     <string name="permission_adb_not_connected">Nicht verbunden — zum Einrichten tippen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -60,8 +60,8 @@
     <string name="home_status_not_paired_suggestion">Complete el emparejamiento de la Depuración inalámbrica en la configuración.</string>
     <string name="home_status_not_paired_title">Configuración incompleta</string>
     <string name="home_status_ready_suggestion">CallVault graba las llamadas automáticamente según sus ajustes.</string>
-    <string name="home_status_update_regrant_title">Grabación en pausa tras la actualización</string>
-    <string name="home_status_update_regrant_suggestion">La actualización eliminó un permiso que CallVault necesita. Toca aquí y activa la depuración inalámbrica una vez: la grabación se restaura sola. No hace falta reinstalar.</string>
+    <string name="home_status_update_regrant_title">Reconecta para seguir grabando</string>
+    <string name="home_status_update_regrant_suggestion">Una actualización eliminó un permiso que CallVault necesita para reiniciar la grabación. Puede que siga funcionando por ahora: toca aquí y activa la depuración inalámbrica una vez para restaurarlo. No hace falta reinstalar.</string>
     <string name="home_status_ready_title">Listo para grabar</string>
     <string name="permission_adb_description">Necesario para capturar el audio de las llamadas. Empareje una vez mediante la notificación y luego se conecta automáticamente.</string>
     <string name="permission_adb_not_connected">Sin conexión — toque para configurar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -63,8 +63,8 @@
     <string name="home_status_dev_options_off_title">Options pour les développeurs désactivées</string>
     <string name="home_status_dev_options_off_suggestion">CallVault enregistre via le débogage sans fil, qui nécessite les options pour les développeurs. L\'enregistrement ne peut pas fonctionner tant que vous ne réactivez pas les options pour les développeurs (et le débogage sans fil) dans les paramètres du système.</string>
     <string name="home_status_ready_suggestion">CallVault enregistre les appels automatiquement selon vos paramètres.</string>
-    <string name="home_status_update_regrant_title">Enregistrement suspendu après la mise à jour</string>
-    <string name="home_status_update_regrant_suggestion">La mise à jour a supprimé une autorisation dont CallVault a besoin. Appuie ici, puis active le débogage sans fil une fois — l\'enregistrement se rétablit tout seul. Aucune réinstallation nécessaire.</string>
+    <string name="home_status_update_regrant_title">Reconnecte-toi pour continuer à enregistrer</string>
+    <string name="home_status_update_regrant_suggestion">Une mise à jour a supprimé une autorisation dont CallVault a besoin pour relancer l\'enregistrement. Ça marche peut-être encore — appuie ici, puis active le débogage sans fil une fois pour la rétablir. Aucune réinstallation nécessaire.</string>
     <string name="home_status_ready_title">Prêt à enregistrer</string>
     <string name="permission_adb_description">Nécessaire pour capturer l\'audio des appels. Associez une fois via la notification, puis la connexion se fait automatiquement.</string>
     <string name="permission_adb_not_connected">Non connecté — touchez pour configurer</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -60,8 +60,8 @@
     <string name="home_status_not_paired_suggestion">Fejezze be a vezeték nélküli hibakeresés párosítását a beállításban.</string>
     <string name="home_status_not_paired_title">A beállítás nem fejeződött be</string>
     <string name="home_status_ready_suggestion">A CallVault a beállításai szerint automatikusan rögzíti a hívásokat.</string>
-    <string name="home_status_update_regrant_title">A rögzítés szünetel a frissítés után</string>
-    <string name="home_status_update_regrant_suggestion">A frissítés törölt egy engedélyt, amelyre a CallVaultnak szüksége van. Koppints ide, majd kapcsold be egyszer a vezeték nélküli hibakeresést – a rögzítés magától helyreáll. Nincs szükség újratelepítésre.</string>
+    <string name="home_status_update_regrant_title">Csatlakozz újra a rögzítéshez</string>
+    <string name="home_status_update_regrant_suggestion">Egy frissítés törölt egy engedélyt, amelyre a CallVaultnak szüksége van a rögzítés újraindításához. Lehet, hogy még működik – koppints ide, majd kapcsold be egyszer a vezeték nélküli hibakeresést a visszaállításához. Nincs szükség újratelepítésre.</string>
     <string name="home_status_ready_title">Készen áll a rögzítésre</string>
     <string name="permission_adb_description">A hívás hangjának rögzítéséhez szükséges. Párosítsa egyszer az értesítésen keresztül, ezután automatikusan csatlakozik.</string>
     <string name="permission_adb_not_connected">Nincs csatlakoztatva — koppintson a beállításhoz</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -60,8 +60,8 @@
     <string name="home_status_not_paired_suggestion">Completi l\'abbinamento del Debug wireless nella configurazione.</string>
     <string name="home_status_not_paired_title">Configurazione non completata</string>
     <string name="home_status_ready_suggestion">CallVault registra le chiamate automaticamente in base alle Sue impostazioni.</string>
-    <string name="home_status_update_regrant_title">Registrazione in pausa dopo l\'aggiornamento</string>
-    <string name="home_status_update_regrant_suggestion">L\'aggiornamento ha rimosso un\'autorizzazione necessaria a CallVault. Tocca qui, poi attiva una volta il debug wireless: la registrazione si ripristina da sola. Nessuna reinstallazione necessaria.</string>
+    <string name="home_status_update_regrant_title">Riconnetti per continuare a registrare</string>
+    <string name="home_status_update_regrant_suggestion">Un aggiornamento ha rimosso un\'autorizzazione necessaria a CallVault per riavviare la registrazione. Per ora potrebbe funzionare ancora: tocca qui e attiva una volta il debug wireless per ripristinarla. Nessuna reinstallazione necessaria.</string>
     <string name="home_status_ready_title">Pronto a registrare</string>
     <string name="permission_adb_description">Necessario per registrare l\'audio delle chiamate. Abbini una sola volta tramite la notifica, poi si connetterà automaticamente.</string>
     <string name="permission_adb_not_connected">Non connesso — tocchi per configurare</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -60,8 +60,8 @@
     <string name="home_status_not_paired_suggestion">Dokończ parowanie Debugowania bezprzewodowego w konfiguracji.</string>
     <string name="home_status_not_paired_title">Konfiguracja nieukończona</string>
     <string name="home_status_ready_suggestion">CallVault nagrywa rozmowy automatycznie zgodnie z Twoimi ustawieniami.</string>
-    <string name="home_status_update_regrant_title">Nagrywanie wstrzymane po aktualizacji</string>
-    <string name="home_status_update_regrant_suggestion">Aktualizacja usunęła uprawnienie, którego potrzebuje CallVault. Dotknij tutaj, a następnie włącz raz debugowanie bezprzewodowe — nagrywanie przywróci się samo. Nie trzeba instalować ponownie.</string>
+    <string name="home_status_update_regrant_title">Połącz ponownie, aby nagrywać</string>
+    <string name="home_status_update_regrant_suggestion">Aktualizacja usunęła uprawnienie potrzebne CallVault do wznowienia nagrywania. Na razie może działać — dotknij tutaj i włącz raz debugowanie bezprzewodowe, aby je przywrócić. Nie trzeba instalować ponownie.</string>
     <string name="home_status_ready_title">Gotowy do nagrywania</string>
     <string name="permission_adb_description">Wymagane do nagrywania dźwięku rozmów. Sparuj raz przez powiadomienie, a następnie połączenie nastąpi automatycznie.</string>
     <string name="permission_adb_not_connected">Brak połączenia — dotknij, aby skonfigurować</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -60,8 +60,8 @@
     <string name="home_status_not_paired_suggestion">Завершите сопряжение для отладки по Wi-Fi в настройке.</string>
     <string name="home_status_not_paired_title">Настройка не завершена</string>
     <string name="home_status_ready_suggestion">CallVault записывает звонки автоматически согласно вашим настройкам.</string>
-    <string name="home_status_update_regrant_title">Запись приостановлена после обновления</string>
-    <string name="home_status_update_regrant_suggestion">Обновление сбросило разрешение, необходимое CallVault. Нажмите здесь и один раз включите беспроводную отладку — запись восстановится сама. Переустановка не нужна.</string>
+    <string name="home_status_update_regrant_title">Переподключитесь для записи</string>
+    <string name="home_status_update_regrant_suggestion">Обновление сбросило разрешение, необходимое CallVault для перезапуска записи. Пока может работать — нажмите здесь и один раз включите беспроводную отладку, чтобы восстановить его. Переустановка не нужна.</string>
     <string name="home_status_ready_title">Готово к записи</string>
     <string name="permission_adb_description">Требуется для записи звука звонков. Выполните сопряжение один раз через уведомление, далее подключение будет происходить автоматически.</string>
     <string name="permission_adb_not_connected">Не подключено — нажмите, чтобы настроить</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -60,8 +60,8 @@
     <string name="home_status_not_paired_suggestion">Hoàn tất việc ghép nối Gỡ lỗi không dây trong phần thiết lập.</string>
     <string name="home_status_not_paired_title">Thiết lập chưa hoàn tất</string>
     <string name="home_status_ready_suggestion">CallVault tự động ghi âm cuộc gọi theo cài đặt của bạn.</string>
-    <string name="home_status_update_regrant_title">Ghi âm tạm dừng sau khi cập nhật</string>
-    <string name="home_status_update_regrant_suggestion">Bản cập nhật đã xóa một quyền mà CallVault cần. Nhấn vào đây, rồi bật gỡ lỗi không dây một lần — bản ghi sẽ tự khôi phục. Không cần cài đặt lại.</string>
+    <string name="home_status_update_regrant_title">Kết nối lại để tiếp tục ghi âm</string>
+    <string name="home_status_update_regrant_suggestion">Một bản cập nhật đã xóa quyền mà CallVault cần để khởi động lại việc ghi âm. Hiện tại có thể vẫn hoạt động — nhấn vào đây, rồi bật gỡ lỗi không dây một lần để khôi phục. Không cần cài đặt lại.</string>
     <string name="home_status_ready_title">Sẵn sàng ghi âm</string>
     <string name="permission_adb_description">Bắt buộc để ghi âm cuộc gọi. Ghép nối một lần qua thông báo, sau đó nó sẽ tự động kết nối.</string>
     <string name="permission_adb_not_connected">Chưa kết nối — nhấn để thiết lập</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -60,8 +60,8 @@
     <string name="home_status_not_paired_suggestion">请在设置中完成无线调试配对。</string>
     <string name="home_status_not_paired_title">设置未完成</string>
     <string name="home_status_ready_suggestion">CallVault 会根据你的设置自动录制通话。</string>
-    <string name="home_status_update_regrant_title">更新后录音已暂停</string>
-    <string name="home_status_update_regrant_suggestion">此次更新清除了 CallVault 所需的一项权限。点按这里，然后开启一次无线调试——录音会自动恢复。无需重新安装。</string>
+    <string name="home_status_update_regrant_title">重新连接以继续录音</string>
+    <string name="home_status_update_regrant_suggestion">一次更新清除了 CallVault 重新启动录音所需的一项权限。目前可能仍可使用——点按这里，然后开启一次无线调试即可恢复。无需重新安装。</string>
     <string name="home_status_ready_title">准备就绪</string>
     <string name="permission_adb_description">录制通话音频所必需。通过通知配对一次后，即可自动连接。</string>
     <string name="permission_adb_not_connected">未连接——点按进行设置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,8 +351,8 @@
     <string name="home_status_not_paired_suggestion">Finish Wireless Debugging pairing in setup.</string>
     <string name="home_status_dev_options_off_title">Developer options is off</string>
     <string name="home_status_dev_options_off_suggestion">CallVault records through Wireless debugging, which needs Developer options. Recording cannot work until you re-enable Developer options (and Wireless debugging) in system settings.</string>
-    <string name="home_status_update_regrant_title">Recording paused after update</string>
-    <string name="home_status_update_regrant_suggestion">The update cleared a permission CallVault needs. Tap here, then turn Wireless debugging on once — recording restores itself. No reinstall needed.</string>
+    <string name="home_status_update_regrant_title">Reconnect to keep recording</string>
+    <string name="home_status_update_regrant_suggestion">An update removed a permission CallVault needs to restart recording. It may still work for now — tap here, then turn Wireless debugging on once to restore it. No reinstall needed.</string>
     <string name="home_status_ready_title">Ready to record</string>
     <string name="home_status_ready_suggestion">CallVault records calls automatically per your settings.</string>
 


### PR DESCRIPTION
## Problem (field report)
After the 1.4.2 update, a user saw **"Recording paused after update"** — but recording actually **worked**. Their log:
- `Recorder daemon already connected; reusing existing binder` → the recorder survived the update; recording flowed over its binder.
- `Could not disable Wireless debugging (missing WRITE_SECURE_SETTINGS?)` → **WD was still ON** but the install-over dropped `WRITE_SECURE_SETTINGS`.

The 1.4.1 banner fired purely on "WSS missing", and the post-update recovery called `ensureServerRunning`, which **early-returns on the already-connected daemon** and never reached the re-grant. So the banner was a false alarm and the permission stayed un-restored.

## Fix
- **`AdbShell.tryHealWriteSecureSettings()`** — re-grants over a transport that's *already up* (WD on / loopback armed), connecting with **no `adb_wifi` write** (no adbd churn, no risk to the warm daemon) and self-granting. No-op when nothing safe is up.
- **`HomeViewModel.refresh()`** — when the status resolves to `UPDATE_REGRANT_NEEDED`, runs the heal off-thread and drops the banner on success → **zero user action**.
- **`UpdatePackageReplacedReceiver`** — uses the heal instead of `ensureServerRunning`, so WSS is restored even when the daemon is already warm.
- **Honest wording** for the residual (no-transport) case: "Reconnect to keep recording" / "It may still work for now — turn Wireless debugging on once." Reworded across all 9 locales.

## Test plan
- [x] `assembleRelease` clean (lint + translations pass), all 9 locales.
- [x] On-device (OnePlus): WD on + `pm revoke WRITE_SECURE_SETTINGS` + launch → WSS re-granted in ~15s, no user action; status returns to "Ready to record", **no banner**.
- [ ] CodeQL check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)