### PR TITLE
v1.4.5 — USB reliability: keep recording when the screen locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.4.5] — 2026-07-24
+
+The headline: **recording no longer stops if you lock the screen during a call** — on phones where it did.
+
+### Added
+- **Keep recording when the screen locks.** On many phones (OnePlus, Xiaomi, Samsung…), locking the
+  screen during a call restarts the USB connection, which was killing the recorder mid-call. CallVault
+  can now set your phone's **Default USB Configuration to "Charging only"** from inside the app, which
+  prevents it — no digging through system menus.
+  - A new **Settings → Reliability** section lets you pick the USB mode (Charging only is recommended)
+    and holds the off-Wi-Fi recording option too.
+  - A **setup step** offers the one-tap fix during onboarding.
+  - If USB is on a data mode, the **Home screen** and the **recorder notification** show a gentle
+    "locking the screen may stop recording — tap to fix" prompt.
+  - Note: with "Charging only", plugging into a PC defaults to charging — pick "File transfer" manually
+    when you actually want to move files.
+
 ## [1.4.4] — 2026-07-24
 
 ### Fixed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,8 +120,8 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // (versionCode = the CI run number), but local builds and the in-app "About" version use these
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
-val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10434)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.4")
+val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10441)
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.5")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
+++ b/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
@@ -178,6 +178,7 @@ class AppPreferences(context: Context) {
         LAST_SEEN_VERSION_CODE("last_seen_version_code"),
         UPDATE_SUCCESS_BANNER_VERSION("update_success_banner_version"),
         WHATS_NEW_OFFWIFI_SEEN("whats_new_offwifi_seen"),
+        USB_DEFAULT_MODE("usb_default_mode"),
         UPDATE_SOURCE_OVERRIDE_URL("update_source_override_url"),
 
         // --- Persistent recorder server (CallVault Plan 5) ---
@@ -400,6 +401,10 @@ class AppPreferences(context: Context) {
      */
     fun hasSeenOffWifiWhatsNew() = getBoolean(Key.WHATS_NEW_OFFWIFI_SEEN, false)
     fun setSeenOffWifiWhatsNew(seen: Boolean) = setBoolean(Key.WHATS_NEW_OFFWIFI_SEEN, seen)
+
+    /** Cached name of the last-read [com.baba.callvault.integrations.adb.UsbDefaultMode], or null. */
+    fun getUsbDefaultMode() = getString(Key.USB_DEFAULT_MODE)
+    fun setUsbDefaultMode(mode: String?) = setString(Key.USB_DEFAULT_MODE, mode)
 
     /**
      * TEST-ONLY: a GitHub release API URL to fetch the update from instead of `/latest`. Not exposed

--- a/app/src/main/java/com/baba/callvault/integrations/adb/UsbDefaultConfig.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/UsbDefaultConfig.kt
@@ -64,8 +64,17 @@ object UsbDefaultConfig {
      * there is no live shell to read through (caller should fall back to [cached]); does NOT force a
      * connection, so it never causes WD/adbd churn. Caches the value on success. Call OFF the main thread.
      */
-    fun readViaShell(context: Context): UsbDefaultMode? {
-        val out = runShell(context, READ_CMD) ?: return null
+    fun readViaShell(context: Context): UsbDefaultMode? = parseAndCache(context, runShell(context, READ_CMD, ensure = true))
+
+    /**
+     * Like [readViaShell] but reads ONLY if an ADB connection is already up — never forces one, so it
+     * causes no WD/adbd churn. Use for opportunistic cache refreshes on paths that already hold a
+     * connection (e.g. right after a daemon launch). Returns null when nothing was read. OFF main thread.
+     */
+    fun readIfConnected(context: Context): UsbDefaultMode? = parseAndCache(context, runShell(context, READ_CMD, ensure = false))
+
+    private fun parseAndCache(context: Context, out: String?): UsbDefaultMode? {
+        if (out == null) return null
         // Filter for the relevant line in Kotlin rather than a `| grep` (pipes are fragile over `shell:`).
         val line = out.lineSequence().firstOrNull { it.contains("screen_unlocked_functions") } ?: return null
         val mode = parse(line)
@@ -80,6 +89,16 @@ object UsbDefaultConfig {
             .getOrDefault(UsbDefaultMode.UNKNOWN)
 
     /**
+     * True when the cached Default USB Configuration is a DATA mode (File transfer, etc.) — i.e. locking
+     * the screen mid-call may restart adbd and kill the recorder. CHARGING and UNKNOWN return false, so we
+     * never warn without a confirmed data value.
+     */
+    fun isScreenLockRisk(context: Context): Boolean = when (cached(context)) {
+        UsbDefaultMode.CHARGING, UsbDefaultMode.UNKNOWN -> false
+        else -> true
+    }
+
+    /**
      * Sets the Default USB Configuration over the ADB shell (ensures a connection first). Returns true if
      * the command was delivered.
      *
@@ -91,7 +110,7 @@ object UsbDefaultConfig {
         if (mode == UsbDefaultMode.UNKNOWN) return false
         // `svc` applies the change ON-DEVICE even when its (empty) response stream closes early, so we
         // can't trust the stream result. Fire it, cache optimistically, then CONFIRM by reading back.
-        runShell(context, "svc usb setScreenUnlockedFunctions ${mode.svcArg}".trimEnd())
+        runShell(context, "svc usb setScreenUnlockedFunctions ${mode.svcArg}".trimEnd(), ensure = true)
         AppPreferences(context).setUsbDefaultMode(mode.name)
         val readback = runCatching { readViaShell(context) }.getOrNull()
         // A null read-back means the link dropped (expected when switching to CHARGING kills USB-adb) —
@@ -118,9 +137,14 @@ object UsbDefaultConfig {
      * flaky ("Stream closed"), so retry once with a fresh connection — mirroring the daemon launcher.
      * Returns null if both attempts fail. Call OFF the main thread.
      */
-    private fun runShell(context: Context, cmd: String): String? {
-        repeat(2) { attempt ->
-            val connected = if (attempt == 0) AdbShell.ensureConnected(context) else AdbShell.forceReconnect(context)
+    private fun runShell(context: Context, cmd: String, ensure: Boolean): String? {
+        val attempts = if (ensure) 2 else 1
+        repeat(attempts) { attempt ->
+            val connected = when {
+                !ensure -> AdbConnectionManager.getInstance(context).isConnected // opportunistic: never force
+                attempt == 0 -> AdbShell.ensureConnected(context)
+                else -> AdbShell.forceReconnect(context)
+            }
             if (!connected) return@repeat
             val out = runCatching {
                 AdbShell.openShell(context, cmd).use { s -> s.openInputStream().use { String(it.readBytes()) } }
@@ -128,7 +152,7 @@ object UsbDefaultConfig {
                 .getOrNull()
             if (out != null) return out
         }
-        AppLogger.w(TAG, "USB shell cmd failed after retry ('$cmd')")
+        if (ensure) AppLogger.w(TAG, "USB shell cmd failed after retry ('$cmd')")
         return null
     }
 

--- a/app/src/main/java/com/baba/callvault/integrations/adb/UsbDefaultConfig.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/adb/UsbDefaultConfig.kt
@@ -1,0 +1,136 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.integrations.adb
+
+import android.content.Context
+import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.utils.AppLogger
+
+/**
+ * The device's **Default USB Configuration** (Developer options → "Default USB Configuration") — i.e.
+ * the USB functions applied when the screen is unlocked (`screen_unlocked_functions`).
+ *
+ * **Why CallVault cares.** On OnePlus/Xiaomi/Samsung a DATA default (File transfer, etc.) makes the USB
+ * gadget renegotiate on every screen on/off transition, which **restarts `adbd`** — and that kills the
+ * shell-uid recorder daemon. If it happens mid-call (user locks the phone) the recording stops. Setting
+ * the default to **"No data transfer / Charging only"** (no screen-unlocked functions) removes that
+ * churn, so the daemon survives a screen lock and the recording continues. Confirmed on-device.
+ *
+ * Read via `dumpsys usb` and changed via `svc usb setScreenUnlockedFunctions <fn>`, both over the app's
+ * embedded ADB shell (shell uid holds the privilege). Both are framework-level → OEM-agnostic.
+ */
+enum class UsbDefaultMode(
+    /** Argument to `svc usb setScreenUnlockedFunctions` ("" = charging/off). */
+    val svcArg: String,
+) {
+    /** "No data transfer / Charging only" — RECOMMENDED; the recorder survives a screen lock. */
+    CHARGING(""),
+    /** "File transfer / Android Auto" (MTP). */
+    FILE_TRANSFER("mtp"),
+    /** "PTP". */
+    PTP("ptp"),
+    /** "USB tethering" (RNDIS). */
+    TETHERING("rndis"),
+    /** "MIDI". */
+    MIDI("midi"),
+    /** Couldn't read / unrecognised value. */
+    UNKNOWN(""),
+}
+
+object UsbDefaultConfig {
+
+    private const val TAG = "CV:UsbDefault"
+
+    /** The only mode in which recording reliably survives a mid-call screen lock. */
+    val RECOMMENDED = UsbDefaultMode.CHARGING
+
+    /** Modes offered to the user in the picker (UNKNOWN is never a choice). */
+    val SELECTABLE = listOf(
+        UsbDefaultMode.CHARGING,
+        UsbDefaultMode.FILE_TRANSFER,
+        UsbDefaultMode.PTP,
+        UsbDefaultMode.TETHERING,
+        UsbDefaultMode.MIDI,
+    )
+
+    /**
+     * Reads the current Default USB Configuration over the ADB shell (`dumpsys usb`). Returns null when
+     * there is no live shell to read through (caller should fall back to [cached]); does NOT force a
+     * connection, so it never causes WD/adbd churn. Caches the value on success. Call OFF the main thread.
+     */
+    fun readViaShell(context: Context): UsbDefaultMode? {
+        val out = runShell(context, READ_CMD) ?: return null
+        // Filter for the relevant line in Kotlin rather than a `| grep` (pipes are fragile over `shell:`).
+        val line = out.lineSequence().firstOrNull { it.contains("screen_unlocked_functions") } ?: return null
+        val mode = parse(line)
+        if (mode != UsbDefaultMode.UNKNOWN) AppPreferences(context).setUsbDefaultMode(mode.name)
+        AppLogger.i(TAG, "Default USB Configuration read: $mode (raw: '${line.trim()}')")
+        return mode
+    }
+
+    /** The last successfully-read value (persisted), for UI shown while no shell is available. */
+    fun cached(context: Context): UsbDefaultMode =
+        runCatching { UsbDefaultMode.valueOf(AppPreferences(context).getUsbDefaultMode() ?: "") }
+            .getOrDefault(UsbDefaultMode.UNKNOWN)
+
+    /**
+     * Sets the Default USB Configuration over the ADB shell (ensures a connection first). Returns true if
+     * the command was delivered.
+     *
+     * NOTE: switching to [UsbDefaultMode.CHARGING] drops USB *data* (including USB-adb) until the user
+     * picks a data mode again — harmless in normal wireless/loopback use, but it means a cable plugged
+     * into a PC defaults to charging. Call OFF the main thread.
+     */
+    fun setViaShell(context: Context, mode: UsbDefaultMode): Boolean {
+        if (mode == UsbDefaultMode.UNKNOWN) return false
+        // `svc` applies the change ON-DEVICE even when its (empty) response stream closes early, so we
+        // can't trust the stream result. Fire it, cache optimistically, then CONFIRM by reading back.
+        runShell(context, "svc usb setScreenUnlockedFunctions ${mode.svcArg}".trimEnd())
+        AppPreferences(context).setUsbDefaultMode(mode.name)
+        val readback = runCatching { readViaShell(context) }.getOrNull()
+        // A null read-back means the link dropped (expected when switching to CHARGING kills USB-adb) —
+        // treat that as applied; only a read-back showing a DIFFERENT mode is a real failure.
+        val ok = readback == null || readback == mode
+        AppLogger.i(TAG, "Set Default USB Configuration to $mode (read-back=$readback, ok=$ok)")
+        return ok
+    }
+
+    private fun parse(dumpsysLine: String): UsbDefaultMode {
+        val v = dumpsysLine.substringAfter("screen_unlocked_functions=", "").trim().lowercase()
+        return when {
+            v.contains("mtp") -> UsbDefaultMode.FILE_TRANSFER
+            v.contains("ptp") -> UsbDefaultMode.PTP
+            v.contains("rndis") -> UsbDefaultMode.TETHERING
+            v.contains("midi") -> UsbDefaultMode.MIDI
+            v.isEmpty() || v == "none" -> UsbDefaultMode.CHARGING
+            else -> UsbDefaultMode.UNKNOWN
+        }
+    }
+
+    /**
+     * Runs [cmd] over the embedded ADB shell and returns its stdout. The wireless/loopback link is
+     * flaky ("Stream closed"), so retry once with a fresh connection — mirroring the daemon launcher.
+     * Returns null if both attempts fail. Call OFF the main thread.
+     */
+    private fun runShell(context: Context, cmd: String): String? {
+        repeat(2) { attempt ->
+            val connected = if (attempt == 0) AdbShell.ensureConnected(context) else AdbShell.forceReconnect(context)
+            if (!connected) return@repeat
+            val out = runCatching {
+                AdbShell.openShell(context, cmd).use { s -> s.openInputStream().use { String(it.readBytes()) } }
+            }.onFailure { AppLogger.d(TAG, "USB shell cmd attempt ${attempt + 1} failed ('$cmd'): ${it.message}") }
+                .getOrNull()
+            if (out != null) return out
+        }
+        AppLogger.w(TAG, "USB shell cmd failed after retry ('$cmd')")
+        return null
+    }
+
+    private const val READ_CMD = "dumpsys usb"
+}

--- a/app/src/main/java/com/baba/callvault/server/RecorderServerLauncher.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderServerLauncher.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import android.os.SystemClock
 import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.integrations.adb.AdbShell
+import com.baba.callvault.integrations.adb.UsbDefaultConfig
 import com.baba.callvault.utils.AppLogger
 
 /**
@@ -199,6 +200,10 @@ object RecorderServerLauncher {
      * user toggle. No-op if WD is already off or WRITE_SECURE_SETTINGS is missing.
      */
     private fun applyWdPolicy(context: Context) {
+        // We still hold the ADB shell here (before WD is turned off) — opportunistically refresh the
+        // USB-default cache that drives the "locking the screen may stop recording" warning. Never forces
+        // a connection (no-op when the shell isn't up), so it adds no churn and only a fast dumpsys read.
+        runCatching { UsbDefaultConfig.readIfConnected(context) }
         if (AdbShell.disableWirelessDebugging(context)) {
             AppLogger.i(TAG, "Wireless debugging disabled (daemon connected; commands flow over binder)")
         } else {

--- a/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/DaemonKeepAliveService.kt
@@ -25,6 +25,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.baba.callvault.R
 import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.integrations.adb.UsbDefaultConfig
 import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.server.RecorderServerLauncher
 import com.baba.callvault.utils.AppLogger
@@ -173,20 +174,28 @@ class DaemonKeepAliveService : Service() {
         }
     }
 
-    private fun buildNotification(ready: Boolean): Notification =
-        NotificationCompat.Builder(this, CHANNEL_ID)
+    private fun buildNotification(ready: Boolean): Notification {
+        val baseText = getString(if (ready) R.string.notif_readiness_ready_text else R.string.notif_readiness_starting_text)
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.stat_notify_sync)
             .setContentTitle(
                 getString(if (ready) R.string.notif_readiness_ready_title else R.string.notif_readiness_starting_title),
             )
-            .setContentText(
-                getString(if (ready) R.string.notif_readiness_ready_text else R.string.notif_readiness_starting_text),
-            )
+            .setContentText(baseText)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setPriority(NotificationCompat.PRIORITY_MIN)
             .setVisibility(NotificationCompat.VISIBILITY_SECRET)
-            .build()
+
+        // When recording is ready BUT the USB default is a data mode, locking the screen mid-call can kill
+        // the recorder — surface that right on the readiness notification so the user can act.
+        if (ready && UsbDefaultConfig.isScreenLockRisk(this)) {
+            val warning = getString(R.string.notif_usb_lock_warning)
+            builder.setContentText(warning)
+                .setStyle(NotificationCompat.BigTextStyle().bigText("$baseText\n$warning"))
+        }
+        return builder.build()
+    }
 
     override fun onDestroy() {
         watchdogHandler.removeCallbacks(watchdog)

--- a/app/src/main/java/com/baba/callvault/ui/common/DropdownComponents.kt
+++ b/app/src/main/java/com/baba/callvault/ui/common/DropdownComponents.kt
@@ -40,6 +40,8 @@ data class OptionItem(
  * @param options          All available options shown in the dropdown menu.
  * @param onOptionSelected Called with the chosen [OptionItem] when the user picks a new option.
  * @param modifier         Optional layout modifier forwarded to the root [ExposedDropdownMenuBox].
+ * @param enabled          When `false`, the field is greyed out and can't be opened (e.g. while a
+ *                         selection is being applied). Defaults to `true`.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,25 +50,29 @@ fun M3DropdownField(
     selected: OptionItem,
     options: List<OptionItem>,
     onOptionSelected: (OptionItem) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     var expanded by remember { mutableStateOf(false) }
+    // Never leave the menu open once the field is disabled mid-interaction.
+    if (!enabled && expanded) expanded = false
 
     ExposedDropdownMenuBox(
         expanded         = expanded,
-        onExpandedChange = { expanded = !expanded },
+        onExpandedChange = { if (enabled) expanded = !expanded },
         modifier         = modifier.padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
         OutlinedTextField(
             value         = selected.label,
             onValueChange = {},
             readOnly      = true,
+            enabled       = enabled,
             singleLine    = true,
             maxLines      = 1,
             label         = { Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis) },
             trailingIcon  = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             colors        = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
-            modifier      = Modifier.menuAnchor(type = ExposedDropdownMenuAnchorType.PrimaryNotEditable, enabled = true).fillMaxWidth()
+            modifier      = Modifier.menuAnchor(type = ExposedDropdownMenuAnchorType.PrimaryNotEditable, enabled = enabled).fillMaxWidth()
         )
         ExposedDropdownMenu(
             expanded         = expanded,

--- a/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
@@ -196,6 +196,15 @@ fun HomeScreen(
                 )
             }
 
+            if (uiState.usbScreenLockRisk) {
+                item {
+                    UsbReliabilityAdvisoryCard(
+                        fixing = uiState.usbFixInProgress,
+                        onFix = { viewModel.setUsbChargingOnly() },
+                    )
+                }
+            }
+
             uiState.updatedToVersion?.let { version ->
                 item {
                     UpdatedBannerCard(
@@ -339,6 +348,58 @@ private fun UpdatedBannerCard(version: String, onDismiss: () -> Unit) {
                     imageVector = Icons.Filled.Close,
                     contentDescription = stringResource(R.string.general_close),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Gentle advisory shown under the hero card when the Default USB Configuration is a DATA mode — locking
+ * the screen mid-call can then stop recording. NOT a red "broken" state (recording works otherwise), so
+ * it uses a soft warning tint. Tapping it applies the one-tap fix (set USB to "Charging only"); a spinner
+ * replaces the action while that runs.
+ */
+@Composable
+private fun UsbReliabilityAdvisoryCard(fixing: Boolean, onFix: () -> Unit) {
+    val accent = LocalCvBrand.current.warning
+    val tinted = accent.copy(alpha = 0.10f).compositeOver(MaterialTheme.colorScheme.surface)
+    CvCard(
+        color = tinted,
+        onClick = if (fixing) null else onFix,
+        contentPadding = PaddingValues(16.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Filled.WarningAmber,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.home_usb_advisory_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = stringResource(R.string.home_usb_advisory_text),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.width(10.dp))
+            if (fixing) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            } else {
+                Text(
+                    text = stringResource(R.string.home_usb_advisory_fix),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = accent,
                 )
             }
         }

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -1053,6 +1053,7 @@ private fun UsbDefaultConfigRow() {
             label = stringResource(R.string.settings_usb_default_label),
             selected = selected,
             options = options,
+            enabled = !applying,
             onOptionSelected = { opt ->
                 val target = runCatching { UsbDefaultMode.valueOf(opt.key) }.getOrNull() ?: return@M3DropdownField
                 if (target == mode || applying) return@M3DropdownField
@@ -1064,8 +1065,24 @@ private fun UsbDefaultConfigRow() {
                 }
             },
         )
-        HintText(stringResource(R.string.settings_usb_default_hint))
-        if (applying) HintText(stringResource(R.string.settings_usb_default_applying))
+        // While the change is being applied + verified, grey the field (above) and show a live spinner,
+        // so the (few-second) delay before the value updates can't be mistaken for "nothing happened".
+        if (applying) {
+            Row(
+                modifier = Modifier.padding(start = 16.dp, top = 2.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.settings_usb_default_applying),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            HintText(stringResource(R.string.settings_usb_default_hint))
+        }
     }
 }
 

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -55,7 +55,10 @@ import com.baba.callvault.utils.AppLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.annotation.StringRes
 import com.baba.callvault.data.AppPreferences
+import com.baba.callvault.integrations.adb.UsbDefaultConfig
+import com.baba.callvault.integrations.adb.UsbDefaultMode
 import com.baba.callvault.data.RetentionPeriod
 import com.baba.callvault.data.StorageTarget
 import com.baba.callvault.integrations.scrcpy.RECOMMENDED_AUDIO_BIT_RATE
@@ -992,7 +995,73 @@ private fun BugReportSection(
         }
 
         OfflineRecordingToggle()
+
+        SettingsDivider()
+
+        UsbDefaultConfigRow()
     }
+}
+
+/**
+ * Lets the user pick the device's **Default USB Configuration** (what USB does when the screen unlocks)
+ * from inside the app, applied over the embedded ADB shell. **"Charging only" is recommended**: on many
+ * OEMs a data default (File transfer, etc.) makes the USB gadget renegotiate on every screen on/off,
+ * restarting adbd and killing the recorder daemon — which stops a recording if you lock the phone
+ * mid-call. The other modes are offered for people who rely on them (e.g. USB tethering); picking one
+ * just trades that reliability. Reads the live value on open (falls back to the cached value), and shows
+ * a spinner-style "applying" hint while the shell command runs.
+ */
+@Composable
+private fun UsbDefaultConfigRow() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var mode by remember { mutableStateOf(UsbDefaultConfig.cached(context)) }
+    var applying by remember { mutableStateOf(false) }
+
+    // Refresh the live value once when shown (readViaShell connects+retries internally); falls back to
+    // the shown cached value on failure.
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) { UsbDefaultConfig.readViaShell(context) }?.let { mode = it }
+    }
+
+    val recommendedLabel = stringResource(R.string.general_recommended)
+    val options = UsbDefaultConfig.SELECTABLE.map { m ->
+        val base = stringResource(usbModeLabelRes(m))
+        OptionItem(m.name, if (m == UsbDefaultConfig.RECOMMENDED) "$base ($recommendedLabel)" else base)
+    }
+    // When the current value is UNKNOWN (never read), don't force a wrong selection — show recommended.
+    val selected = options.find { it.key == mode.name } ?: options.first()
+
+    DropdownRow {
+        M3DropdownField(
+            label = stringResource(R.string.settings_usb_default_label),
+            selected = selected,
+            options = options,
+            onOptionSelected = { opt ->
+                val target = runCatching { UsbDefaultMode.valueOf(opt.key) }.getOrNull() ?: return@M3DropdownField
+                if (target == mode || applying) return@M3DropdownField
+                applying = true
+                scope.launch {
+                    val ok = withContext(Dispatchers.IO) { UsbDefaultConfig.setViaShell(context, target) }
+                    if (ok) mode = target
+                    applying = false
+                }
+            },
+        )
+        HintText(stringResource(R.string.settings_usb_default_hint))
+        if (applying) HintText(stringResource(R.string.settings_usb_default_applying))
+    }
+}
+
+/** Maps a [UsbDefaultMode] to its user-facing label string resource. */
+@StringRes
+private fun usbModeLabelRes(mode: UsbDefaultMode): Int = when (mode) {
+    UsbDefaultMode.CHARGING -> R.string.usb_mode_charging
+    UsbDefaultMode.FILE_TRANSFER -> R.string.usb_mode_file_transfer
+    UsbDefaultMode.PTP -> R.string.usb_mode_ptp
+    UsbDefaultMode.TETHERING -> R.string.usb_mode_tethering
+    UsbDefaultMode.MIDI -> R.string.usb_mode_midi
+    UsbDefaultMode.UNKNOWN -> R.string.usb_mode_charging
 }
 
 /**

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -298,6 +298,12 @@ fun SettingsContent(
                     onToggle = { onToggleSection(SECTION_VISUAL) }
                 )
             }
+            item {
+                ReliabilitySection(
+                    expanded = openSection == SECTION_RELIABILITY,
+                    onToggle = { onToggleSection(SECTION_RELIABILITY) }
+                )
+            }
             // Debug section: always visible so anyone can enable logging and share logs to report an issue.
             item {
                 BugReportSection(
@@ -384,6 +390,7 @@ private const val SECTION_STORAGE = "storage"
 private const val SECTION_RETENTION = "retention"
 private const val SECTION_AUDIO = "audio"
 private const val SECTION_VISUAL = "visual"
+private const val SECTION_RELIABILITY = "reliability"
 private const val SECTION_BUG_REPORT = "bug_report"
 private const val SECTION_UPDATES = "updates"
 private const val SECTION_ABOUT = "about"
@@ -994,10 +1001,19 @@ private fun BugReportSection(
             }
         }
 
+    }
+}
+
+/**
+ * "Reliability" — controls that keep recording working in tricky conditions: recording without Wi-Fi
+ * (loopback opt-in) and the Default USB Configuration that stops a screen-lock from killing the recorder
+ * mid-call. Grouped together so users have one place to make recording robust.
+ */
+@Composable
+private fun ReliabilitySection(expanded: Boolean, onToggle: () -> Unit) {
+    SettingsSection(title = stringResource(R.string.settings_section_reliability), expanded = expanded, onToggle = onToggle) {
         OfflineRecordingToggle()
-
         SettingsDivider()
-
         UsbDefaultConfigRow()
     }
 }

--- a/app/src/main/java/com/baba/callvault/ui/screens/WizardScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/WizardScreen.kt
@@ -34,16 +34,20 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -59,9 +63,17 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.baba.callvault.R
+import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.data.StorageTarget
 import com.baba.callvault.data.SyncScheduleMode
+import com.baba.callvault.integrations.adb.UsbDefaultConfig
+import com.baba.callvault.integrations.adb.UsbDefaultMode
 import com.baba.callvault.integrations.scrcpy.ScrcpyAudioCodec
+import com.baba.callvault.ui.common.OfflineDialogMode
+import com.baba.callvault.ui.common.OfflineRecordingDialog
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import com.baba.callvault.system.PersistentFolderPickerContract
 import com.baba.callvault.system.storage.SafHelper
 import com.baba.callvault.system.takePersistableFolderPermission
@@ -154,6 +166,7 @@ fun WizardScreen(
             add(WizardStep.STORAGE)
             if (usesDrive) add(WizardStep.SCHEDULE)
             add(WizardStep.AUTO_RECORD)
+            add(WizardStep.RELIABILITY)
             add(WizardStep.AUDIO)
             add(WizardStep.FILE_NAME)
         }
@@ -245,6 +258,7 @@ fun WizardScreen(
                         onIncomingChange = viewModel::setAutoRecordIncoming,
                         onOutgoingChange = viewModel::setAutoRecordOutgoing
                     )
+                    WizardStep.RELIABILITY -> ReliabilityStep()
                     WizardStep.AUDIO -> AudioStep(
                         audioCodec = audioCodec,
                         audioBitRate = audioBitRate,
@@ -262,7 +276,7 @@ fun WizardScreen(
 }
 
 /** The logical steps of the wizard (the schedule step is conditionally included). */
-private enum class WizardStep { STORAGE, SCHEDULE, AUTO_RECORD, AUDIO, FILE_NAME }
+private enum class WizardStep { STORAGE, SCHEDULE, AUTO_RECORD, RELIABILITY, AUDIO, FILE_NAME }
 
 // ── Shell: header + progress + bottom bar ─────────────────────────────────────────────────────
 
@@ -676,6 +690,125 @@ private fun AutoRecordStep(
     }
 }
 
+/**
+ * Onboarding "Reliability" step — two OPTIONAL, one-tap opt-ins that make recording robust:
+ *  1. **USB "Charging only"** — on many phones, locking the screen mid-call restarts adbd and kills the
+ *     recorder; setting the Default USB Configuration to "Charging only" prevents that. Applied over the
+ *     embedded shell in one tap.
+ *  2. **Offline recording (no Wi-Fi)** — the warned loopback opt-in (via the shared dialog).
+ * Both are skippable (Next always advances) — nothing here gates setup.
+ */
+@Composable
+private fun ReliabilityStep() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var usbMode by remember { mutableStateOf(UsbDefaultConfig.cached(context)) }
+    var usbApplying by remember { mutableStateOf(false) }
+    // Read the live value once (connects+retries internally); falls back to the cached value.
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) { UsbDefaultConfig.readViaShell(context) }?.let { usbMode = it }
+    }
+    val chargingOnly = usbMode == UsbDefaultMode.CHARGING
+
+    var showOffline by remember { mutableStateOf(false) }
+    var offlineEnabled by remember { mutableStateOf(AppPreferences(context).isOfflineRecordingEnabled()) }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        // ── USB "Charging only" ──
+        CvCard {
+            Text(
+                text = stringResource(R.string.wizard_reliability_usb_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.wizard_reliability_usb_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+            when {
+                chargingOnly -> WizardDoneRow(stringResource(R.string.wizard_reliability_usb_done))
+                usbApplying -> WizardApplyingRow(stringResource(R.string.settings_usb_default_applying))
+                else -> CvPrimaryButton(
+                    text = stringResource(R.string.wizard_reliability_usb_button),
+                    onClick = {
+                        usbApplying = true
+                        scope.launch {
+                            withContext(Dispatchers.IO) { UsbDefaultConfig.setViaShell(context, UsbDefaultMode.CHARGING) }
+                            usbMode = UsbDefaultConfig.cached(context)
+                            usbApplying = false
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+
+        // ── Offline recording (no Wi-Fi) ──
+        CvCard {
+            Text(
+                text = stringResource(R.string.settings_offline_recording_label),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.settings_offline_recording_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+            if (offlineEnabled) {
+                WizardDoneRow(stringResource(R.string.wizard_reliability_offline_done))
+            } else {
+                CvSecondaryButton(
+                    text = stringResource(R.string.wizard_reliability_offline_button),
+                    onClick = { showOffline = true },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+
+    if (showOffline) {
+        OfflineRecordingDialog(
+            mode = OfflineDialogMode.ENABLE,
+            onResult = { offlineEnabled = it },
+            onClose = { showOffline = false },
+        )
+    }
+}
+
+/** A small "done" row: a teal check + label, shown once a reliability opt-in has been applied. */
+@Composable
+private fun WizardDoneRow(text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = Icons.Filled.Check,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.primary)
+    }
+}
+
+/** A small "applying" row: a spinner + label, shown while a shell change is in flight. */
+@Composable
+private fun WizardApplyingRow(text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+        Spacer(Modifier.width(10.dp))
+        Text(text, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
 @Composable
 private fun AudioStep(
     audioCodec: String,
@@ -747,6 +880,7 @@ private fun stepTitleRes(step: WizardStep): Int = when (step) {
     WizardStep.STORAGE -> R.string.wizard_storage_title
     WizardStep.SCHEDULE -> R.string.wizard_schedule_title
     WizardStep.AUTO_RECORD -> R.string.wizard_auto_record_title
+    WizardStep.RELIABILITY -> R.string.wizard_reliability_title
     WizardStep.AUDIO -> R.string.wizard_audio_title
     WizardStep.FILE_NAME -> R.string.wizard_filename_title
 }
@@ -755,6 +889,7 @@ private fun stepSubtitleRes(step: WizardStep): Int = when (step) {
     WizardStep.STORAGE -> R.string.wizard_storage_subtitle
     WizardStep.SCHEDULE -> R.string.wizard_schedule_subtitle
     WizardStep.AUTO_RECORD -> R.string.wizard_auto_record_subtitle
+    WizardStep.RELIABILITY -> R.string.wizard_reliability_subtitle
     WizardStep.AUDIO -> R.string.wizard_audio_subtitle
     WizardStep.FILE_NAME -> R.string.wizard_filename_subtitle
 }

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
@@ -24,6 +24,8 @@ import com.baba.callvault.data.recordings.RecordingsRepository.RecordingItem
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingSource
 import com.baba.callvault.integrations.adb.AdbShell
 import com.baba.callvault.integrations.adb.DeveloperOptions
+import com.baba.callvault.integrations.adb.UsbDefaultConfig
+import com.baba.callvault.integrations.adb.UsbDefaultMode
 import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.system.updates.UpdateInstallWorker
 import com.baba.callvault.system.updates.UpdateScheduler
@@ -127,6 +129,10 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         val updatedToVersion: String? = null,
         /** Whether to show the one-time "What's new: off-Wi-Fi" intro modal (updated AND not seen yet). */
         val showWhatsNew: Boolean = false,
+        /** True when the USB default is a data mode → locking the screen mid-call can stop recording. */
+        val usbScreenLockRisk: Boolean = false,
+        /** True while the one-tap "set USB to Charging only" fix is running. */
+        val usbFixInProgress: Boolean = false,
         /** Uris of recordings currently being deleted — drives an inline spinner on their row. */
         val deletingUris: Set<Uri> = emptySet()
     ) {
@@ -265,6 +271,22 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         if (lastSeen != current) preferences.setLastSeenVersionCode(current)
     }
 
+    /**
+     * One-tap fix for the reliability advisory: sets the Default USB Configuration to "Charging only"
+     * over the embedded shell, so locking the screen mid-call no longer kills the recorder. Re-derives
+     * the risk flag afterwards so the advisory clears on success.
+     */
+    fun setUsbChargingOnly() {
+        if (_uiState.value.usbFixInProgress) return
+        _uiState.update { it.copy(usbFixInProgress = true) }
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) { UsbDefaultConfig.setViaShell(appContext, UsbDefaultMode.CHARGING) }
+            _uiState.update {
+                it.copy(usbFixInProgress = false, usbScreenLockRisk = UsbDefaultConfig.isScreenLockRisk(appContext))
+            }
+        }
+    }
+
     /** Dismisses the "updated successfully" banner (clears its persisted state). */
     fun dismissUpdatedBanner() {
         preferences.setUpdateSuccessBannerVersion(null)
@@ -295,7 +317,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                 updatedToVersion = updatedTo,
                 // The off-Wi-Fi "What's new" is a ONE-TIME feature intro: show it only after an update
                 // AND only until it's been seen once, so it never recurs on every later release.
-                showWhatsNew = updatedTo != null && !preferences.hasSeenOffWifiWhatsNew()
+                showWhatsNew = updatedTo != null && !preferences.hasSeenOffWifiWhatsNew(),
+                // Advisory when the USB default is a data mode (cheap cached read; never blocks/forces ADB).
+                usbScreenLockRisk = UsbDefaultConfig.isScreenLockRisk(appContext)
             )
         }
         // An install-over can drop WRITE_SECURE_SETTINGS while the daemon stays warm (recording still

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -165,6 +165,14 @@
     <string name="folder_cloud_warning">⚠ Dieser Aufnahmeordner liegt in der Cloud, was für die Aufnahme unzuverlässig ist. Wählen Sie einen Ordner auf dem Gerät.</string>
     <string name="settings_offline_recording_label">Offline-Aufnahme (ohne Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Anrufe auch dann aufnehmen, wenn kein Wi-Fi-Netzwerk verfügbar ist.</string>
+    <string name="settings_usb_default_label">USB beim Entsperren</string>
+    <string name="settings_usb_default_hint">„Nur Laden“ hält die Aufnahme am Leben, wenn du während eines Anrufs den Bildschirm sperrst. Andere Modi erlauben Datenübertragung per USB, können aber eine Aufnahme beim Sperren unterbrechen.</string>
+    <string name="settings_usb_default_applying">Wird angewendet…</string>
+    <string name="usb_mode_charging">Nur Laden (keine Daten)</string>
+    <string name="usb_mode_file_transfer">Dateiübertragung</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">USB-Tethering</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">Offline-Aufnahme aktivieren?</string>
     <string name="offline_recording_warning_message">Dadurch wird ein lokaler Debugging-Port auf Ihrem Telefon geöffnet, damit Anrufe ohne Wi-Fi aufgenommen werden können. Er ist durch den Schlüssel Ihres Geräts geschützt, stellt aber einen kleinen Sicherheitskompromiss dar. Aktivieren Sie ihn nur, wenn Sie Anrufe ohne Wi-Fi aufnehmen müssen.</string>
     <string name="offline_recording_warning_continue">Trotzdem fortfahren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -206,6 +206,14 @@
     <string name="storage_target_drive">Nur Google Drive</string>
     <string name="storage_target_local">Nur auf diesem Gerät</string>
     <string name="wizard_audio_subtitle">Wählen Sie das Aufnahmeformat und die Bitrate. Opus mit 16 kbps wird für klare Sprache bei geringer Dateigröße empfohlen.</string>
+    <string name="wizard_reliability_title">Zuverlässige Aufnahme</string>
+    <string name="wizard_reliability_subtitle">Zwei optionale Einstellungen, die die Aufnahme unter schwierigen Bedingungen am Laufen halten. Du kannst sie überspringen und später in den Einstellungen ändern.</string>
+    <string name="wizard_reliability_usb_title">Aufnahme beim Sperren des Bildschirms fortsetzen</string>
+    <string name="wizard_reliability_usb_desc">Bei manchen Handys kann das Sperren des Bildschirms während eines Anrufs die Aufnahme stoppen. „Nur Laden“ für USB verhindert das. (Dein Handy lädt dann standardmäßig am PC – wähle bei Bedarf manuell Dateiübertragung.)</string>
+    <string name="wizard_reliability_usb_button">USB auf „Nur Laden“ setzen</string>
+    <string name="wizard_reliability_usb_done">USB ist auf „Nur Laden“ eingestellt</string>
+    <string name="wizard_reliability_offline_button">Aktivieren</string>
+    <string name="wizard_reliability_offline_done">Offline-Aufnahme ist aktiviert</string>
     <string name="wizard_audio_title">Audioqualität</string>
     <string name="wizard_auto_record_subtitle">Wählen Sie, welche Anrufe automatisch aufgezeichnet werden. Sie können dies später in den Einstellungen feinabstimmen.</string>
     <string name="wizard_auto_record_title">Automatische Aufnahme</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -178,6 +178,7 @@
     <string name="offline_recording_warning_continue">Trotzdem fortfahren</string>
     <string name="settings_section_about">Über</string>
     <string name="settings_section_audio">Tonkonfiguration</string>
+    <string name="settings_section_reliability">Zuverlässigkeit</string>
     <string name="settings_section_debug">Debug-Optionen</string>
     <string name="settings_section_recorder_server">Aufnahmedienst</string>
     <string name="settings_section_recording">Aufnahme</string>

--- a/app/src/main/res/values-de/strings_home.xml
+++ b/app/src/main/res/values-de/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">Aufnahme ohne Wi-Fi ist aktiv.</string>
     <string name="offline_recording_disabling">Aufnahme ohne Wi-Fi wird deaktiviert…</string>
     <string name="home_support_pill">Unterstützen</string>
+    <string name="home_usb_advisory_title">Aufnahme kann bei Sperrbildschirm stoppen</string>
+    <string name="home_usb_advisory_text">USB ist auf einen Datenmodus eingestellt. Tippe, um „Nur Laden“ zu wählen.</string>
+    <string name="home_usb_advisory_fix">Beheben</string>
 </resources>

--- a/app/src/main/res/values-de/strings_notifications.xml
+++ b/app/src/main/res/values-de/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">Anrufrekorder wird gestartet…</string>
     <string name="notif_readiness_ready_text">Der Rekorder ist verbunden.</string>
     <string name="notif_readiness_starting_text">Rekorder wird verbunden – Anrufe werden erst aufgenommen, wenn dies abgeschlossen ist.</string>
+    <string name="notif_usb_lock_warning">Das Sperren des Bildschirms während eines Anrufs kann die Aufnahme stoppen. Stelle USB unter Einstellungen → Zuverlässigkeit auf „Nur Laden“.</string>
     <string name="notif_pairing_channel">ADB-Kopplung</string>
     <string name="notif_pairing_searching_title">Kopplungsdienst wird gesucht…</string>
     <string name="notif_pairing_searching_text">Öffnen Sie auf dem Telefon den Dialog „Gerät über Kopplungscode koppeln“.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -206,6 +206,14 @@
     <string name="storage_target_drive">Solo en Google Drive</string>
     <string name="storage_target_local">Solo en este dispositivo</string>
     <string name="wizard_audio_subtitle">Elija el formato de grabación y la tasa de bits. Se recomienda Opus a 16 kbps para una voz clara con archivos de tamaño reducido.</string>
+    <string name="wizard_reliability_title">Grabación fiable</string>
+    <string name="wizard_reliability_subtitle">Dos ajustes opcionales que mantienen la grabación en condiciones difíciles. Puedes omitirlos y cambiarlos más tarde en Ajustes.</string>
+    <string name="wizard_reliability_usb_title">Sigue grabando al bloquear la pantalla</string>
+    <string name="wizard_reliability_usb_desc">En algunos teléfonos, bloquear la pantalla durante una llamada puede detener la grabación. Poner USB en "Solo carga" lo evita. (El teléfono se quedará en carga al conectarlo a un PC; elige Transferencia de archivos manualmente cuando la necesites.)</string>
+    <string name="wizard_reliability_usb_button">Poner USB en Solo carga</string>
+    <string name="wizard_reliability_usb_done">USB está en Solo carga</string>
+    <string name="wizard_reliability_offline_button">Activar</string>
+    <string name="wizard_reliability_offline_done">La grabación sin conexión está activada</string>
     <string name="wizard_audio_title">Calidad de audio</string>
     <string name="wizard_auto_record_subtitle">Elija qué llamadas se graban automáticamente. Puede ajustar esto con más detalle más tarde en Ajustes.</string>
     <string name="wizard_auto_record_title">Grabación automática</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -178,6 +178,7 @@
     <string name="offline_recording_warning_continue">Continuar de todos modos</string>
     <string name="settings_section_about">Acerca de</string>
     <string name="settings_section_audio">Configuración de audio</string>
+    <string name="settings_section_reliability">Fiabilidad</string>
     <string name="settings_section_debug">Opciones de depuración</string>
     <string name="settings_section_recorder_server">Servicio de grabación</string>
     <string name="settings_section_recording">Grabando</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -165,6 +165,14 @@
     <string name="folder_cloud_warning">⚠ Esta carpeta de grabación está en la nube, lo que no es fiable para la captura. Elige una carpeta en el dispositivo.</string>
     <string name="settings_offline_recording_label">Grabación sin conexión (sin Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Graba llamadas incluso cuando no hay red Wi-Fi.</string>
+    <string name="settings_usb_default_label">USB al desbloquear</string>
+    <string name="settings_usb_default_hint">"Solo carga" mantiene la grabación activa si bloqueas la pantalla durante una llamada. Los otros modos permiten transferir datos por USB, pero pueden interrumpir una grabación al bloquear el teléfono.</string>
+    <string name="settings_usb_default_applying">Aplicando…</string>
+    <string name="usb_mode_charging">Solo carga (sin datos)</string>
+    <string name="usb_mode_file_transfer">Transferencia de archivos</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">Anclaje USB</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">¿Activar la grabación sin conexión?</string>
     <string name="offline_recording_warning_message">Esto abre un puerto de depuración local en tu teléfono para que las llamadas puedan grabarse sin Wi-Fi. Está protegido por la clave de tu dispositivo, pero supone una pequeña concesión de seguridad. Actívalo solo si necesitas grabar llamadas sin Wi-Fi.</string>
     <string name="offline_recording_warning_continue">Continuar de todos modos</string>

--- a/app/src/main/res/values-es/strings_home.xml
+++ b/app/src/main/res/values-es/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">La grabación sin Wi-Fi está activada.</string>
     <string name="offline_recording_disabling">Desactivando la grabación sin Wi-Fi…</string>
     <string name="home_support_pill">Apoyar</string>
+    <string name="home_usb_advisory_title">La grabación puede detenerse al bloquear</string>
+    <string name="home_usb_advisory_text">USB está en un modo de datos. Toca para ponerlo en Solo carga.</string>
+    <string name="home_usb_advisory_fix">Corregir</string>
 </resources>

--- a/app/src/main/res/values-es/strings_notifications.xml
+++ b/app/src/main/res/values-es/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">Iniciando la grabadora de llamadas…</string>
     <string name="notif_readiness_ready_text">La grabadora está conectada.</string>
     <string name="notif_readiness_starting_text">Conectando la grabadora; las llamadas no se grabarán hasta que esto finalice.</string>
+    <string name="notif_usb_lock_warning">Bloquear la pantalla durante una llamada puede detener la grabación. Configura USB como "Solo carga" en Ajustes → Fiabilidad.</string>
     <string name="notif_pairing_channel">Vinculación de ADB</string>
     <string name="notif_pairing_searching_title">Buscando el servicio de vinculación…</string>
     <string name="notif_pairing_searching_text">Abra el cuadro de diálogo «Vincular dispositivo mediante código de vinculación» del teléfono.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -211,6 +211,14 @@
     <string name="storage_target_drive">Google Drive uniquement</string>
     <string name="storage_target_local">Sur cet appareil uniquement</string>
     <string name="wizard_audio_subtitle">Choisissez le format d\'enregistrement et le débit. Opus à 16 kbps est recommandé pour une voix claire dans des fichiers de petite taille.</string>
+    <string name="wizard_reliability_title">Enregistrement fiable</string>
+    <string name="wizard_reliability_subtitle">Deux réglages facultatifs qui maintiennent l\'enregistrement dans des conditions difficiles. Tu peux les ignorer et les modifier plus tard dans les Paramètres.</string>
+    <string name="wizard_reliability_usb_title">Continuer d\'enregistrer quand l\'écran se verrouille</string>
+    <string name="wizard_reliability_usb_desc">Sur certains téléphones, verrouiller l\'écran pendant un appel peut arrêter l\'enregistrement. Régler l\'USB sur « Charge uniquement » l\'empêche. (Ton téléphone se met alors en charge par défaut sur un PC — choisis Transfert de fichiers manuellement au besoin.)</string>
+    <string name="wizard_reliability_usb_button">Régler l\'USB sur Charge uniquement</string>
+    <string name="wizard_reliability_usb_done">L\'USB est réglé sur Charge uniquement</string>
+    <string name="wizard_reliability_offline_button">Activer</string>
+    <string name="wizard_reliability_offline_done">L\'enregistrement hors ligne est activé</string>
     <string name="wizard_audio_title">Qualité audio</string>
     <string name="wizard_auto_record_subtitle">Choisissez quels appels sont enregistrés automatiquement. Vous pourrez affiner ce réglage plus tard dans les Paramètres.</string>
     <string name="wizard_auto_record_title">Enregistrement automatique</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -183,6 +183,7 @@
     <string name="offline_recording_warning_continue">Continuer quand même</string>
     <string name="settings_section_about">À propos</string>
     <string name="settings_section_audio">Configuration audio</string>
+    <string name="settings_section_reliability">Fiabilité</string>
     <string name="settings_section_debug">Options de débogage</string>
     <string name="settings_section_recorder_server">Service d\'enregistrement</string>
     <string name="settings_section_recording">Enregistrement</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -170,6 +170,14 @@
     <string name="folder_cloud_warning">⚠ Ce dossier d\'enregistrement se trouve dans le cloud, ce qui n\'est pas fiable pour la capture. Choisissez un dossier sur l\'appareil.</string>
     <string name="settings_offline_recording_label">Enregistrement hors ligne (sans Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Enregistrer les appels même en l\'absence de réseau Wi-Fi.</string>
+    <string name="settings_usb_default_label">USB au déverrouillage</string>
+    <string name="settings_usb_default_hint">« Charge uniquement » maintient l\'enregistrement actif si tu verrouilles l\'écran pendant un appel. Les autres modes permettent le transfert de données en USB mais peuvent interrompre un enregistrement au verrouillage.</string>
+    <string name="settings_usb_default_applying">Application…</string>
+    <string name="usb_mode_charging">Charge uniquement (sans données)</string>
+    <string name="usb_mode_file_transfer">Transfert de fichiers</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">Partage de connexion USB</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">Activer l\'enregistrement hors ligne ?</string>
     <string name="offline_recording_warning_message">Cela ouvre un port de débogage local sur votre téléphone afin que les appels puissent être enregistrés sans Wi-Fi. Il est protégé par la clé de votre appareil, mais cela représente un léger compromis de sécurité. Ne l\'activez que si vous avez besoin d\'enregistrer des appels sans Wi-Fi.</string>
     <string name="offline_recording_warning_continue">Continuer quand même</string>

--- a/app/src/main/res/values-fr/strings_home.xml
+++ b/app/src/main/res/values-fr/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">L\'enregistrement sans Wi-Fi est activé.</string>
     <string name="offline_recording_disabling">Désactivation de l\'enregistrement sans Wi-Fi…</string>
     <string name="home_support_pill">Soutenir</string>
+    <string name="home_usb_advisory_title">L\'enregistrement peut s\'arrêter au verrouillage</string>
+    <string name="home_usb_advisory_text">L\'USB est en mode données. Appuie pour choisir Charge uniquement.</string>
+    <string name="home_usb_advisory_fix">Corriger</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_notifications.xml
+++ b/app/src/main/res/values-fr/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">Démarrage de l\'enregistreur d\'appels…</string>
     <string name="notif_readiness_ready_text">L\'enregistreur est connecté.</string>
     <string name="notif_readiness_starting_text">Connexion de l\'enregistreur — les appels ne seront pas enregistrés tant que ce n\'est pas terminé.</string>
+    <string name="notif_usb_lock_warning">Verrouiller l\'écran pendant un appel peut arrêter l\'enregistrement. Règle l\'USB sur « Charge uniquement » dans Paramètres → Fiabilité.</string>
     <string name="notif_pairing_channel">Association ADB</string>
     <string name="notif_pairing_searching_title">Recherche du service d\'association…</string>
     <string name="notif_pairing_searching_text">Ouvrez la boîte de dialogue « Associer l\'appareil à l\'aide d\'un code d\'association » du téléphone.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -165,6 +165,14 @@
     <string name="folder_cloud_warning">⚠ Ez a rögzítési mappa a felhőben van, ami megbízhatatlan a rögzítéshez. Válasszon egy eszközön lévő mappát.</string>
     <string name="settings_offline_recording_label">Offline rögzítés (Wi-Fi nélkül)</string>
     <string name="settings_offline_recording_desc">Hívások rögzítése akkor is, ha nincs Wi-Fi hálózat.</string>
+    <string name="settings_usb_default_label">USB a képernyő feloldásakor</string>
+    <string name="settings_usb_default_hint">A „Csak töltés“ életben tartja a rögzítést, ha hívás közben zárolod a képernyőt. A többi mód engedi az USB-adatátvitelt, de megszakíthatja a rögzítést a telefon zárolásakor.</string>
+    <string name="settings_usb_default_applying">Alkalmazás…</string>
+    <string name="usb_mode_charging">Csak töltés (adat nélkül)</string>
+    <string name="usb_mode_file_transfer">Fájlátvitel</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">USB-megosztás</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">Engedélyezi az offline rögzítést?</string>
     <string name="offline_recording_warning_message">Ez megnyit egy helyi hibakeresési portot a telefonján, hogy a hívások Wi-Fi nélkül is rögzíthetők legyenek. Az eszköz kulcsa védi, de kis biztonsági kompromisszumot jelent. Csak akkor engedélyezze, ha Wi-Fi nélkül kell hívásokat rögzítenie.</string>
     <string name="offline_recording_warning_continue">Folytatás mindenképp</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -206,6 +206,14 @@
     <string name="storage_target_drive">Csak Google Drive</string>
     <string name="storage_target_local">Csak erre az eszközre</string>
     <string name="wizard_audio_subtitle">Válassza ki a rögzítési formátumot és a bitrátát. A tiszta hang és a kis fájlméret érdekében az Opus 16 kbps ajánlott.</string>
+    <string name="wizard_reliability_title">Megbízható rögzítés</string>
+    <string name="wizard_reliability_subtitle">Két opcionális beállítás, amely nehéz körülmények között is működteti a rögzítést. Kihagyhatod, és később a Beállításokban módosíthatod.</string>
+    <string name="wizard_reliability_usb_title">A rögzítés folytatása a képernyő zárolásakor</string>
+    <string name="wizard_reliability_usb_desc">Egyes telefonokon a képernyő zárolása hívás közben leállíthatja a rögzítést. A „Csak töltés“ USB-beállítás megakadályozza ezt. (A telefon PC-hez csatlakoztatva ekkor töltésre vált – szükség esetén válaszd kézzel a Fájlátvitelt.)</string>
+    <string name="wizard_reliability_usb_button">USB beállítása Csak töltésre</string>
+    <string name="wizard_reliability_usb_done">Az USB „Csak töltés“ értékre van állítva</string>
+    <string name="wizard_reliability_offline_button">Bekapcsolás</string>
+    <string name="wizard_reliability_offline_done">Az offline rögzítés be van kapcsolva</string>
     <string name="wizard_audio_title">Hangminőség</string>
     <string name="wizard_auto_record_subtitle">Válassza ki, mely hívások rögzüljenek automatikusan. Ezt később a Beállításokban finomhangolhatja.</string>
     <string name="wizard_auto_record_title">Automatikus rögzítés</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -178,6 +178,7 @@
     <string name="offline_recording_warning_continue">Folytatás mindenképp</string>
     <string name="settings_section_about">Névjegy</string>
     <string name="settings_section_audio">Hangbeállítások</string>
+    <string name="settings_section_reliability">Megbízhatóság</string>
     <string name="settings_section_debug">Debug beállítások</string>
     <string name="settings_section_recorder_server">Rögzítőszolgáltatás</string>
     <string name="settings_section_recording">Felvétel</string>

--- a/app/src/main/res/values-hu/strings_home.xml
+++ b/app/src/main/res/values-hu/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">A Wi-Fi nélküli rögzítés be van kapcsolva.</string>
     <string name="offline_recording_disabling">Wi-Fi nélküli rögzítés kikapcsolása…</string>
     <string name="home_support_pill">Támogatás</string>
+    <string name="home_usb_advisory_title">A rögzítés leállhat a képernyő zárolásakor</string>
+    <string name="home_usb_advisory_text">Az USB adatmódban van. Koppints a Csak töltés beállításához.</string>
+    <string name="home_usb_advisory_fix">Javítás</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_notifications.xml
+++ b/app/src/main/res/values-hu/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">A hívásrögzítő indítása…</string>
     <string name="notif_readiness_ready_text">A rögzítő csatlakozva van.</string>
     <string name="notif_readiness_starting_text">A rögzítő csatlakoztatása folyamatban — a hívások rögzítése csak ennek befejezése után indul el.</string>
+    <string name="notif_usb_lock_warning">A képernyő zárolása hívás közben leállíthatja a rögzítést. Állítsd az USB-t „Csak töltés“ értékre a Beállítások → Megbízhatóság alatt.</string>
     <string name="notif_pairing_channel">ADB párosítás</string>
     <string name="notif_pairing_searching_title">Párosítási szolgáltatás keresése…</string>
     <string name="notif_pairing_searching_text">Nyissa meg a telefon „Eszköz párosítása párosítási kóddal” párbeszédpanelét.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -178,6 +178,7 @@
     <string name="offline_recording_warning_continue">Continua comunque</string>
     <string name="settings_section_about">Info</string>
     <string name="settings_section_audio">Configurazione audio</string>
+    <string name="settings_section_reliability">Affidabilità</string>
     <string name="settings_section_debug">Opzioni di debug</string>
     <string name="settings_section_recorder_server">Servizio di registrazione</string>
     <string name="settings_section_recording">Registrazione</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -206,6 +206,14 @@
     <string name="storage_target_drive">Solo su Google Drive</string>
     <string name="storage_target_local">Solo su questo dispositivo</string>
     <string name="wizard_audio_subtitle">Scelga il formato di registrazione e il bit rate. Opus a 16 kbps è consigliato per una voce nitida con file di piccole dimensioni.</string>
+    <string name="wizard_reliability_title">Registrazione affidabile</string>
+    <string name="wizard_reliability_subtitle">Due impostazioni facoltative che mantengono attiva la registrazione in condizioni difficili. Puoi saltarle e modificarle in seguito nelle Impostazioni.</string>
+    <string name="wizard_reliability_usb_title">Continua a registrare quando blocchi lo schermo</string>
+    <string name="wizard_reliability_usb_desc">Su alcuni telefoni, bloccare lo schermo durante una chiamata può interrompere la registrazione. Impostare USB su "Solo ricarica" lo evita. (Il telefono, collegato a un PC, resta in ricarica: scegli Trasferimento file manualmente quando serve.)</string>
+    <string name="wizard_reliability_usb_button">Imposta USB su Solo ricarica</string>
+    <string name="wizard_reliability_usb_done">USB è impostato su Solo ricarica</string>
+    <string name="wizard_reliability_offline_button">Attiva</string>
+    <string name="wizard_reliability_offline_done">La registrazione offline è attiva</string>
     <string name="wizard_audio_title">Qualità audio</string>
     <string name="wizard_auto_record_subtitle">Scelga quali chiamate registrare automaticamente. Potrà perfezionarlo in seguito nelle Impostazioni.</string>
     <string name="wizard_auto_record_title">Registrazione automatica</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -165,6 +165,14 @@
     <string name="folder_cloud_warning">⚠ Questa cartella di registrazione si trova nel cloud, il che non è affidabile per l\'acquisizione. Scelga una cartella sul dispositivo.</string>
     <string name="settings_offline_recording_label">Registrazione offline (senza Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Registra le chiamate anche quando non è disponibile una rete Wi-Fi.</string>
+    <string name="settings_usb_default_label">USB allo sblocco</string>
+    <string name="settings_usb_default_hint">"Solo ricarica" mantiene attiva la registrazione se blocchi lo schermo durante una chiamata. Le altre modalità consentono il trasferimento dati via USB ma possono interrompere una registrazione al blocco.</string>
+    <string name="settings_usb_default_applying">Applicazione…</string>
+    <string name="usb_mode_charging">Solo ricarica (senza dati)</string>
+    <string name="usb_mode_file_transfer">Trasferimento file</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">Tethering USB</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">Abilitare la registrazione offline?</string>
     <string name="offline_recording_warning_message">Questa opzione apre una porta di debug locale sul telefono affinché le chiamate possano essere registrate senza Wi-Fi. È protetta dalla chiave del dispositivo, ma rappresenta un piccolo compromesso in termini di sicurezza. Abilitala solo se hai bisogno di registrare chiamate senza Wi-Fi.</string>
     <string name="offline_recording_warning_continue">Continua comunque</string>

--- a/app/src/main/res/values-it/strings_home.xml
+++ b/app/src/main/res/values-it/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">La registrazione senza Wi-Fi è attiva.</string>
     <string name="offline_recording_disabling">Disattivazione della registrazione senza Wi-Fi…</string>
     <string name="home_support_pill">Sostieni</string>
+    <string name="home_usb_advisory_title">La registrazione può fermarsi al blocco</string>
+    <string name="home_usb_advisory_text">L\'USB è in modalità dati. Tocca per impostare Solo ricarica.</string>
+    <string name="home_usb_advisory_fix">Correggi</string>
 </resources>

--- a/app/src/main/res/values-it/strings_notifications.xml
+++ b/app/src/main/res/values-it/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">Avvio del registratore di chiamate…</string>
     <string name="notif_readiness_ready_text">Il registratore è connesso.</string>
     <string name="notif_readiness_starting_text">Connessione del registratore in corso: le chiamate non verranno registrate finché non termina.</string>
+    <string name="notif_usb_lock_warning">Bloccare lo schermo durante una chiamata può interrompere la registrazione. Imposta USB su "Solo ricarica" in Impostazioni → Affidabilità.</string>
     <string name="notif_pairing_channel">Associazione ADB</string>
     <string name="notif_pairing_searching_title">Ricerca del servizio di associazione…</string>
     <string name="notif_pairing_searching_text">Apra la finestra \"Associa dispositivo tramite codice di associazione\" del telefono.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -206,6 +206,14 @@
     <string name="storage_target_drive">Tylko Google Drive</string>
     <string name="storage_target_local">Tylko na tym urządzeniu</string>
     <string name="wizard_audio_subtitle">Wybierz format nagrywania i przepływność. Opus przy 16 kb/s jest zalecany dla wyraźnego głosu przy małym rozmiarze plików.</string>
+    <string name="wizard_reliability_title">Niezawodne nagrywanie</string>
+    <string name="wizard_reliability_subtitle">Dwa opcjonalne ustawienia, które utrzymują nagrywanie w trudnych warunkach. Możesz je pominąć i zmienić później w Ustawieniach.</string>
+    <string name="wizard_reliability_usb_title">Nagrywaj dalej po zablokowaniu ekranu</string>
+    <string name="wizard_reliability_usb_desc">W niektórych telefonach zablokowanie ekranu podczas rozmowy może zatrzymać nagrywanie. Ustawienie USB na „Tylko ładowanie“ temu zapobiega. (Telefon po podłączeniu do komputera domyślnie się ładuje — w razie potrzeby wybierz ręcznie Przesyłanie plików.)</string>
+    <string name="wizard_reliability_usb_button">Ustaw USB na Tylko ładowanie</string>
+    <string name="wizard_reliability_usb_done">USB jest ustawione na Tylko ładowanie</string>
+    <string name="wizard_reliability_offline_button">Włącz</string>
+    <string name="wizard_reliability_offline_done">Nagrywanie offline jest włączone</string>
     <string name="wizard_audio_title">Jakość dźwięku</string>
     <string name="wizard_auto_record_subtitle">Wybierz, które rozmowy są nagrywane automatycznie. Możesz to później dostosować w Ustawieniach.</string>
     <string name="wizard_auto_record_title">Automatyczne nagrywanie</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -178,6 +178,7 @@
     <string name="offline_recording_warning_continue">Kontynuuj mimo to</string>
     <string name="settings_section_about">O nas</string>
     <string name="settings_section_audio">Ustawienia dźwięku</string>
+    <string name="settings_section_reliability">Niezawodność</string>
     <string name="settings_section_debug">Opcje debugowania</string>
     <string name="settings_section_recorder_server">Usługa nagrywania</string>
     <string name="settings_section_recording">Nagrywanie</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -165,6 +165,14 @@
     <string name="folder_cloud_warning">⚠ Ten folder nagrań znajduje się w chmurze, co jest zawodne przy nagrywaniu. Wybierz folder na urządzeniu.</string>
     <string name="settings_offline_recording_label">Nagrywanie offline (bez Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Nagrywaj połączenia nawet wtedy, gdy nie ma sieci Wi-Fi.</string>
+    <string name="settings_usb_default_label">USB po odblokowaniu</string>
+    <string name="settings_usb_default_hint">„Tylko ładowanie“ utrzymuje nagrywanie, gdy zablokujesz ekran podczas rozmowy. Inne tryby pozwalają na przesyłanie danych przez USB, ale mogą przerwać nagrywanie po zablokowaniu telefonu.</string>
+    <string name="settings_usb_default_applying">Stosowanie…</string>
+    <string name="usb_mode_charging">Tylko ładowanie (bez danych)</string>
+    <string name="usb_mode_file_transfer">Przesyłanie plików</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">Tethering USB</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">Włączyć nagrywanie offline?</string>
     <string name="offline_recording_warning_message">Spowoduje to otwarcie lokalnego portu debugowania w telefonie, aby połączenia mogły być nagrywane bez Wi-Fi. Jest on chroniony kluczem urządzenia, ale stanowi niewielki kompromis w zakresie bezpieczeństwa. Włącz tę opcję tylko wtedy, gdy musisz nagrywać połączenia bez Wi-Fi.</string>
     <string name="offline_recording_warning_continue">Kontynuuj mimo to</string>

--- a/app/src/main/res/values-pl/strings_home.xml
+++ b/app/src/main/res/values-pl/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">Nagrywanie bez Wi-Fi jest włączone.</string>
     <string name="offline_recording_disabling">Wyłączanie nagrywania bez Wi-Fi…</string>
     <string name="home_support_pill">Wesprzyj</string>
+    <string name="home_usb_advisory_title">Nagrywanie może się zatrzymać po zablokowaniu</string>
+    <string name="home_usb_advisory_text">USB jest w trybie danych. Dotknij, aby ustawić Tylko ładowanie.</string>
+    <string name="home_usb_advisory_fix">Napraw</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_notifications.xml
+++ b/app/src/main/res/values-pl/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">Uruchamianie rejestratora połączeń…</string>
     <string name="notif_readiness_ready_text">Rejestrator jest połączony.</string>
     <string name="notif_readiness_starting_text">Łączenie rejestratora — połączenia nie będą nagrywane, dopóki proces się nie zakończy.</string>
+    <string name="notif_usb_lock_warning">Zablokowanie ekranu podczas rozmowy może zatrzymać nagrywanie. Ustaw USB na „Tylko ładowanie“ w Ustawienia → Niezawodność.</string>
     <string name="notif_pairing_channel">Parowanie ADB</string>
     <string name="notif_pairing_searching_title">Wyszukiwanie usługi parowania…</string>
     <string name="notif_pairing_searching_text">Otwórz na telefonie okno „Sparuj urządzenie za pomocą kodu parowania”.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -178,6 +178,7 @@
     <string name="offline_recording_warning_continue">Всё равно продолжить</string>
     <string name="settings_section_about">О приложении</string>
     <string name="settings_section_audio">Настройки аудио</string>
+    <string name="settings_section_reliability">Надёжность</string>
     <string name="settings_section_debug">Настройки отладки</string>
     <string name="settings_section_recorder_server">Служба записи</string>
     <string name="settings_section_recording">Запись</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -165,6 +165,14 @@
     <string name="folder_cloud_warning">⚠ Эта папка для записей находится в облаке, что ненадёжно для записи. Выберите папку на устройстве.</string>
     <string name="settings_offline_recording_label">Запись без сети (без Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Записывать звонки даже при отсутствии сети Wi-Fi.</string>
+    <string name="settings_usb_default_label">USB при разблокировке</string>
+    <string name="settings_usb_default_hint">«Только зарядка» сохраняет запись, если вы блокируете экран во время звонка. Другие режимы позволяют передавать данные по USB, но могут прервать запись при блокировке телефона.</string>
+    <string name="settings_usb_default_applying">Применение…</string>
+    <string name="usb_mode_charging">Только зарядка (без данных)</string>
+    <string name="usb_mode_file_transfer">Передача файлов</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">USB-модем</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">Включить запись без Wi-Fi?</string>
     <string name="offline_recording_warning_message">При этом на телефоне открывается локальный порт отладки, чтобы звонки можно было записывать без Wi-Fi. Он защищён ключом вашего устройства, но представляет собой небольшой компромисс в плане безопасности. Включайте эту функцию только в том случае, если вам нужно записывать звонки без Wi-Fi.</string>
     <string name="offline_recording_warning_continue">Всё равно продолжить</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -206,6 +206,14 @@
     <string name="storage_target_drive">Только в Google Drive</string>
     <string name="storage_target_local">Только на этом устройстве</string>
     <string name="wizard_audio_subtitle">Выберите формат записи и битрейт. Рекомендуется Opus с 16 кбит/с для чёткого голоса при небольшом размере файлов.</string>
+    <string name="wizard_reliability_title">Надёжная запись</string>
+    <string name="wizard_reliability_subtitle">Две необязательные настройки, которые сохраняют запись в сложных условиях. Их можно пропустить и изменить позже в настройках.</string>
+    <string name="wizard_reliability_usb_title">Продолжайте запись при блокировке экрана</string>
+    <string name="wizard_reliability_usb_desc">На некоторых телефонах блокировка экрана во время звонка может остановить запись. Режим USB «Только зарядка» это предотвращает. (При подключении к ПК телефон будет только заряжаться — при необходимости выберите «Передача файлов» вручную.)</string>
+    <string name="wizard_reliability_usb_button">Установить USB «Только зарядка»</string>
+    <string name="wizard_reliability_usb_done">USB установлен на «Только зарядка»</string>
+    <string name="wizard_reliability_offline_button">Включить</string>
+    <string name="wizard_reliability_offline_done">Автономная запись включена</string>
     <string name="wizard_audio_title">Качество звука</string>
     <string name="wizard_auto_record_subtitle">Выберите, какие звонки записываются автоматически. Это можно точнее настроить позже в настройках.</string>
     <string name="wizard_auto_record_title">Автоматическая запись</string>

--- a/app/src/main/res/values-ru/strings_home.xml
+++ b/app/src/main/res/values-ru/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">Запись без Wi-Fi включена.</string>
     <string name="offline_recording_disabling">Выключение записи без Wi-Fi…</string>
     <string name="home_support_pill">Поддержать</string>
+    <string name="home_usb_advisory_title">Запись может остановиться при блокировке</string>
+    <string name="home_usb_advisory_text">USB в режиме передачи данных. Нажмите, чтобы выбрать «Только зарядка».</string>
+    <string name="home_usb_advisory_fix">Исправить</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_notifications.xml
+++ b/app/src/main/res/values-ru/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">Запуск записи звонков…</string>
     <string name="notif_readiness_ready_text">Запись подключена.</string>
     <string name="notif_readiness_starting_text">Подключение записи — до завершения звонки не записываются.</string>
+    <string name="notif_usb_lock_warning">Блокировка экрана во время звонка может остановить запись. Выберите для USB режим «Только зарядка» в Настройки → Надёжность.</string>
     <string name="notif_pairing_channel">Подключение по ADB</string>
     <string name="notif_pairing_searching_title">Поиск сервиса подключения…</string>
     <string name="notif_pairing_searching_text">Откройте на телефоне диалог «Подключить устройство с помощью кода подключения».</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -178,6 +178,7 @@
     <string name="offline_recording_warning_continue">Vẫn tiếp tục</string>
     <string name="settings_section_about">Về</string>
     <string name="settings_section_audio">Cấu hình âm thanh</string>
+    <string name="settings_section_reliability">Độ tin cậy</string>
     <string name="settings_section_debug">Tùy chọn gỡ lỗi</string>
     <string name="settings_section_recorder_server">Dịch vụ ghi âm</string>
     <string name="settings_section_recording">Ghi âm</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -206,6 +206,14 @@
     <string name="storage_target_drive">Chỉ trên Google Drive</string>
     <string name="storage_target_local">Chỉ trên thiết bị này</string>
     <string name="wizard_audio_subtitle">Chọn định dạng ghi âm và bit rate. Opus ở 16 kbps được khuyến nghị để có giọng nói rõ ràng với kích thước tệp nhỏ.</string>
+    <string name="wizard_reliability_title">Ghi âm đáng tin cậy</string>
+    <string name="wizard_reliability_subtitle">Hai tùy chọn giúp việc ghi âm hoạt động trong điều kiện khó khăn. Bạn có thể bỏ qua và thay đổi sau trong Cài đặt.</string>
+    <string name="wizard_reliability_usb_title">Tiếp tục ghi âm khi khóa màn hình</string>
+    <string name="wizard_reliability_usb_desc">Trên một số điện thoại, khóa màn hình khi đang gọi có thể dừng ghi âm. Đặt USB thành "Chỉ sạc" sẽ ngăn điều đó. (Khi cắm vào máy tính, điện thoại sẽ mặc định chỉ sạc — chọn Truyền tệp thủ công khi cần.)</string>
+    <string name="wizard_reliability_usb_button">Đặt USB thành Chỉ sạc</string>
+    <string name="wizard_reliability_usb_done">USB đã đặt thành Chỉ sạc</string>
+    <string name="wizard_reliability_offline_button">Bật</string>
+    <string name="wizard_reliability_offline_done">Ghi âm ngoại tuyến đang bật</string>
     <string name="wizard_audio_title">Chất lượng âm thanh</string>
     <string name="wizard_auto_record_subtitle">Chọn cuộc gọi nào được ghi âm tự động. Bạn có thể tinh chỉnh sau trong Cài đặt.</string>
     <string name="wizard_auto_record_title">Tự động ghi âm</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -165,6 +165,14 @@
     <string name="folder_cloud_warning">⚠ Thư mục ghi âm này nằm trên đám mây, vốn không đáng tin cậy cho việc ghi âm. Hãy chọn một thư mục trên thiết bị.</string>
     <string name="settings_offline_recording_label">Ghi âm ngoại tuyến (không có Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Ghi âm cuộc gọi ngay cả khi không có mạng Wi-Fi.</string>
+    <string name="settings_usb_default_label">USB khi mở khóa màn hình</string>
+    <string name="settings_usb_default_hint">"Chỉ sạc" giữ cho bản ghi tiếp tục nếu bạn khóa màn hình khi đang gọi. Các chế độ khác cho phép truyền dữ liệu qua USB nhưng có thể làm gián đoạn bản ghi khi bạn khóa máy.</string>
+    <string name="settings_usb_default_applying">Đang áp dụng…</string>
+    <string name="usb_mode_charging">Chỉ sạc (không dữ liệu)</string>
+    <string name="usb_mode_file_transfer">Truyền tệp</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">Chia sẻ Internet qua USB</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">Bật ghi âm ngoại tuyến?</string>
     <string name="offline_recording_warning_message">Thao tác này mở một cổng gỡ lỗi cục bộ trên điện thoại của bạn để có thể ghi âm cuộc gọi mà không cần Wi-Fi. Cổng này được bảo vệ bằng khóa của thiết bị, nhưng đây là một sự đánh đổi nhỏ về bảo mật. Chỉ bật khi bạn cần ghi âm cuộc gọi mà không có Wi-Fi.</string>
     <string name="offline_recording_warning_continue">Vẫn tiếp tục</string>

--- a/app/src/main/res/values-vi/strings_home.xml
+++ b/app/src/main/res/values-vi/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">Ghi âm không cần Wi-Fi đang bật.</string>
     <string name="offline_recording_disabling">Đang tắt ghi âm không cần Wi-Fi…</string>
     <string name="home_support_pill">Ủng hộ</string>
+    <string name="home_usb_advisory_title">Ghi âm có thể dừng khi khóa màn hình</string>
+    <string name="home_usb_advisory_text">USB đang ở chế độ dữ liệu. Nhấn để đặt Chỉ sạc.</string>
+    <string name="home_usb_advisory_fix">Sửa</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_notifications.xml
+++ b/app/src/main/res/values-vi/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">Trình ghi âm cuộc gọi đang khởi động…</string>
     <string name="notif_readiness_ready_text">Trình ghi âm đã được kết nối.</string>
     <string name="notif_readiness_starting_text">Đang kết nối trình ghi âm — cuộc gọi sẽ không được ghi cho đến khi hoàn tất.</string>
+    <string name="notif_usb_lock_warning">Khóa màn hình khi đang gọi có thể dừng ghi âm. Đặt USB thành "Chỉ sạc" trong Cài đặt → Độ tin cậy.</string>
     <string name="notif_pairing_channel">Ghép nối ADB</string>
     <string name="notif_pairing_searching_title">Đang tìm dịch vụ ghép nối…</string>
     <string name="notif_pairing_searching_text">Mở hộp thoại \'Ghép nối thiết bị bằng mã ghép nối\' trên điện thoại.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -206,6 +206,14 @@
     <string name="storage_target_drive">仅 Google Drive</string>
     <string name="storage_target_local">仅保存在本设备</string>
     <string name="wizard_audio_subtitle">选择录音格式和比特率。推荐使用 16 kbps 的 Opus，可在小文件下获得清晰的语音。</string>
+    <string name="wizard_reliability_title">可靠录音</string>
+    <string name="wizard_reliability_subtitle">两项可选设置，让录音在复杂情况下也能正常工作。你可以跳过，稍后在“设置”中更改。</string>
+    <string name="wizard_reliability_usb_title">锁屏时继续录音</string>
+    <string name="wizard_reliability_usb_desc">在某些手机上，通话中锁屏可能会中断录音。将 USB 设为“仅充电”即可避免。（连接电脑时手机将默认为充电——需要时请手动选择文件传输。）</string>
+    <string name="wizard_reliability_usb_button">将 USB 设为仅充电</string>
+    <string name="wizard_reliability_usb_done">USB 已设为仅充电</string>
+    <string name="wizard_reliability_offline_button">启用</string>
+    <string name="wizard_reliability_offline_done">离线录音已开启</string>
     <string name="wizard_audio_title">音频质量</string>
     <string name="wizard_auto_record_subtitle">选择哪些通话会被自动录制。你之后可以在设置中进一步调整。</string>
     <string name="wizard_auto_record_title">自动录音</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -165,6 +165,14 @@
     <string name="folder_cloud_warning">⚠ 此录音文件夹位于云端，用于录音并不可靠。请选择设备本地的文件夹。</string>
     <string name="settings_offline_recording_label">离线录音（无 Wi-Fi）</string>
     <string name="settings_offline_recording_desc">即使没有 Wi-Fi 网络也能录制通话。</string>
+    <string name="settings_usb_default_label">解锁时的 USB 模式</string>
+    <string name="settings_usb_default_hint">“仅充电”可在通话中锁屏时保持录音不中断。其他模式允许 USB 传输数据，但在锁定手机时可能中断录音。</string>
+    <string name="settings_usb_default_applying">正在应用…</string>
+    <string name="usb_mode_charging">仅充电（无数据）</string>
+    <string name="usb_mode_file_transfer">文件传输</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">USB 网络共享</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">启用离线录音？</string>
     <string name="offline_recording_warning_message">此操作会在您的手机上开启一个本地调试端口，以便在没有 Wi-Fi 的情况下录制通话。它受设备密钥保护，但会带来轻微的安全权衡。仅在您需要在没有 Wi-Fi 的情况下录制通话时才启用。</string>
     <string name="offline_recording_warning_continue">仍然继续</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -178,6 +178,7 @@
     <string name="offline_recording_warning_continue">仍然继续</string>
     <string name="settings_section_about">关于</string>
     <string name="settings_section_audio">音源选项</string>
+    <string name="settings_section_reliability">可靠性</string>
     <string name="settings_section_debug">调试选项</string>
     <string name="settings_section_recorder_server">录音服务</string>
     <string name="settings_section_recording">自动录音触发条件</string>

--- a/app/src/main/res/values-zh-rCN/strings_home.xml
+++ b/app/src/main/res/values-zh-rCN/strings_home.xml
@@ -26,4 +26,7 @@
     <string name="offline_recording_on">无 Wi-Fi 录音已开启。</string>
     <string name="offline_recording_disabling">正在关闭无 Wi-Fi 录音…</string>
     <string name="home_support_pill">支持</string>
+    <string name="home_usb_advisory_title">锁屏时录音可能中断</string>
+    <string name="home_usb_advisory_text">USB 处于数据模式。点按设为仅充电。</string>
+    <string name="home_usb_advisory_fix">修复</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_notifications.xml
+++ b/app/src/main/res/values-zh-rCN/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">通话录音正在启动…</string>
     <string name="notif_readiness_ready_text">录音器已连接。</string>
     <string name="notif_readiness_starting_text">正在连接录音器——完成前通话不会被录制。</string>
+    <string name="notif_usb_lock_warning">通话中锁屏可能会中断录音。请在“设置 → 可靠性”中将 USB 设为“仅充电”。</string>
     <string name="notif_pairing_channel">ADB 配对</string>
     <string name="notif_pairing_searching_title">正在查找配对服务…</string>
     <string name="notif_pairing_searching_text">请打开手机的“使用配对码配对设备”对话框。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,6 +344,14 @@
     <string name="wizard_auto_record_title">Automatic recording</string>
     <string name="wizard_auto_record_subtitle">Choose which calls are recorded automatically. You can fine-tune this later in Settings.</string>
     <!-- Wizard: Audio step -->
+    <string name="wizard_reliability_title">Reliable recording</string>
+    <string name="wizard_reliability_subtitle">Two optional settings that keep recording working in tricky conditions. You can skip these and change them later in Settings.</string>
+    <string name="wizard_reliability_usb_title">Keep recording when the screen locks</string>
+    <string name="wizard_reliability_usb_desc">On some phones, locking the screen during a call can stop the recording. Setting USB to \"Charging only\" prevents that. (Your phone then defaults to charging when plugged into a PC — pick File transfer manually when you need it.)</string>
+    <string name="wizard_reliability_usb_button">Set USB to Charging only</string>
+    <string name="wizard_reliability_usb_done">USB is set to Charging only</string>
+    <string name="wizard_reliability_offline_button">Enable</string>
+    <string name="wizard_reliability_offline_done">Offline recording is on</string>
     <string name="wizard_audio_title">Audio quality</string>
     <string name="wizard_audio_subtitle">Pick the recording format and bit rate. Opus at 16 kbps is recommended for clear voice at small file sizes.</string>
     <string name="wizard_filename_title">File name format</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,7 @@
     <string name="settings_section_recording_storage">Recording &amp; storage</string>
     <string name="settings_section_visual">Visual settings</string>
     <string name="settings_section_audio">Audio configuration</string>
+    <string name="settings_section_reliability">Reliability</string>
     <string name="settings_section_debug">Debug</string>
     <string name="settings_section_security">Security</string>
     <string name="settings_section_recorder_server">Recorder service</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,14 @@
     <!-- Offline recording (loopback) opt-in + security warning -->
     <string name="settings_offline_recording_label">Offline recording (no Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Record calls even when there is no Wi-Fi network.</string>
+    <string name="settings_usb_default_label">USB when screen unlocks</string>
+    <string name="settings_usb_default_hint">"Charging only" keeps recording alive if you lock the screen during a call. Other modes let USB transfer data but can interrupt a recording when you lock the phone.</string>
+    <string name="settings_usb_default_applying">Applying…</string>
+    <string name="usb_mode_charging">Charging only (no data)</string>
+    <string name="usb_mode_file_transfer">File transfer</string>
+    <string name="usb_mode_ptp">PTP</string>
+    <string name="usb_mode_tethering">USB tethering</string>
+    <string name="usb_mode_midi">MIDI</string>
     <string name="offline_recording_warning_title">Enable offline recording?</string>
     <string name="offline_recording_warning_message">This opens a local debugging port on your phone so calls can record with no Wi-Fi. It is protected by your device\'s key, but it is a small security tradeoff. Only enable it if you need to record calls without Wi-Fi.</string>
     <string name="offline_recording_warning_continue">Continue anyway</string>

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -14,6 +14,9 @@
     <string name="home_hero_pill_dev_options_off">Recording broken</string>
     <string name="home_hero_pill_update_regrant">Action needed</string>
     <string name="home_support_pill">Support</string>
+    <string name="home_usb_advisory_title">Recording may stop on screen lock</string>
+    <string name="home_usb_advisory_text">USB is set to a data mode. Tap to set it to Charging only.</string>
+    <string name="home_usb_advisory_fix">Fix</string>
 
     <!-- Recordings section -->
     <string name="home_recordings_count">%1$d saved</string>

--- a/app/src/main/res/values/strings_notifications.xml
+++ b/app/src/main/res/values/strings_notifications.xml
@@ -6,6 +6,7 @@
     <string name="notif_readiness_starting_title">Call recorder starting up…</string>
     <string name="notif_readiness_ready_text">The recorder is connected.</string>
     <string name="notif_readiness_starting_text">Connecting the recorder — calls won\'t record until this finishes.</string>
+    <string name="notif_usb_lock_warning">Locking the screen during a call may stop the recording. Set USB to \"Charging only\" in Settings → Reliability.</string>
 
     <!-- ADB wireless-debugging pairing notifications -->
     <string name="notif_pairing_channel">ADB pairing</string>


### PR DESCRIPTION
Fixes the field-reported issue where **locking the screen during a call kills the recorder** on OnePlus/Xiaomi/Samsung (locking restarts adbd → kills the shell-uid daemon mid-call). Root cause is unfixable in-app (even Shizuku hits this wall), but the OEM-proven mitigation is a device setting — **Default USB Configuration = "Charging only"** — which CallVault can now read and set itself over the embedded ADB shell (`dumpsys usb` / `svc usb setScreenUnlockedFunctions`, framework-level so OEM-agnostic).

## Added
- **Settings → Reliability** section: a USB-mode picker (Charging only *recommended*, + File transfer / PTP / USB tethering / MIDI) and the off-Wi-Fi recording toggle, grouped. Greys + spins while applying; confirms the change by reading it back.
- **Onboarding "Reliable recording" step**: one-tap "Set USB to Charging only" + the offline opt-in (both skippable).
- **Home advisory** + **readiness-notification warning** when USB is a data mode, with a one-tap fix. Driven by a cached read (`readIfConnected`, no ADB churn).
- All UI strings in all 9 locales.

## Test plan
- [x] `assembleRelease` clean (lint + translations pass), all 9 locales.
- [x] On-device (OnePlus): picker reads live value + changes it (dumpsys confirms); Reliability section renders; picker greys+spinner while applying; Home advisory renders for a data mode.
- [x] The device setting ("Charging only") confirmed to fix the screen-lock kill by the reporter.
- [ ] CodeQL check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)