### PR TITLE
v1.4.4 — mono call audio (quality at 24kbps) + suppress false "paused" banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.4.4] — 2026-07-24
+
+### Fixed
+- **Call audio quality restored at the same bitrate — the far party is clear again.** Recording captured
+  the call in stereo (your side on one channel, the other person's on the other) and encoded it as
+  stereo, which split the bitrate and starved each side — so the **other party** sounded noticeably
+  worse at the default 24 kbps. Calls are mono content, so CallVault now downmixes to a single channel
+  and gives the whole bitrate to the voice. Same setting, much better quality.
+- **No false "recording paused" warning while recording actually works.** The post-update permission
+  banner now only appears when a call genuinely couldn't be recorded (the recorder isn't running), not
+  while it's warm and recording normally — and CallVault keeps quietly restoring the permission in the
+  background.
+
 ## [1.4.3] — 2026-07-24
 
 ### Fixed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,8 +120,8 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // (versionCode = the CI run number), but local builds and the in-app "About" version use these
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10433)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.3")
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10434)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.4")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/AdbShell.kt
@@ -448,7 +448,11 @@ object AdbShell {
         AppLogger.i(TAG, "WRITE_SECURE_SETTINGS missing; healing over live transport (WD/loopback already up)")
         ensureConnected(context)   // connects without a WD write and self-grants via grantSecureSettingsIfNeeded
         val healed = hasWriteSecureSettings(context)
-        if (healed) AppLogger.i(TAG, "WRITE_SECURE_SETTINGS re-granted via live transport (no adbd churn)")
+        if (healed) {
+            AppLogger.i(TAG, "WRITE_SECURE_SETTINGS re-granted via live transport (no adbd churn)")
+        } else {
+            AppLogger.w(TAG, "WRITE_SECURE_SETTINGS heal did NOT land (ADB connect/grant failed); recording still works while the daemon is warm")
+        }
         return healed
     }
 }

--- a/app/src/main/java/com/baba/callvault/server/DirectAudioRecorderSession.kt
+++ b/app/src/main/java/com/baba/callvault/server/DirectAudioRecorderSession.kt
@@ -67,12 +67,17 @@ internal class DirectAudioRecorderSession(
             ?: throw UnsupportedOperationException("source ${source.cliKey} is not a mic-type source")
         val mime = encoderMimeFor(codec)
 
-        // Try stereo first (matches scrcpy's 48 kHz stereo output); fall back to mono if the source
-        // won't initialise in stereo (some OEM VOICE_CALL routes are mono-only).
-        val (record, channelCount) = openAudioRecord(androidSource)
+        // Capture stereo when the route allows it — that reliably gets BOTH directions (uplink on one
+        // channel, the remote party's downlink on the other); mono routes fall back to 1 channel.
+        val (record, captureChannels) = openAudioRecord(androidSource)
         audioRecord = record
 
-        val format = MediaFormat.createAudioFormat(mime, SAMPLE_RATE, channelCount).apply {
+        // ...but always ENCODE MONO. A phone call is mono content, and encoding the captured stereo as
+        // stereo Opus splits the bitrate across the two channels — at the default 24 kbps that leaves
+        // ~12 kbps per side and audibly degrades the FAR party (their downlink channel gets starved).
+        // Downmixing to one channel gives the whole bitrate to the (mono) call, restoring quality at the
+        // same setting. See [captureLoop]'s downmix.
+        val format = MediaFormat.createAudioFormat(mime, SAMPLE_RATE, ENCODE_CHANNELS).apply {
             setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
             if (mime == MediaFormat.MIMETYPE_AUDIO_AAC) {
                 setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC)
@@ -94,9 +99,9 @@ internal class DirectAudioRecorderSession(
         if (record.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
             throw IllegalStateException("AudioRecord failed to enter RECORDING state")
         }
-        AppLogger.i(TAG, "Direct capture started: source=${source.cliKey} codec=${codec.cliKey} ch=$channelCount rate=$SAMPLE_RATE")
+        AppLogger.i(TAG, "Direct capture started: source=${source.cliKey} codec=${codec.cliKey} captureCh=$captureChannels encodeCh=$ENCODE_CHANNELS rate=$SAMPLE_RATE")
 
-        readThread = Thread { runCatching { captureLoop(record, enc, mux) }
+        readThread = Thread { runCatching { captureLoop(record, enc, mux, captureChannels) }
             .onFailure { AppLogger.w(TAG, "Direct capture loop ended: ${it.message}") } }
             .apply { isDaemon = true; name = "direct-capture" }
             .also { it.start() }
@@ -107,24 +112,29 @@ internal class DirectAudioRecorderSession(
      * signals EOS. Standard synchronous MediaCodec drive: queue input with a monotonic sample-count PTS,
      * drain output, add the track on INFO_OUTPUT_FORMAT_CHANGED (its format carries the Opus/AAC CSD).
      */
-    private fun captureLoop(record: AudioRecord, enc: MediaCodec, mux: MediaMuxer) {
+    private fun captureLoop(record: AudioRecord, enc: MediaCodec, mux: MediaMuxer, captureChannels: Int) {
         val pcm = ByteArray(READ_CHUNK_BYTES)
+        val mono = ByteArray(READ_CHUNK_BYTES / 2)   // downmix target (half the samples of stereo input)
+        val downmix = captureChannels == 2
         val info = MediaCodec.BufferInfo()
         var muxerStarted = false
         var totalFrames = 0L
-        val bytesPerFrame = 2 * record.channelCount // PCM-16
+        val bytesPerFrame = 2 * ENCODE_CHANNELS // PCM-16, mono → 2 bytes/frame (matches what we feed the encoder)
 
         while (!stopRequested.get()) {
             val read = record.read(pcm, 0, pcm.size)
             if (read <= 0) continue
 
+            // Feed MONO to the encoder: downmix a stereo capture (average L+R), or pass a mono capture through.
+            val (buf, len) = if (downmix) mono to downmixStereoToMono(pcm, read, mono) else pcm to read
+
             val inIdx = enc.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
             if (inIdx >= 0) {
                 val inBuf = enc.getInputBuffer(inIdx)!!
-                inBuf.clear(); inBuf.put(pcm, 0, read)
+                inBuf.clear(); inBuf.put(buf, 0, len)
                 val ptsUs = totalFrames * 1_000_000L / SAMPLE_RATE
-                enc.queueInputBuffer(inIdx, 0, read, ptsUs, 0)
-                totalFrames += read / bytesPerFrame
+                enc.queueInputBuffer(inIdx, 0, len, ptsUs, 0)
+                totalFrames += len / bytesPerFrame
             }
             muxerStarted = drainEncoder(enc, mux, info, muxerStarted)
         }
@@ -192,6 +202,25 @@ internal class DirectAudioRecorderSession(
         audioRecord = null; encoder = null; muxer = null
     }
 
+    /**
+     * Downmixes interleaved stereo PCM-16 (little-endian) into mono by averaging each L/R pair. Returns
+     * the number of mono bytes written to [dst] (= [srcLen] / 2). Averaging (not summing) avoids clipping.
+     */
+    private fun downmixStereoToMono(src: ByteArray, srcLen: Int, dst: ByteArray): Int {
+        var di = 0
+        var si = 0
+        while (si + 3 < srcLen) {
+            val l = (src[si].toInt() and 0xFF or (src[si + 1].toInt() shl 8)).toShort().toInt()
+            val r = (src[si + 2].toInt() and 0xFF or (src[si + 3].toInt() shl 8)).toShort().toInt()
+            val m = (l + r) / 2
+            dst[di] = (m and 0xFF).toByte()
+            dst[di + 1] = ((m shr 8) and 0xFF).toByte()
+            di += 2
+            si += 4
+        }
+        return di
+    }
+
     private fun openAudioRecord(androidSource: Int): Pair<AudioRecord, Int> {
         for (channelMask in intArrayOf(AudioFormat.CHANNEL_IN_STEREO, AudioFormat.CHANNEL_IN_MONO)) {
             val channels = if (channelMask == AudioFormat.CHANNEL_IN_STEREO) 2 else 1
@@ -212,6 +241,9 @@ internal class DirectAudioRecorderSession(
 
         /** Match scrcpy's output so the muxed file is equivalent (48 kHz). */
         private const val SAMPLE_RATE = 48_000
+
+        /** Always encode mono — a call is mono content, so this gives the full bitrate to the voice. */
+        private const val ENCODE_CHANNELS = 1
         private const val READ_CHUNK_BYTES = 4096
         private const val MAX_INPUT_SIZE = 16_384
         private const val BUFFER_FACTOR = 4

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
@@ -24,6 +24,7 @@ import com.baba.callvault.data.recordings.RecordingsRepository.RecordingItem
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingSource
 import com.baba.callvault.integrations.adb.AdbShell
 import com.baba.callvault.integrations.adb.DeveloperOptions
+import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.system.updates.UpdateInstallWorker
 import com.baba.callvault.system.updates.UpdateScheduler
 import androidx.work.WorkManager
@@ -298,9 +299,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             )
         }
         // An install-over can drop WRITE_SECURE_SETTINGS while the daemon stays warm (recording still
-        // works). Rather than nag with the banner, silently self-heal over any transport that's already
-        // up (WD still on / loopback armed) — no user action, no adbd churn. If it heals, drop the banner.
-        if (status == HomeStatus.UPDATE_REGRANT_NEEDED) {
+        // works). Whenever the grant is missing, silently try to restore it over any transport that's
+        // already up (WD still on / loopback armed) — no user action, no adbd churn — so a later daemon
+        // death stays recoverable. Recompute the status afterwards so any banner reflects the heal.
+        if (!AdbShell.hasWriteSecureSettings(appContext)) {
             viewModelScope.launch {
                 val healed = withContext(Dispatchers.IO) { AdbShell.tryHealWriteSecureSettings(appContext) }
                 if (healed) _uiState.update { it.copy(status = computeStatus()) }
@@ -400,12 +402,16 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         // isExplicitlyDisabled (not !isEnabled): an absent/unreadable global must not paint a
         // permanent red banner on ROMs that don't expose the setting.
         if (DeveloperOptions.isExplicitlyDisabled(appContext)) return HomeStatus.DEV_OPTIONS_OFF
-        // Paired + dev options on, but WRITE_SECURE_SETTINGS is gone → an install-over (Obtainium /
-        // manual sideload) dropped the grant and no transport survived to self-heal it. The app can't
-        // re-enable Wireless debugging, so the daemon can't be relaunched: recording is dead until the
-        // user toggles Wireless debugging on once (which lets ensureConnected re-grant it). Once granted
-        // the permission persists, so "paired but missing" reliably means "an update cleared it".
-        if (!AdbShell.hasWriteSecureSettings(appContext)) return HomeStatus.UPDATE_REGRANT_NEEDED
+        // WRITE_SECURE_SETTINGS gone → an install-over (Obtainium / manual sideload) dropped the grant.
+        // But this ONLY matters if recording can't happen: the grant is needed to RELAUNCH a dead daemon,
+        // NOT to record over an already-warm one. So while the daemon binder is connected (recording works
+        // right now), we do NOT alarm — showing "recording paused" then was a false warning a user hit.
+        // We only surface UPDATE_REGRANT_NEEDED when the grant is missing AND the daemon is disconnected,
+        // i.e. the next call genuinely couldn't be recorded (can't relaunch without the grant). refresh()
+        // still tries a silent, non-churning self-heal whenever the grant is missing.
+        if (!AdbShell.hasWriteSecureSettings(appContext) && !RecorderConnection.isConnected) {
+            return HomeStatus.UPDATE_REGRANT_NEEDED
+        }
         return HomeStatus.READY
     }
 


### PR DESCRIPTION
Two field reports from a user on OnePlus CPH2653 / 1.4.3 — **both confirmed fixed by the reporter on a v1.4.4 test build**.

## Fixed
### 1. Call audio quality regressed (specifically the far party)
`DirectAudioRecorderSession` captured `VOICE_CALL` in **stereo** (uplink on one channel, the remote downlink on the other) and encoded stereo Opus, so the default 24 kbps was split ~12 kbps/side and **starved the remote channel**. A call is mono content, so: keep the stereo *capture* (reliably gets both directions) but **downmix to mono** and encode 1 channel — the whole bitrate goes to the voice. `downmixStereoToMono()` + `ENCODE_CHANNELS = 1`.

### 2. False "Recording paused after update" banner while recording worked
`WRITE_SECURE_SETTINGS` is only needed to **relaunch a dead daemon**, not to record over a warm one. Gate `UPDATE_REGRANT_NEEDED` on `WSS missing AND !RecorderConnection.isConnected`, so the banner is suppressed while the recorder is warm and recording. `refresh()` still runs the silent, non-churning self-heal whenever WSS is missing; `tryHealWriteSecureSettings` now logs when the grant didn't land.

## Test plan
- [x] `assembleRelease` clean (lint + translations pass).
- [x] On-device (test phone): banner suppressed with WSS revoked + WD off + daemon warm → status stays "Ready to record".
- [x] **Reporter confirmed** on his device: far-side quality restored + no false banner.
- [ ] CodeQL check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)