### PR TITLE
v1.4.6 — Resilient recording (opt-in) + fix a bug that could lose calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ docs/superpowers/
 
 # App signing keystore — the release identity; keep local, back up separately, NEVER commit.
 /signing/
+
+# Native (CMake/NDK) build cache
+.cxx/
+app/.cxx/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,7 +3,8 @@
 1. `brew install --cask android-commandlinetools` (one-time)
 2. Source the env: `source ~/.callvault-env.sh`
    - Sets JAVA_HOME (brew openjdk@17), ANDROID_HOME (~/Library/Android/sdk), PATH.
-3. One-time SDK packages: `sdkmanager "platforms;android-36" "build-tools;36.0.0"`
+3. One-time SDK packages: `sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;27.2.12479018" "cmake;3.22.1"`
+   - The NDK and CMake build `libaudiohandoff.so`, the native half of Resilient recording. Without them the build fails at `externalNativeBuild`.
 4. Build (from the repo root): `./gradlew assembleDebug`
 5. APK: `app/build/outputs/apk/debug/app-debug.apk`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to CallVault are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project uses semantic-ish versioning.
 
+## [1.4.6] — 2026-07-26
+
+The headline: **a call that starts recording now finishes recording** — opt in under Settings → Reliability.
+
+### Added
+- **Resilient recording (opt-in).** Until now, the background helper held the microphone and did the
+  encoding for the whole call — so if Android stopped it part-way through, the recording stopped with
+  it and you were left with a half-length file. With this on, the helper only *starts* the capture and
+  then hands it to CallVault itself, which keeps it and does the encoding. The helper can then be
+  killed at any point mid-call and the recording simply carries on to the end.
+  - **Off by default**, and turning it off restores exactly the previous behaviour. Enable it under
+    **Settings → Reliability**, or from the one-time note shown after updating.
+  - It doesn't change how a recording *starts*, so it complements the "Charging only" USB fix from
+    1.4.5 rather than replacing it.
+
+### Fixed
+- **A call could occasionally not record at all.** When starting a recording, CallVault read a USB
+  setting over its ADB connection with no time limit. Normally that is instant, but if the connection
+  had gone half-dead the read never returned, and the recording never started — leaving an empty file.
+  It is now capped at 1.5 seconds and falls back to the last known value. This affected every
+  recording, not just the new opt-in.
+- **The "Voice performance" audio source now uses the fast direct path.** It was matched against a
+  source name that doesn't exist, so it silently fell back to the slower scrcpy path.
+
+### Note
+- CallVault now ships a small native library and therefore requires a **64-bit ARM device**
+  (`arm64-v8a`) — effectively every phone running Android 11 or newer.
+
 ## [1.4.5] — 2026-07-24
 
 The headline: **recording no longer stops if you lock the screen during a call** — on phones where it did.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to CallVault are documented here. The format is based on
 
 ## [1.4.6] — 2026-07-26
 
-The headline: **a call that starts recording now finishes recording** — opt in under Settings → Reliability.
+The headline: **recording is now resistant to the background helper being stopped mid-call** — opt in under Settings → Reliability.
 
 ### Added
 - **Resilient recording (opt-in).** Until now, the background helper held the microphone and did the

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ You pair **once**; after that it's hands-free.
 |:---:|---|
 | 🎙️ | Records **both sides** of incoming & outgoing calls (incl. Bluetooth / headset) |
 | 📶 | **Offline recording (opt-in)** — record calls even with **no Wi-Fi network**, for calls on the road (off by default; opens a local, RSA-gated debugging port when enabled) |
-| 🛡️ | **Resilient recording (opt-in)** — once a call starts recording it **finishes**, even if Android stops the background helper part-way through (off by default) |
+| 🔓 | **Keeps recording when the screen locks** — on many phones that otherwise stop a recording mid-call, fixed from inside the app in one tap |
+| 🛡️ | **Resilient recording (opt-in)** — makes recording **resistant to interruptions**: a recording already in progress is unaffected if Android stops the background helper mid-call (off by default) |
 | 🤖 | **Automatic** recording with per-call rules — ignore anonymous, cross-country, or specific contacts |
 | ☁️ | Save to **device, a cloud folder, or both**, with optional **scheduled sync** (immediate / daily / weekly) |
 | 🧹 | **Retention / auto-delete** — remove recordings after a chosen age, separately for device & cloud, swept daily at a time you pick (your local time zone) |
@@ -48,6 +49,12 @@ After a one-time pairing, CallVault runs a **persistent privileged daemon** — 
 
 - **Wireless Debugging is fully automatic and transient.** CallVault turns it on only long enough to (re)launch the daemon, then turns it back off. You never toggle it manually after the first pair.
 - Call audio is captured by the daemon through a **direct `AudioRecord` path** and muxed into a file you own (via the Storage Access Framework) — on the device and/or a cloud folder you pick through the system file picker. `scrcpy-server` is launched only as a fallback, when the direct path can't handle the chosen source or codec on your device.
+
+### Keeping a recording alive when the screen locks
+
+On many phones (OnePlus, Xiaomi, Samsung…), locking the screen during a call renegotiates the USB connection, which restarts the system's ADB daemon and takes the recorder down with it — mid-call.
+
+The fix is to set the phone's **Default USB Configuration** to **"Charging only"**, and CallVault can do that for you: the setup wizard offers it, **Settings ▸ Reliability** has it, and if USB is on a data mode the Home screen and the recorder notification show a "locking the screen may stop recording — tap to fix" prompt. The trade-off is that plugging into a PC then defaults to charging, so pick *File transfer* manually when you actually want to move files.
 
 ### Resilient recording (opt-in)
 
@@ -89,12 +96,14 @@ It doesn't change how a recording *starts* — the daemon is still needed for th
 2. **Open CallVault** and accept the disclaimer.
 3. On the **Permissions** screen, grant **Notifications**, then tap **Pair**. CallVault opens the Wireless-debugging screen and waits — when you flip the toggle on, pairing starts automatically.
 4. Tap **"Pair device with pairing code"**, and type the 6-digit code into CallVault's notification. After a few seconds you'll get **"Paired ✓"** — tap it to return.
-5. Grant the remaining permissions, then complete the **Setup Wizard**: where to save recordings, sync schedule, auto-record, audio quality, and file-name format.
+5. Grant the remaining permissions, then complete the **Setup Wizard**: where to save recordings, upload schedule (if you picked a cloud folder), auto-record rules, **reliability** (the screen-lock fix and off-Wi-Fi recording), audio quality, and file-name format.
 
 **Day-to-day:** the **Home** screen shows app status and your recordings — tap one to play, expand a *Device + Drive* recording to play/delete each copy, and filter by source/direction/contact/date. Settings is one tap away.
 
 > [!TIP]
 > On OEMs that aggressively kill background apps (OnePlus/OxygenOS, Xiaomi, etc.), allow CallVault in **Auto-launch / Startup Manager** and exclude it from **battery optimization** so it records reliably and starts after a reboot. See [dontkillmyapp.com](https://dontkillmyapp.com/).
+>
+> If a recording ever stops when you lock the screen, set USB to **"Charging only"** — see [above](#keeping-a-recording-alive-when-the-screen-locks). Turning on **Resilient recording** additionally protects a call that is already being recorded.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You pair **once**; after that it's hands-free.
 |:---:|---|
 | 🎙️ | Records **both sides** of incoming & outgoing calls (incl. Bluetooth / headset) |
 | 📶 | **Offline recording (opt-in)** — record calls even with **no Wi-Fi network**, for calls on the road (off by default; opens a local, RSA-gated debugging port when enabled) |
+| 🛡️ | **Resilient recording (opt-in)** — once a call starts recording it **finishes**, even if Android stops the background helper part-way through (off by default) |
 | 🤖 | **Automatic** recording with per-call rules — ignore anonymous, cross-country, or specific contacts |
 | ☁️ | Save to **device, a cloud folder, or both**, with optional **scheduled sync** (immediate / daily / weekly) |
 | 🧹 | **Retention / auto-delete** — remove recordings after a chosen age, separately for device & cloud, swept daily at a time you pick (your local time zone) |
@@ -46,11 +47,20 @@ You pair **once**; after that it's hands-free.
 After a one-time pairing, CallVault runs a **persistent privileged daemon** — a detached `app_process` under the shell user, in the spirit of Shizuku — that **survives Wireless Debugging being turned off**. Recording commands then flow to it over **binder IPC**, so no ADB connection is needed at record time.
 
 - **Wireless Debugging is fully automatic and transient.** CallVault turns it on only long enough to (re)launch the daemon, then turns it back off. You never toggle it manually after the first pair.
-- Call audio is captured via scrcpy and muxed into a file you own (via the Storage Access Framework) — on the device and/or a cloud folder you pick through the system file picker.
+- Call audio is captured by the daemon through a **direct `AudioRecord` path** and muxed into a file you own (via the Storage Access Framework) — on the device and/or a cloud folder you pick through the system file picker. `scrcpy-server` is launched only as a fallback, when the direct path can't handle the chosen source or codec on your device.
+
+### Resilient recording (opt-in)
+
+Normally the daemon holds the microphone and encodes for the whole call, so if Android stops it part-way through — locking the screen can do this on some OEMs — the recording stops with it.
+
+With **Resilient recording** on, the daemon only *creates* the capture and then **hands it to the app**, which holds it and does the encoding itself. Because the app is the one Android keeps alive, the daemon can die at any point mid-call and the recording simply carries on to the end.
+
+It doesn't change how a recording *starts* — the daemon is still needed for that — so it's a completeness guarantee, not a replacement for the setup above. Off by default; enable under **Settings ▸ Reliability**.
 
 ## Requirements
 
 - **Android 11 or newer** (best on Android 12+; on Android 11 the screen must be unlocked during a call).
+- **A 64-bit ARM device (`arm64-v8a`)** — which is effectively every phone shipping Android 11+. The APK carries a native library for that ABI only, so it will not install on 32-bit-only or x86 devices.
 - **Wireless Debugging** available in Developer Options.
 - **Developer options must stay enabled.** If you turn Developer options off later (or an OS update
   resets it), the recorder can't run and calls come out empty — the Home screen will show a red
@@ -94,7 +104,9 @@ This is a standard single-module Android project at the repo root. See [BUILDING
 ./gradlew :app:assembleDebug   # → app/build/outputs/apk/debug/app-debug.apk
 ```
 
-Requires JDK 17 and the Android SDK. CallVault is **reflection-heavy** (hidden APIs, the daemon is launched by class name) — a minified release build will break it unless minification is disabled.
+Requires JDK 17, the Android SDK, and — since CallVault now builds a small native library for Resilient recording — the **NDK and CMake** (`sdkmanager "ndk;27.2.12479018" "cmake;3.22.1"`).
+
+CallVault is **reflection-heavy** (hidden APIs, the daemon is launched by class name) — a minified release build will break it, so minification stays off.
 
 ## Credits & attribution
 
@@ -102,7 +114,7 @@ CallVault is a modified fork of **[ShizuCallRecorder](https://github.com/kitsume
 
 Built on the work of:
 - [ShizuCallRecorder](https://github.com/kitsumed/ShizuCallRecorder) — the upstream project this is forked from
-- [scrcpy](https://github.com/genymobile/scrcpy) — the audio-capture server
+- [scrcpy](https://github.com/genymobile/scrcpy) — the fallback audio-capture server
 - [libadb-android](https://github.com/MuntashirAkon/libadb-android) — the embedded ADB client
 
 ## License

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,12 +128,19 @@ android {
     namespace = "com.baba.callvault"
     compileSdk = 36
 
+    // Required for libaudiohandoff.so, the native half of "Resilient recording".
+    ndkVersion = "27.2.12479018"
+
     defaultConfig {
         applicationId = "com.baba.callvault"
         minSdk = 30
         targetSdk = 36
         versionCode = ciVersionCode.get()
         versionName = ciVersionName.get()
+
+        // arm64 only. Every device this app can run on (minSdk 30, and the ADB-over-binder daemon it
+        // depends on) is arm64, and shipping one ABI keeps the APK small.
+        ndk { abiFilters += "arm64-v8a" }
 
         buildConfigField("String", "CI_BUILD_NUMBER", "\"${ciBuildNumber.get()}\"")
 
@@ -202,17 +209,29 @@ android {
         sourceCompatibility =  JavaVersion.VERSION_17
         targetCompatibility =  JavaVersion.VERSION_17
     }
+    // Builds libaudiohandoff.so (see src/main/cpp).
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+
     buildFeatures {
         compose = true
-        // Re-enabled for CallVault Plan 5 Task 0c: the binder command-channel spike needs the
-        // generated AIDL stubs (IPersistDebugService, BinderContainer) shared between the app and the
-        // app_process daemon. THROWAWAY — flip back to false when persistserver/ + aidl/ are removed.
+        // Required: the app and the shell-uid app_process daemon talk over the generated AIDL stubs
+        // (IRecorderService, BinderContainer).
         aidl = true
         buildConfig = true
     }
     packaging {
         // Exclude the original metadata from libphonenumber to avoid conflicts with our extracted version. This ensures only our processed assets are included in the final APK.
         resources.excludes.add("com/google/i18n/phonenumbers/data/**")
+        // REQUIRED, do not remove: extracts native libs to nativeLibraryDir on install. The shell-uid
+        // app_process DAEMON has no app classloader library-search path, so it can only load
+        // libaudiohandoff.so from an explicit on-disk path (<apkDir>/lib/arm64/). Left uncompressed
+        // inside the APK it would not exist as a file for the daemon to load.
+        jniLibs { useLegacyPackaging = true }
     }
     androidResources {
         generateLocaleConfig = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,7 @@ val extractLibphonenumberMetadata = tasks.register<ExtractMetadataTask>("extract
 // defaults — so BUMP versionName here every release to match the CHANGELOG and the version dispatched
 // to the build workflow.
 val ciVersionCode = providers.gradleProperty("versionCode").map { it.toIntOrNull() }.orElse(10441)
-val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.5")
+val ciVersionName = providers.gradleProperty("versionName").orElse("1.4.6")
 val ciBuildNumber = providers.gradleProperty("ciBuildNumber").orElse("Local")
 
 android {

--- a/app/src/main/aidl/com/baba/callvault/server/IRecorderService.aidl
+++ b/app/src/main/aidl/com/baba/callvault/server/IRecorderService.aidl
@@ -21,8 +21,7 @@ package com.baba.callvault.server;
  * the SAF file and performs call-log lookups itself, exactly as
  * [com.baba.callvault.services.recording.AudioRecordingEngine] does today.
  *
- * Mirrors the proven spike interface [com.baba.callvault.persistserver.IPersistDebugService]
- * and Shizuku's IShizukuService command-channel pattern.
+ * Mirrors Shizuku's IShizukuService command-channel pattern.
  */
 interface IRecorderService {
 
@@ -46,4 +45,27 @@ interface IRecorderService {
 
     /** Stops any active recording and terminates the daemon process. */
     void destroy();
+
+    /**
+     * "Resilient recording" (audio-capture handoff, Option B). The daemon creates a privileged
+     * AudioRecord for [source] at [sampleRate], extracts the IAudioRecord binder + cblk ashmem fd, and
+     * DELIVERS them to the app's provider ("sendHandoff"). The app then holds its own ref (keep-alive)
+     * and reads the ring + encodes into ITS OWN output fd — so the recording SURVIVES the daemon being
+     * killed mid-call. The push delivery runs synchronously inside this call, so on a true return the
+     * app has USUALLY started capturing — but the caller must confirm via the app-side capture state
+     * (this return only reflects that the daemon delivered, not that the app-side encode actually began).
+     *
+     * @param source     scrcpy `audio_source` cliKey (must map to a real MediaRecorder.AudioSource;
+     *                   output/playback are not supported and must use startRecording instead).
+     * @param sampleRate Capture sample rate in Hz (e.g. 48000).
+     * @param channels   Preferred channel count (2 for voice-call to capture both directions, 1 for
+     *                   mono sources). The daemon may fall back to mono and reports the ACTUAL count in
+     *                   the delivery.
+     * @return true if the daemon created the track and delivered the handoff to the app (delivery only;
+     *         the app confirms live capture separately).
+     */
+    boolean startHandoff(String source, int sampleRate, int channels);
+
+    /** Releases the daemon's held handoff AudioRecord (frees the capture input). Idempotent. */
+    void stopHandoff();
 }

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Native half of "Resilient recording" (audio-capture handoff): extracts the IAudioRecord binder +
+# cblk ashmem fd in the daemon, and drains the cblk ring in the app.
+cmake_minimum_required(VERSION 3.22.1)
+project(audiohandoff)
+
+add_library(audiohandoff SHARED audiohandoff.cpp)
+
+find_library(log-lib log)
+
+target_link_libraries(audiohandoff ${log-lib})

--- a/app/src/main/cpp/audiohandoff.cpp
+++ b/app/src/main/cpp/audiohandoff.cpp
@@ -1,0 +1,286 @@
+// Native half of "Resilient recording" (audio-capture handoff).
+//
+// The privileged shell-uid daemon creates an AudioRecord, and this code extracts its IAudioRecord
+// binder + control-block (cblk) ashmem fd so they can be handed to the always-alive app. The app then
+// drains the cblk ring itself, which is why a recording survives the daemon being killed mid-call.
+//
+// Everything here is deliberately libc/NDK-only: the app process runs under a restricted linker
+// namespace that cannot load libaudioclient at all, so the few framework symbols we need
+// (javaObjectForIBinder) are resolved manually out of already-mapped libs instead of via dlsym.
+
+#include <jni.h>
+#include <android/log.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <elf.h>
+#include <cstring>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <csetjmp>
+#include <csignal>
+#include <cerrno>
+#include <vector>
+
+#define TAG "CV:AudioHandoff"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
+
+// ---- Manual symbol resolution: reach a function in an already-loaded lib that our ISOLATED app
+// classloader namespace can't dlsym (the daemon's .so can't dlopen libandroid_runtime/libbinder, but
+// those libs ARE mapped in the process). We compute the runtime address = load_bias + st_value, where
+// load_bias comes from /proc/self/maps and st_value from the on-disk ELF .dynsym. Bypasses nativeloader.
+
+// Load bias of a mapped lib = lowest mapping start for that path MINUS the min PT_LOAD p_vaddr.
+static uintptr_t manualLibBase(const char *nameSuffix) {
+    FILE *f = fopen("/proc/self/maps", "r");
+    if (!f) return 0;
+    char line[512];
+    uintptr_t base = 0;
+    size_t sl = strlen(nameSuffix);
+    while (fgets(line, sizeof(line), f)) {
+        char *path = strchr(line, '/');
+        if (!path) continue;
+        size_t pl = strlen(path);
+        if (pl && path[pl - 1] == '\n') { path[--pl] = 0; }
+        if (pl >= sl && strcmp(path + pl - sl, nameSuffix) == 0) {
+            uintptr_t start = strtoull(line, nullptr, 16);
+            if (base == 0 || start < base) base = start;   // lowest mapping = load address of hdr
+        }
+    }
+    fclose(f);
+    return base;
+}
+
+// Symbol's link-time st_value from the ELF file's .dynsym, plus the min PT_LOAD vaddr (for load_bias).
+static uintptr_t manualSymOffset(const char *fullPath, const char *symbol, uintptr_t *minVaddrOut) {
+    int fd = open(fullPath, O_RDONLY);
+    if (fd < 0) return 0;
+    struct stat st{};
+    if (fstat(fd, &st) != 0) { close(fd); return 0; }
+    void *m = mmap(nullptr, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);
+    if (m == MAP_FAILED) return 0;
+    auto *b = static_cast<uint8_t *>(m);
+    auto *eh = reinterpret_cast<Elf64_Ehdr *>(b);
+    uintptr_t off = 0, minVaddr = UINTPTR_MAX;
+    auto *ph = reinterpret_cast<Elf64_Phdr *>(b + eh->e_phoff);
+    for (int i = 0; i < eh->e_phnum; i++)
+        if (ph[i].p_type == PT_LOAD && ph[i].p_vaddr < minVaddr) minVaddr = ph[i].p_vaddr;
+    auto *sh = reinterpret_cast<Elf64_Shdr *>(b + eh->e_shoff);
+    for (int i = 0; i < eh->e_shnum; i++) {
+        if (sh[i].sh_type == SHT_DYNSYM) {
+            auto *syms = reinterpret_cast<Elf64_Sym *>(b + sh[i].sh_offset);
+            size_t n = sh[i].sh_size / sizeof(Elf64_Sym);
+            const char *strtab = reinterpret_cast<const char *>(b + sh[sh[i].sh_link].sh_offset);
+            for (size_t k = 0; k < n; k++) {
+                if (strcmp(strtab + syms[k].st_name, symbol) == 0) { off = syms[k].st_value; break; }
+            }
+        }
+    }
+    munmap(m, st.st_size);
+    if (minVaddrOut) *minVaddrOut = (minVaddr == UINTPTR_MAX) ? 0 : minVaddr;
+    return off;
+}
+
+// Runtime address of `symbol` in an already-loaded lib. `suffix` matches /proc/self/maps; `fullPath`
+// is the on-disk ELF (e.g. /system/lib64/libandroid_runtime.so).
+static void *manualResolve(const char *suffix, const char *fullPath, const char *symbol) {
+    uintptr_t base = manualLibBase(suffix);
+    uintptr_t minVaddr = 0;
+    uintptr_t off = manualSymOffset(fullPath, symbol, &minVaddr);
+    if (!base || !off) { LOGI("manualResolve: %s base=%p off=%p FAIL", symbol, (void*)base, (void*)off); return nullptr; }
+    void *addr = reinterpret_cast<void *>(base + off - minVaddr);
+    LOGI("manualResolve: %s base=0x%lx off=0x%lx minVaddr=0x%lx -> %p",
+         symbol, (unsigned long)base, (unsigned long)off, (unsigned long)minVaddr, addr);
+    return addr;
+}
+
+// Guarded pointer reads (scanning object memory for candidate pointers can't crash).
+static sigjmp_buf g_hf;
+static void hfHandler(int) { siglongjmp(g_hf, 1); }
+static bool hfPlaus(void *p) { uintptr_t v = (uintptr_t) p; return (v & 7) == 0 && (v & 0x00FFFFFFFFFFFFFFull) >= 0x10000; }
+static bool hfRead(void *a, void **o) { if (!hfPlaus(a)) return false; if (sigsetjmp(g_hf, 1)) return false; *o = *reinterpret_cast<void **>(a); return true; }
+
+// javaObjectForIBinder(JNIEnv*, const sp<IBinder>&) -> jobject (Java BinderProxy), manually resolved.
+typedef jobject (*JavaObjForIBinderFn)(JNIEnv *, const void *);
+static JavaObjForIBinderFn g_javaObjForIBinder = nullptr;
+
+// Validate that `ptr` is a native android::AudioRecord: ptr+0x190 -> BpAudioRecord, +0x10 -> a BpBinder
+// (plausible object with a plausible vptr). Used to pick the right long field from the Java AudioRecord.
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_baba_callvault_services_recording_handoff_AudioHandoffNative_nativeValidateArPtr(JNIEnv *, jclass, jlong ptr) {
+    struct sigaction sa{}, o1{}, o2{}; sa.sa_handler = hfHandler; sigemptyset(&sa.sa_mask);
+    sigaction(SIGSEGV, &sa, &o1); sigaction(SIGBUS, &sa, &o2);
+    void *ar = reinterpret_cast<void *>(ptr), *bpAR = nullptr, *bp = nullptr, *vptr = nullptr;
+    bool ok = hfRead(reinterpret_cast<uint8_t *>(ar) + 0x190, &bpAR) && hfPlaus(bpAR) &&
+              hfRead(reinterpret_cast<uint8_t *>(bpAR) + 0x10, &bp) && hfPlaus(bp) &&
+              hfRead(bp, &vptr) && hfPlaus(vptr);
+    sigaction(SIGSEGV, &o1, nullptr); sigaction(SIGBUS, &o2, nullptr);
+    return ok ? JNI_TRUE : JNI_FALSE;
+}
+
+// Extract the IAudioRecord BpBinder (ptr+0x190 -> +0x10) and wrap it into a Java IBinder via the
+// manually-resolved javaObjectForIBinder (bypassing the isolated-namespace dlsym block). Returns the
+// Java IBinder (BinderProxy) the daemon can hand to the app via BinderDelivery, or null.
+extern "C" JNIEXPORT jobject JNICALL
+Java_com_baba_callvault_services_recording_handoff_AudioHandoffNative_nativeExtractBinder(JNIEnv *env, jclass, jlong ptr) {
+    if (!g_javaObjForIBinder) {
+        g_javaObjForIBinder = (JavaObjForIBinderFn) manualResolve(
+            "libandroid_runtime.so", "/system/lib64/libandroid_runtime.so",
+            "_ZN7android20javaObjectForIBinderEP7_JNIEnvRKNS_2spINS_7IBinderEEE");
+    }
+    if (!g_javaObjForIBinder) { LOGI("extractBinder: javaObjectForIBinder unresolved"); return nullptr; }
+
+    struct sigaction sa{}, o1{}, o2{}; sa.sa_handler = hfHandler; sigemptyset(&sa.sa_mask);
+    sigaction(SIGSEGV, &sa, &o1); sigaction(SIGBUS, &sa, &o2);
+    void *ar = reinterpret_cast<void *>(ptr), *bpAR = nullptr, *bp = nullptr;
+    bool ok = hfRead(reinterpret_cast<uint8_t *>(ar) + 0x190, &bpAR) && hfPlaus(bpAR) &&
+              hfRead(reinterpret_cast<uint8_t *>(bpAR) + 0x10, &bp) && hfPlaus(bp);
+    sigaction(SIGSEGV, &o1, nullptr); sigaction(SIGBUS, &o2, nullptr);
+    if (!ok) { LOGI("extractBinder: couldn't read BpBinder at ar+0x190/+0x10"); return nullptr; }
+
+    const void *spRef = bp;   // sp<IBinder> = { IBinder* }
+    jobject jb = g_javaObjForIBinder(env, &spRef);
+    LOGI("extractBinder: BpBinder=%p -> Java IBinder=%p", bp, jb);
+    return jb;
+}
+
+// ioctl ASHMEM_GET_SIZE on an fd (the app uses this on the received cblk fd to mmap the RIGHT size,
+// which varies with sample rate / frameCount — hardcoding 8192 broke at 48 kHz). -1 on failure.
+extern "C" JNIEXPORT jint JNICALL
+Java_com_baba_callvault_services_recording_handoff_AudioHandoffNative_nativeAshmemSize(JNIEnv *, jclass, jint fd) {
+    return ioctl(fd, 0x00007704 /*ASHMEM_GET_SIZE*/, 0);
+}
+
+// Find the cblk ashmem fd in this process and return a DUP of it (caller owns the dup; the original stays
+// owned by the AudioRecord). Identifies the cblk by its frameCount header field (word 42 = byte 168 =
+// AudioRecord.bufferSizeInFrames) rather than a hardcoded byte size — the ashmem size varies with the
+// sample rate, so size matching broke at 48 kHz. -1 if not found.
+extern "C" JNIEXPORT jint JNICALL
+Java_com_baba_callvault_services_recording_handoff_AudioHandoffNative_nativeFindCblkFd(JNIEnv *, jclass, jint expectedFrameCount) {
+    DIR *d = opendir("/proc/self/fd");
+    if (!d) return -1;
+    struct dirent *e;
+    char p[64], t[256];
+    int result = -1;
+    const uint32_t fc = static_cast<uint32_t>(expectedFrameCount);
+    while ((e = readdir(d)) != nullptr) {
+        if (e->d_name[0] == '.') continue;
+        snprintf(p, sizeof(p), "/proc/self/fd/%s", e->d_name);
+        ssize_t n = readlink(p, t, sizeof(t) - 1);
+        if (n <= 0) continue;
+        t[n] = 0;
+        if (!strstr(t, "ashmem")) continue;
+        int fd = atoi(e->d_name);
+        int sz = ioctl(fd, 0x00007704 /*ASHMEM_GET_SIZE*/, 0);
+        if (sz < 200) continue;                                   // too small to hold a cblk header
+        void *m = mmap(nullptr, sz, PROT_READ, MAP_SHARED, fd, 0);
+        if (m == MAP_FAILED) continue;
+        uint32_t w42 = static_cast<volatile uint32_t *>(m)[42];   // frameCount field
+        munmap(m, sz);
+        if (w42 == fc) { result = dup(fd); LOGI("nativeFindCblkFd: fd=%d sz=%d w42=%u -> dup=%d", fd, sz, w42, result); break; }
+    }
+    closedir(d);
+    if (result < 0) LOGI("nativeFindCblkFd: no ashmem with frameCount=%u found", fc);
+    return result;
+}
+
+
+// Phase-3 productionization: drain the surviving cblk ring and stream ORDERED interleaved PCM-16 to a
+// pipe write-fd until STOPPED, keeping the track alive (w46=w47) exactly like nativeMonitorCblk. The app
+// reads the pipe and encodes (MediaCodec + MediaMuxer) to the output file — the encode runs ENTIRELY in
+// the app process, so it survives the daemon dying. `writeFd` ownership is transferred here: we close it
+// on exit so the reader sees EOF and finalises the container. Ring geometry: frames of `frameSize` bytes
+// (=2 mono, 4 stereo) start at byte `dataOff`; `frameCount` frames wrap the ring. `guardFrames` leaves
+// the freshest N frames UNREAD each cycle (they may still be mid-write by the server) — killing torn-read
+// glitches at the write cursor; we only advance mFront (w46) to what we actually consumed so the server
+// won't overwrite guarded, not-yet-read frames.
+//
+// Stop control: `stopFlag` is a direct ByteBuffer whose first int the app flips to non-zero on call-end;
+// we check it each cycle and exit cleanly. `maxSeconds` is a safety cap (max call length) so a lost stop
+// signal can't drain forever. Replaces Phase-2's fixed duration — the app now owns the recording length.
+extern "C" JNIEXPORT void JNICALL
+Java_com_baba_callvault_services_recording_handoff_AudioHandoffNative_nativeDrainToPipe(
+        JNIEnv *env, jclass, jint fd, jint size, jint frameCount, jint dataOff, jint frameSize,
+        jint guardFrames, jint writeFd, jobject stopFlag, jint maxSeconds) {
+    void *base = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (base == MAP_FAILED) { LOGI("drainToPipe: mmap FAILED"); close(writeFd); return; }
+    auto *stop = static_cast<volatile int32_t *>(env->GetDirectBufferAddress(stopFlag));
+    auto *w = reinterpret_cast<volatile uint32_t *>(base);
+    auto *frontPtr = reinterpret_cast<volatile uint32_t *>(w + 46); // mFront
+    auto *rearPtr = reinterpret_cast<volatile uint32_t *>(w + 47);  // mRear
+    auto *ring = static_cast<volatile uint8_t *>(base) + dataOff;
+    const uint32_t fc = static_cast<uint32_t>(frameCount);
+    const uint32_t guard = static_cast<uint32_t>(guardFrames);
+    const int fsz = frameSize;                // bytes per frame (2 mono, 4 stereo)
+    // CRITICAL: the physical ring wraps at P2 = roundup(frameCount) to the next power of 2, and positions
+    // are masked with (P2-1) — NOT modulo frameCount. This is what AudioRecordClientProxy::obtainBuffer
+    // does (front &= mFrameCountP2-1). Wrapping at frameCount for non-power-of-2 sizes (all 48kHz configs)
+    // read the wrong/zeroed region between frameCount and P2 => the gaps. (16kHz mono fc=2048 was already
+    // a power of 2, which is why only it sounded clean.)
+    uint32_t p2 = 1; while (p2 < fc) p2 <<= 1;
+    const uint32_t mask = p2 - 1;
+
+    // DECOUPLE ring consumption from downstream: the consumer MUST advance mFront on a steady cadence,
+    // never blocking on the pipe. If it blocks (encoder/file backpressure), mFront stalls, the server laps
+    // the ring (overrun), and we read corrupted/zeroed frames = periodic micro-gaps (the choppiness). So we
+    // copy available frames into a heap stage + advance mFront IMMEDIATELY, then drain the stage to the
+    // pipe NON-BLOCKING. A pipe stall only grows RAM, never stalls the ring read.
+    fcntl(writeFd, F_SETFL, O_NONBLOCK);
+    std::vector<uint8_t> stage; size_t drainOff = 0;
+    auto pumpPipe = [&](bool finalFlush) {
+        while (drainOff < stage.size()) {
+            ssize_t n = write(writeFd, stage.data() + drainOff, stage.size() - drainOff);
+            if (n > 0) { drainOff += static_cast<size_t>(n); }
+            else if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                if (!finalFlush) return;          // pipe full — keep it staged, retry next cycle
+                usleep(2000); continue;           // final flush: wait for the reader to catch up
+            } else return;                        // reader closed / error
+        }
+        stage.clear(); drainOff = 0;              // fully drained
+    };
+
+    uint32_t lastFront = *rearPtr;            // start from 'now' (server rear)
+    long totalBytes = 0; int tick = 0; uint32_t prevRear = lastFront;
+    const int CYCLE_US = 5000;                // 5 ms — keep ring occupancy tiny (<< the ring's ms)
+    const int cyclesPerSec = 1000000 / CYCLE_US; // 200
+    const long maxCycles = static_cast<long>(maxSeconds) * cyclesPerSec;
+    LOGI("drainToPipe: start frameCount=%u P2=%u dataOff=%d frameSize=%d guard=%u maxSec=%d cycle=%dus (decoupled)", fc, p2, dataOff, fsz, guard, maxSeconds, CYCLE_US);
+    for (long i = 0; i < maxCycles; i++) {
+        if (stop && __atomic_load_n(stop, __ATOMIC_ACQUIRE) != 0) { LOGI("drainToPipe: stop requested at t~%lds", i / cyclesPerSec); break; }
+        uint32_t rear = __atomic_load_n(rearPtr, __ATOMIC_ACQUIRE);  // acquire: data reads see server's release
+        uint32_t safeRear = (rear - lastFront > guard) ? rear - guard : lastFront; // hold back freshest
+        uint32_t avail = safeRear - lastFront;     // unsigned wrap-safe frame count
+        if (avail > fc) avail = fc;                // clamp on overrun (drop stale, resync below)
+        if (avail > 0) {
+            uint32_t startIdx = lastFront & mask;              // physical position (wrap at P2, not fc)
+            uint32_t firstFrames = p2 - startIdx;              // contiguous to the physical buffer end
+            if (firstFrames > avail) firstFrames = avail;
+            const uint8_t *r1 = const_cast<const uint8_t *>(ring + startIdx * fsz);
+            stage.insert(stage.end(), r1, r1 + static_cast<size_t>(firstFrames) * fsz);
+            uint32_t rem = avail - firstFrames;
+            if (rem > 0) {
+                const uint8_t *r2 = const_cast<const uint8_t *>(ring); // wrapped tail from buffer start
+                stage.insert(stage.end(), r2, r2 + static_cast<size_t>(rem) * fsz);
+            }
+            totalBytes += static_cast<long>(avail) * fsz;
+        }
+        lastFront = safeRear;
+        __atomic_store_n(frontPtr, safeRear, __ATOMIC_RELEASE); // advance mFront NOW (before any pipe I/O)
+        pumpPipe(false);                          // best-effort non-blocking drain
+        if (drainOff > (1u << 20)) { stage.erase(stage.begin(), stage.begin() + drainOff); drainOff = 0; }
+        if ((i + 1) % cyclesPerSec == 0) {
+            LOGI("drainToPipe t=%2ds rear=%u (+%u) bytes=%ld staged=%zu", tick, rear, rear - prevRear, totalBytes, stage.size() - drainOff);
+            prevRear = rear; tick++;
+        }
+        usleep(CYCLE_US);
+    }
+    pumpPipe(true);                           // flush remaining stage (blocking-ish) before EOF
+    close(writeFd);                           // EOF -> reader finalises the container
+    munmap(base, size);
+    LOGI("drainToPipe: done, %ld PCM bytes streamed", totalBytes);
+}

--- a/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
+++ b/app/src/main/java/com/baba/callvault/data/AppPreferences.kt
@@ -118,6 +118,12 @@ class AppPreferences(context: Context) {
         // re-enable it only transiently to (re)launch the daemon — the persistent-server payoff.
         const val WD_DISABLE_WHEN_IDLE = false
 
+        // --- Resilient recording (audio-capture handoff, Option B) ---
+        // OFF by default: the recording path is byte-identical to the daemon-mode default. When true and
+        // the source is handoff-compatible, the daemon hands its live AudioRecord to the app, which reads
+        // the ring + encodes — so a recording SURVIVES the daemon being killed mid-call.
+        const val HANDOFF_PERSIST_ENABLED = false
+
         // --- Audio/Scrcpy Quality ---
         val AUDIO_SOURCE = ScrcpyAudioSource.VOICE_CALL.cliKey
         val AUDIO_CODEC = ScrcpyAudioCodec.OPUS.cliKey
@@ -178,12 +184,14 @@ class AppPreferences(context: Context) {
         LAST_SEEN_VERSION_CODE("last_seen_version_code"),
         UPDATE_SUCCESS_BANNER_VERSION("update_success_banner_version"),
         WHATS_NEW_OFFWIFI_SEEN("whats_new_offwifi_seen"),
+        WHATS_NEW_RESILIENT_SEEN("whats_new_resilient_seen"),
         USB_DEFAULT_MODE("usb_default_mode"),
         UPDATE_SOURCE_OVERRIDE_URL("update_source_override_url"),
 
         // --- Persistent recorder server (CallVault Plan 5) ---
         PERSISTENT_SERVER_ENABLED("persistent_server_enabled"),
         WD_DISABLE_WHEN_IDLE("wd_disable_when_idle"),
+        HANDOFF_PERSIST_ENABLED("handoff_persist_enabled"),
         
         // --- Automation ---
         AUTO_RECORD_INCOMING("auto_record_incoming"),
@@ -402,6 +410,14 @@ class AppPreferences(context: Context) {
     fun hasSeenOffWifiWhatsNew() = getBoolean(Key.WHATS_NEW_OFFWIFI_SEEN, false)
     fun setSeenOffWifiWhatsNew(seen: Boolean) = setBoolean(Key.WHATS_NEW_OFFWIFI_SEEN, seen)
 
+    /**
+     * Whether the one-time "What's new: Resilient recording" intro modal has already been shown. Same
+     * contract as [hasSeenOffWifiWhatsNew]: a per-FEATURE introduction shown once, never a per-release
+     * changelog — so each feature keeps its own flag and nobody who skipped a release loses its note.
+     */
+    fun hasSeenResilientWhatsNew() = getBoolean(Key.WHATS_NEW_RESILIENT_SEEN, false)
+    fun setSeenResilientWhatsNew(seen: Boolean) = setBoolean(Key.WHATS_NEW_RESILIENT_SEEN, seen)
+
     /** Cached name of the last-read [com.baba.callvault.integrations.adb.UsbDefaultMode], or null. */
     fun getUsbDefaultMode() = getString(Key.USB_DEFAULT_MODE)
     fun setUsbDefaultMode(mode: String?) = setString(Key.USB_DEFAULT_MODE, mode)
@@ -428,6 +444,16 @@ class AppPreferences(context: Context) {
 
     /** Sets the "turn Wireless debugging off when the daemon is connected" policy. */
     fun setWdDisableWhenIdle(enabled: Boolean) = setBoolean(Key.WD_DISABLE_WHEN_IDLE, enabled)
+
+    /**
+     * Whether "Resilient recording" (the audio-capture handoff, Option B) is enabled. Default false =
+     * the recording path is byte-identical to daemon mode. When true and the source is handoff-compatible,
+     * the app holds the live capture and a recording survives the daemon dying mid-call.
+     */
+    fun isHandoffPersistEnabled() = getBoolean(Key.HANDOFF_PERSIST_ENABLED, DefaultsValue.HANDOFF_PERSIST_ENABLED)
+
+    /** Sets whether the resilient-recording (audio-handoff) path is enabled. */
+    fun setHandoffPersistEnabled(enabled: Boolean) = setBoolean(Key.HANDOFF_PERSIST_ENABLED, enabled)
 
     // -------- Storage & General --------
 

--- a/app/src/main/java/com/baba/callvault/integrations/scrcpy/ScrcpyAudioSourceMapping.kt
+++ b/app/src/main/java/com/baba/callvault/integrations/scrcpy/ScrcpyAudioSourceMapping.kt
@@ -1,0 +1,38 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.integrations.scrcpy
+
+import android.media.MediaRecorder
+
+/**
+ * The [MediaRecorder.AudioSource] a [ScrcpyAudioSource] can be captured with directly, or `null` when
+ * only scrcpy can capture it.
+ *
+ * This is the single gate for both non-scrcpy capture paths — the daemon's direct `AudioRecord`
+ * recorder ([com.baba.callvault.server.DirectAudioRecorderSession]) and the "Resilient recording"
+ * handoff ([com.baba.callvault.services.recording.handoff.HandoffSource]) — so the two can never
+ * disagree about which sources they support.
+ *
+ * `null` covers the sources that are NOT a plain microphone-style input: `output`/`playback` are
+ * playback-capture (scrcpy-only), and the remaining mic variants are deliberately left to scrcpy
+ * rather than silently switching their capture path.
+ */
+val ScrcpyAudioSource.androidAudioSource: Int?
+    get() = when (cliKey) {
+        "voice-call" -> MediaRecorder.AudioSource.VOICE_CALL
+        "mic-voice-communication" -> MediaRecorder.AudioSource.VOICE_COMMUNICATION
+        "mic" -> MediaRecorder.AudioSource.MIC
+        "mic-voice-recognition" -> MediaRecorder.AudioSource.VOICE_RECOGNITION
+        "voice-performance" -> MediaRecorder.AudioSource.VOICE_PERFORMANCE
+        else -> null
+    }
+
+/** Resolves a scrcpy `audio_source` cliKey to its direct [MediaRecorder.AudioSource], or null. */
+fun androidAudioSourceForKey(cliKey: String): Int? =
+    ScrcpyAudioSource.entries.firstOrNull { it.cliKey == cliKey }?.androidAudioSource

--- a/app/src/main/java/com/baba/callvault/server/BinderDelivery.kt
+++ b/app/src/main/java/com/baba/callvault/server/BinderDelivery.kt
@@ -39,6 +39,9 @@ internal object BinderDelivery {
     /** Mirrors ShizukuProvider.METHOD_SEND_BINDER. */
     private const val METHOD_SEND_BINDER = "sendBinder"
 
+    /** Delivery of a handed-off capture (IAudioRecord binder + cblk fd). */
+    private const val METHOD_SEND_HANDOFF = "sendHandoff"
+
     /** Single user (user 0) on this device; mirrors Shizuku passing the resolved userId. */
     private const val USER_0 = 0
 
@@ -49,23 +52,36 @@ internal object BinderDelivery {
      *
      * @return true if either path got a non-null reply Bundle from the provider's `call`.
      */
-    fun deliverBinderToApp(binder: IBinder, authority: String): Boolean {
-        val bundle = Bundle().apply {
-            // Wrap the binder so it survives the provider hop; mirrors Shizuku's BinderContainer use.
+    fun deliverBinderToApp(binder: IBinder, authority: String): Boolean =
+        deliver(authority, METHOD_SEND_BINDER, Bundle().apply {
             putParcelable(RecorderBinderProvider.EXTRA_BINDER, BinderContainer(binder))
-        }
+        })
 
-        AppLogger.i(TAG, "Delivering binder: trying getContentProviderExternal path (authority=$authority)")
-        if (runCatching { deliverViaActivityManager(authority, bundle) }
+    /** Delivers the extracted IAudioRecord [binder] + [cblkFd] + ring [frameCount] + capture format. */
+    fun deliverHandoffToApp(
+        binder: IBinder, authority: String, cblkFd: android.os.ParcelFileDescriptor?,
+        frameCount: Int, sampleRate: Int, channelCount: Int,
+    ): Boolean =
+        deliver(authority, METHOD_SEND_HANDOFF, Bundle().apply {
+            putParcelable(RecorderBinderProvider.EXTRA_BINDER, BinderContainer(binder))
+            if (cblkFd != null) putParcelable(RecorderBinderProvider.EXTRA_CBLK_FD, cblkFd)
+            putInt(RecorderBinderProvider.EXTRA_FRAME_COUNT, frameCount)
+            putInt(RecorderBinderProvider.EXTRA_SAMPLE_RATE, sampleRate)
+            putInt(RecorderBinderProvider.EXTRA_CHANNELS, channelCount)
+        })
+
+    private fun deliver(authority: String, method: String, bundle: Bundle): Boolean {
+        AppLogger.i(TAG, "Delivering ($method): trying getContentProviderExternal path (authority=$authority)")
+        if (runCatching { deliverViaActivityManager(authority, bundle, method) }
                 .onFailure { AppLogger.w(TAG, "getContentProviderExternal path failed: ${it.message}", it) }
                 .getOrDefault(false)
         ) {
-            AppLogger.i(TAG, "Binder delivered via getContentProviderExternal")
+            AppLogger.i(TAG, "Delivered ($method) via getContentProviderExternal")
             return true
         }
 
         AppLogger.i(TAG, "Falling back to system-context ContentResolver path")
-        return runCatching { deliverViaSystemContext(authority, bundle) }
+        return runCatching { deliverViaSystemContext(authority, bundle, method) }
             .onFailure { AppLogger.e(TAG, "system-context path failed: ${it.message}", it) }
             .getOrDefault(false)
     }
@@ -78,7 +94,7 @@ internal object BinderDelivery {
      *  4. provider.call(<attribution per SDK>, authority, "sendBinder", null, bundle)
      *  5. finally am.removeContentProviderExternal(authority, /*token*/ null)
      */
-    private fun deliverViaActivityManager(authority: String, bundle: Bundle): Boolean {
+    private fun deliverViaActivityManager(authority: String, bundle: Bundle, method: String): Boolean {
         // 1. IActivityManager via public-but-grey ActivityManager.getService().
         val am = Class.forName("android.app.ActivityManager")
             .getMethod("getService")
@@ -100,7 +116,7 @@ internal object BinderDelivery {
                 ?: throw IllegalStateException("ContentProviderHolder.provider is null")
 
             // 4. provider.call(...) — version matrix from Shizuku's IContentProviderCompat.
-            val reply = callProvider(provider, authority, METHOD_SEND_BINDER, bundle)
+            val reply = callProvider(provider, authority, method, bundle)
             AppLogger.i(TAG, "getContentProviderExternal call reply=$reply (null=${reply == null})")
             return reply != null
         } finally {
@@ -165,7 +181,7 @@ internal object BinderDelivery {
      *   ctx.getContentResolver().call(Uri "content://<authority>", "sendBinder", null, bundle)
      * Reflection used for the two hidden ActivityThread methods; the rest is public API.
      */
-    private fun deliverViaSystemContext(authority: String, bundle: Bundle): Boolean {
+    private fun deliverViaSystemContext(authority: String, bundle: Bundle, method: String): Boolean {
         val activityThreadClass = Class.forName("android.app.ActivityThread")
         val at = activityThreadClass.getMethod("systemMain").invoke(null)
             ?: throw IllegalStateException("ActivityThread.systemMain() returned null")
@@ -173,7 +189,7 @@ internal object BinderDelivery {
             ?: throw IllegalStateException("getSystemContext() returned null")
 
         val uri = android.net.Uri.parse("content://$authority")
-        val reply = context.contentResolver.call(uri, METHOD_SEND_BINDER, null, bundle)
+        val reply = context.contentResolver.call(uri, method, null, bundle)
         AppLogger.i(TAG, "system-context call reply=$reply (null=${reply == null})")
         return reply != null
     }

--- a/app/src/main/java/com/baba/callvault/server/DirectAudioRecorderSession.kt
+++ b/app/src/main/java/com/baba/callvault/server/DirectAudioRecorderSession.kt
@@ -15,11 +15,12 @@ import android.media.MediaCodecInfo
 import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.media.MediaMuxer
-import android.media.MediaRecorder
 import android.os.ParcelFileDescriptor
 import com.baba.callvault.integrations.scrcpy.ScrcpyAudioCodec
 import com.baba.callvault.integrations.scrcpy.ScrcpyAudioSource
+import com.baba.callvault.integrations.scrcpy.androidAudioSource
 import com.baba.callvault.utils.AppLogger
+import com.baba.callvault.utils.PcmDownmix
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -63,7 +64,7 @@ internal class DirectAudioRecorderSession(
     }
 
     private fun startInternal() {
-        val androidSource = androidSourceFor(source)
+        val androidSource = source.androidAudioSource
             ?: throw UnsupportedOperationException("source ${source.cliKey} is not a mic-type source")
         val mime = encoderMimeFor(codec)
 
@@ -126,7 +127,7 @@ internal class DirectAudioRecorderSession(
             if (read <= 0) continue
 
             // Feed MONO to the encoder: downmix a stereo capture (average L+R), or pass a mono capture through.
-            val (buf, len) = if (downmix) mono to downmixStereoToMono(pcm, read, mono) else pcm to read
+            val (buf, len) = if (downmix) mono to PcmDownmix.stereoToMono(pcm, read, mono) else pcm to read
 
             val inIdx = enc.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
             if (inIdx >= 0) {
@@ -202,25 +203,6 @@ internal class DirectAudioRecorderSession(
         audioRecord = null; encoder = null; muxer = null
     }
 
-    /**
-     * Downmixes interleaved stereo PCM-16 (little-endian) into mono by averaging each L/R pair. Returns
-     * the number of mono bytes written to [dst] (= [srcLen] / 2). Averaging (not summing) avoids clipping.
-     */
-    private fun downmixStereoToMono(src: ByteArray, srcLen: Int, dst: ByteArray): Int {
-        var di = 0
-        var si = 0
-        while (si + 3 < srcLen) {
-            val l = (src[si].toInt() and 0xFF or (src[si + 1].toInt() shl 8)).toShort().toInt()
-            val r = (src[si + 2].toInt() and 0xFF or (src[si + 3].toInt() shl 8)).toShort().toInt()
-            val m = (l + r) / 2
-            dst[di] = (m and 0xFF).toByte()
-            dst[di + 1] = ((m shr 8) and 0xFF).toByte()
-            di += 2
-            si += 4
-        }
-        return di
-    }
-
     private fun openAudioRecord(androidSource: Int): Pair<AudioRecord, Int> {
         for (channelMask in intArrayOf(AudioFormat.CHANNEL_IN_STEREO, AudioFormat.CHANNEL_IN_MONO)) {
             val channels = if (channelMask == AudioFormat.CHANNEL_IN_STEREO) 2 else 1
@@ -257,18 +239,8 @@ internal class DirectAudioRecorderSession(
          * the codec's MIME. Otherwise [RecorderServer] uses the scrcpy fallback.
          */
         fun supports(source: ScrcpyAudioSource, codec: ScrcpyAudioCodec): Boolean {
-            if (androidSourceFor(source) == null) return false
+            if (source.androidAudioSource == null) return false
             return runCatching { hasEncoder(encoderMimeFor(codec)) }.getOrDefault(false)
-        }
-
-        /** Maps our scrcpy `audio_source` cliKey to an Android [MediaRecorder.AudioSource]; null = needs scrcpy. */
-        private fun androidSourceFor(source: ScrcpyAudioSource): Int? = when (source.cliKey) {
-            "voice-call" -> MediaRecorder.AudioSource.VOICE_CALL
-            "mic-voice-communication" -> MediaRecorder.AudioSource.VOICE_COMMUNICATION
-            "mic" -> MediaRecorder.AudioSource.MIC
-            "mic-voice-recognition" -> MediaRecorder.AudioSource.VOICE_RECOGNITION
-            "mic-voice-performance" -> MediaRecorder.AudioSource.VOICE_PERFORMANCE
-            else -> null // "output"/playback-capture etc. — not a plain AudioRecord source
         }
 
         private fun encoderMimeFor(codec: ScrcpyAudioCodec): String = when (codec) {

--- a/app/src/main/java/com/baba/callvault/server/RecorderBinderProvider.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderBinderProvider.kt
@@ -12,9 +12,11 @@ import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
+import android.os.Binder
 import android.os.Bundle
 import android.os.IBinder
 import android.os.Process
+import com.baba.callvault.services.recording.handoff.HandoffReceiver
 import com.baba.callvault.utils.AppLogger
 
 /**
@@ -50,12 +52,36 @@ class RecorderBinderProvider : ContentProvider() {
      * unmarshals against the framework classloader and returns null (the classic Shizuku gotcha).
      */
     override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
-        if (method != METHOD_SEND_BINDER || extras == null) {
-            AppLogger.w(TAG, "Provider.call ignored method='$method' (extras null=${extras == null})")
-            return Bundle()
+        if (extras == null) { AppLogger.w(TAG, "Provider.call ignored method='$method' (null extras)"); return Bundle() }
+        when (method) {
+            METHOD_SEND_BINDER -> handleSendBinder(extras)
+            METHOD_SEND_HANDOFF -> handleSendHandoff(extras)
+            else -> AppLogger.w(TAG, "Provider.call ignored method='$method'")
         }
-        handleSendBinder(extras)
         return Bundle()
+    }
+
+    /** Resilient recording (Option B): receive the daemon-extracted IAudioRecord IBinder (+ cblk fd) and
+     * hand it to the app-side capture controller, which holds the binder (keep-alive) + reads the ring. */
+    private fun handleSendHandoff(extras: Bundle) {
+        // Only the privileged shell-uid daemon (or system) may deliver a handoff: onReceived feeds the
+        // cblk fd + geometry into native mmap/drain code, so an untrusted 3rd-party app must never reach
+        // it. A rejected caller simply means no handoff arrives → the engine falls back to daemon mode.
+        val callingUid = Binder.getCallingUid()
+        if (callingUid != Process.SHELL_UID && callingUid != Process.SYSTEM_UID && callingUid != Process.myUid()) {
+            AppLogger.w(TAG, "sendHandoff rejected: untrusted caller uid=$callingUid")
+            return
+        }
+        extras.classLoader = BinderContainer::class.java.classLoader
+        @Suppress("DEPRECATION")
+        val binder: IBinder? = extras.getParcelable<BinderContainer>(EXTRA_BINDER)?.binder
+        @Suppress("DEPRECATION")
+        val cblk = extras.getParcelable<android.os.ParcelFileDescriptor>(EXTRA_CBLK_FD)
+        val frameCount = extras.getInt(EXTRA_FRAME_COUNT, 0)
+        val sampleRate = extras.getInt(EXTRA_SAMPLE_RATE, 16000)
+        val channels = extras.getInt(EXTRA_CHANNELS, 1)
+        if (binder == null) { AppLogger.e(TAG, "sendHandoff: IAudioRecord binder null"); return }
+        HandoffReceiver.onReceived(binder, cblk, frameCount, sampleRate, channels)
     }
 
     /** Mirrors `ShizukuProvider.handleSendBinder`: read the container, store + link-to-death the binder. */
@@ -116,7 +142,20 @@ class RecorderBinderProvider : ContentProvider() {
         /** Mirrors ShizukuProvider.METHOD_SEND_BINDER. */
         const val METHOD_SEND_BINDER = "sendBinder"
 
+        /** Delivery of a handed-off capture (IAudioRecord binder + cblk fd); see HandoffReceiver. */
+        const val METHOD_SEND_HANDOFF = "sendHandoff"
+
         /** Bundle key for the [BinderContainer]; analogous to ShizukuProvider.EXTRA_BINDER. */
         const val EXTRA_BINDER = "com.baba.callvault.recorder.extra.BINDER"
+
+        /** Bundle key for the cblk ParcelFileDescriptor. */
+        const val EXTRA_CBLK_FD = "com.baba.callvault.recorder.extra.CBLK_FD"
+
+        /** Bundle key for the authoritative ring frame count (AudioRecord.bufferSizeInFrames). */
+        const val EXTRA_FRAME_COUNT = "com.baba.callvault.recorder.extra.FRAME_COUNT"
+
+        /** Capture format keys, so the app-side drain + encoder match the daemon's AudioRecord. */
+        const val EXTRA_SAMPLE_RATE = "com.baba.callvault.recorder.extra.SAMPLE_RATE"
+        const val EXTRA_CHANNELS = "com.baba.callvault.recorder.extra.CHANNELS"
     }
 }

--- a/app/src/main/java/com/baba/callvault/server/RecorderServer.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderServer.kt
@@ -15,6 +15,8 @@ import android.os.Process
 import androidx.annotation.Keep
 import com.baba.callvault.integrations.scrcpy.ScrcpyAudioCodec
 import com.baba.callvault.integrations.scrcpy.ScrcpyAudioSource
+import com.baba.callvault.services.recording.handoff.AudioHandoffNative
+import com.baba.callvault.services.recording.handoff.HandoffSource
 import com.baba.callvault.utils.AppLogger
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -229,6 +231,34 @@ object RecorderServer {
             stopRecording()
             // Give the worker a beat to finish the teardown post before we exit the process.
             workerHandler.post { exitProcess(0) }
+        }
+
+        // "Resilient recording" (Option B): create the privileged AudioRecord for the requested source,
+        // extract the IAudioRecord + cblk, and DELIVER them to the app. Runs on the binder thread so the
+        // synchronous push completes (app is capturing) before this returns true. Fast (create+extract).
+        override fun startHandoff(source: String?, sampleRate: Int, channels: Int): Boolean {
+            if (source == null) { AppLogger.e(TAG, "startHandoff: null source"); return false }
+            AppLogger.i(TAG, "startHandoff source=$source rate=$sampleRate channels=$channels")
+            // Loaded lazily (not at daemon boot): a user who never enables Resilient recording should
+            // not pay for the dlopen, and daemon boot is on the critical path of a call that is already
+            // ringing. Idempotent, and cheap once loaded.
+            if (!AudioHandoffNative.ensureLoadedFromApk(apkPath)) {
+                AppLogger.e(TAG, "startHandoff: libaudiohandoff.so unavailable in the daemon")
+                return false
+            }
+            return runCatching {
+                HandoffSource.deliverToApp(
+                    RecorderBinderProvider.AUTHORITY, source, sampleRate, channels
+                )
+            }.onFailure { AppLogger.w(TAG, "startHandoff error: ${it.message}") }.getOrDefault(false)
+        }
+
+        // Releases the daemon's held handoff AudioRecord (the app owns capture after the handoff; this
+        // just frees the daemon's now-unneeded input so the next call can create a fresh one).
+        override fun stopHandoff() {
+            AppLogger.i(TAG, "stopHandoff requested")
+            runCatching { HandoffSource.releaseHeld() }
+                .onFailure { AppLogger.w(TAG, "stopHandoff error: ${it.message}") }
         }
     }
 }

--- a/app/src/main/java/com/baba/callvault/server/RecorderServerLauncher.kt
+++ b/app/src/main/java/com/baba/callvault/server/RecorderServerLauncher.kt
@@ -105,6 +105,13 @@ object RecorderServerLauncher {
     private const val SHELL_READY_TIMEOUT_MS = 6_000L
 
     /**
+     * Hard bound on the opportunistic USB-default refresh in [applyWdPolicy]. Generous for a local
+     * `dumpsys` (normally milliseconds) but small enough that a wedged ADB stream cannot delay the start
+     * of a recording — an unbounded read there loses the entire call.
+     */
+    private const val USB_REFRESH_TIMEOUT_MS = 1_500L
+
+    /**
      * Ensures the privileged recorder daemon is running and its binder is available in
      * [RecorderConnection]. Call OFF the main thread (does ADB network I/O and polls/sleeps).
      *
@@ -201,13 +208,36 @@ object RecorderServerLauncher {
      */
     private fun applyWdPolicy(context: Context) {
         // We still hold the ADB shell here (before WD is turned off) — opportunistically refresh the
-        // USB-default cache that drives the "locking the screen may stop recording" warning. Never forces
-        // a connection (no-op when the shell isn't up), so it adds no churn and only a fast dumpsys read.
-        runCatching { UsbDefaultConfig.readIfConnected(context) }
+        // USB-default cache that drives the "locking the screen may stop recording" warning.
+        //
+        // MUST be bounded: this runs on the critical path of STARTING A RECORDING. The dumpsys read is
+        // normally instant (or fails fast with "Stream closed"), but over a half-dead ADB connection the
+        // stream read BLOCKS INDEFINITELY — which silently hangs `startPipeline` and loses the whole call
+        // (observed repeatedly on-device: the log stops right here and the output file stays 0 bytes).
+        // The refresh is opportunistic, so a timeout simply means the cached value stays stale.
+        refreshUsbDefaultBounded(context)
         if (AdbShell.disableWirelessDebugging(context)) {
             AppLogger.i(TAG, "Wireless debugging disabled (daemon connected; commands flow over binder)")
         } else {
             AppLogger.w(TAG, "Could not disable Wireless debugging (missing WRITE_SECURE_SETTINGS?)")
+        }
+    }
+
+    /**
+     * Runs the opportunistic USB-default refresh with a hard time bound so it can never stall a recording.
+     *
+     * The read is done on a throwaway daemon thread and joined for at most [USB_REFRESH_TIMEOUT_MS]; if
+     * the underlying ADB stream is wedged the thread is simply abandoned (it unblocks whenever the stream
+     * finally errors) and we carry on with a stale cached value. Correctness of the recording never
+     * depends on this value — it only drives an advisory UI warning.
+     */
+    private fun refreshUsbDefaultBounded(context: Context) {
+        val worker = Thread { runCatching { UsbDefaultConfig.readIfConnected(context) } }
+            .apply { isDaemon = true; name = "cv-usbdefault-refresh" }
+        worker.start()
+        runCatching { worker.join(USB_REFRESH_TIMEOUT_MS) }
+        if (worker.isAlive) {
+            AppLogger.w(TAG, "USB-default refresh still blocked after ${USB_REFRESH_TIMEOUT_MS}ms; continuing (stale value)")
         }
     }
 

--- a/app/src/main/java/com/baba/callvault/services/recording/AudioRecordingEngine.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/AudioRecordingEngine.kt
@@ -26,6 +26,8 @@ import com.baba.callvault.integrations.scrcpy.ScrcpyClient
 import com.baba.callvault.integrations.scrcpy.ScrcpyLauncher
 import com.baba.callvault.server.RecorderConnection
 import com.baba.callvault.server.RecorderServerLauncher
+import com.baba.callvault.services.recording.handoff.HandoffReceiver
+import com.baba.callvault.services.recording.handoff.HandoffSource
 import com.baba.callvault.system.storage.SafHelper
 import com.baba.callvault.integrations.scrcpy.ServerExtractor
 import com.baba.callvault.utils.AppLogger
@@ -54,6 +56,9 @@ class AudioRecordingEngine {
 
         /** How often the daemon-mode liveness watch re-checks that the daemon's binder is alive. */
         private const val DAEMON_LIVENESS_POLL_MS = 2000L
+
+        /** Capture rate for the resilient-recording (handoff) path — matches DirectAudioRecorderSession. */
+        private const val HANDOFF_SAMPLE_RATE = 48000
     }
 
     /**
@@ -159,6 +164,19 @@ class AudioRecordingEngine {
         private set
 
     /**
+     * Whether this session records via the resilient-recording (audio-handoff, Option B) path: the app
+     * holds the live capture + encodes locally, so the recording survives the daemon dying mid-call. Set
+     * true once the handoff establishes; like [daemonRecording] there is no local pipe-read job, so
+     * `isCurrentlyRecording` must consult this. Mutually exclusive with [daemonMode].
+     */
+    @Volatile
+    var handoffRecording: Boolean = false
+        private set
+
+    /** True when [startPipeline] chose the handoff path; drives the [release] teardown branch. */
+    private var handoffMode: Boolean = false
+
+    /**
      * Fired at most once per session when the liveness watch finds the daemon's binder dead while a
      * daemon-mode recording is supposed to be live (observed when Developer options is off: the
      * daemon dies within ~200ms of Wireless debugging being turned off, so `startRecording` is
@@ -244,6 +262,20 @@ class AudioRecordingEngine {
         currentRecordingUri = safResult.uri
         outputPfd = safResult.descriptor
         stagingFile = safResult.stagingFile
+
+        // Resilient recording (Option B) opt-in: when ENABLED and the source can be captured via a Java
+        // AudioRecord (voice-call/mic/voice-communication/…), use the handoff pipeline — the daemon hands
+        // its live capture to the app, which reads the ring + encodes, so a recording SURVIVES the daemon
+        // dying mid-call. Anything else (pref off, or output/playback sources) falls through to the
+        // unchanged daemon path below. When the pref is OFF this branch is skipped entirely, so the
+        // default recording path is byte-identical to before.
+        if (preferences.isHandoffPersistEnabled() && HandoffSource.supportsHandoff(audioSourceEnum.cliKey) &&
+            startHandoffPipeline(context, audioSourceEnum, codecEnum, bitRate, isCancelled)
+        ) {
+            handoffMode = true
+            currentCodecEnum = codecEnum
+            return
+        }
 
         // CallVault ALWAYS records via the persistent privileged daemon — it is the app's core
         // mechanism, not an option. Hand the SAF output fd to the daemon and let IT own scrcpy + muxing
@@ -369,6 +401,85 @@ class AudioRecordingEngine {
     }
 
     /**
+     * Resilient-recording pipeline (Option B): ensure the daemon is up, register the app-side output
+     * target ([outputPfd] + the user's codec), then ask the daemon to create the privileged AudioRecord
+     * and hand its live `IAudioRecord` + cblk to the app. The app (via [HandoffReceiver]) reads the ring
+     * and encodes into [outputPfd] — so the daemon may then die WITHOUT stopping the recording.
+     *
+     * The push delivery runs synchronously inside `startHandoff`, so by the time it returns the app has
+     * received the handoff; [HandoffReceiver.isLive] confirms capture actually started.
+     *
+     * @return true if the handoff established (capture is live); false → the caller falls back to the
+     *         daemon path so a call is never lost. Never throws except the pre-start cancellation.
+     */
+    private fun startHandoffPipeline(
+        context: Service,
+        audioSourceEnum: ScrcpyAudioSource,
+        codecEnum: ScrcpyAudioCodec,
+        bitRate: Int,
+        isCancelled: () -> Boolean
+    ): Boolean {
+        AppLogger.i(TAG, "Ensuring recorder daemon is running (handoff)")
+        val t0 = System.currentTimeMillis()
+        val connected = RecorderServerLauncher.ensureServerRunning(context)
+        AppLogger.i(TAG, "Handoff: ensureServerRunning=$connected in ${System.currentTimeMillis() - t0}ms")
+        // Same cold-start abort as the daemon path: if the call ended while the daemon was coming up,
+        // abort before creating any capture so the mic never turns on after the call (stuck-mic bug).
+        if (isCancelled()) {
+            AppLogger.w(TAG, "Call ended before the daemon was ready; aborting handoff start")
+            runCatching { outputPfd?.close() }
+            stagingFile?.let { runCatching { it.delete() } }
+            stagingFile = null
+            throw CancellationException("Recording aborted before start (call ended during daemon cold-start)")
+        }
+        val service = RecorderConnection.service
+        if (!connected || service == null) {
+            AppLogger.w(TAG, "Handoff: recorder daemon unavailable (connected=$connected, service=${service != null})")
+            return false
+        }
+        val outFd = outputPfd?.fileDescriptor
+            ?: run { AppLogger.w(TAG, "Handoff: no output fd; falling back"); return false }
+
+        // voice-call is captured STEREO (uplink L / downlink R) then downmixed to mono; mono sources stay
+        // mono. The app always outputs a single mono track (matches prod), so downmixToMono is always on
+        // (a no-op for already-mono capture).
+        val preferredChannels = if (audioSourceEnum == ScrcpyAudioSource.VOICE_CALL) 2 else 1
+        HandoffReceiver.begin(
+            HandoffReceiver.Target(
+                outputFd = outFd,
+                mime = codecEnum.mimeType,
+                muxerFormat = codecEnum.outputFormat,
+                bitRate = bitRate,
+                downmixToMono = true,
+            )
+        )
+        AppLogger.i(TAG, "Handoff: calling daemon startHandoff(${audioSourceEnum.cliKey}, $HANDOFF_SAMPLE_RATE, $preferredChannels)")
+        val t1 = System.currentTimeMillis()
+        val delivered = try {
+            service.startHandoff(audioSourceEnum.cliKey, HANDOFF_SAMPLE_RATE, preferredChannels)
+                .also { AppLogger.i(TAG, "Handoff: startHandoff returned $it in ${System.currentTimeMillis() - t1}ms") }
+        } catch (e: Exception) {
+            // The daemon can die AFTER it has already pushed the handoff and the app started capturing,
+            // but BEFORE this reply returns (DeadObjectException) — precisely the scenario this feature
+            // exists to survive. So the binder reply is NOT authoritative; HandoffReceiver.isLive is.
+            AppLogger.w(TAG, "Handoff: startHandoff reply failed (${e.message}); checking isLive")
+            false
+        }
+        // isLive is the single source of truth: if the app-side capture actually started, the recording
+        // is live regardless of whether the binder reply made it back. Never abort or fall back in that
+        // case — doing so would orphan the running capture AND hand the same fd to a second (daemon) writer.
+        if (HandoffReceiver.isLive) {
+            handoffRecording = true
+            AppLogger.i(TAG, "Handoff established (delivered=$delivered); app now owns capture (survives daemon death)")
+            return true
+        }
+        AppLogger.w(TAG, "Handoff did not establish (delivered=$delivered); releasing + falling back to daemon path")
+        HandoffReceiver.abort()
+        runCatching { service.stopHandoff() }
+        return false
+    }
+
+    /**
      * Safely releases all held resources in the correct order.
      * Everything is wrapped in runCatching to ignore any exceptions and continue the cleanup.
      *
@@ -388,6 +499,21 @@ class AudioRecordingEngine {
     fun release() {
         AppLogger.i(TAG, "Releasing session resources and recording pipeline...")
         livenessHandler.removeCallbacks(livenessWatch)
+
+        if (handoffMode) {
+            // Resilient-recording teardown: stop() flips the drain flag and BLOCKS until the app-side
+            // encoder finalises the container trailer into outputPfd; only then close our fd handle. Then
+            // best-effort ask the daemon to release its held track (ignored if the daemon already died —
+            // which is exactly the case this path exists to survive).
+            runCatching { HandoffReceiver.stop() }
+                .onFailure { AppLogger.w(TAG, "Handoff stop error during release: ${it.message}") }
+            runCatching { RecorderConnection.service?.stopHandoff() }
+                .onFailure { AppLogger.w(TAG, "Daemon stopHandoff failed during release: ${it.message}") }
+            runCatching { outputPfd?.close() }
+            handoffRecording = false
+            finalizeStagingIfNeeded()
+            return
+        }
 
         if (daemonMode) {
             // Ask the daemon to stop + finalise the container, then close our local fd handle. The local

--- a/app/src/main/java/com/baba/callvault/services/recording/RecordingForegroundService.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/RecordingForegroundService.kt
@@ -132,9 +132,9 @@ class RecordingForegroundService : Service() {
     /** True only if the pipeline is actively reading and capturing audio. */
     private val isCurrentlyRecording: Boolean
         get() = (currentState as? RecordingServiceState.Active)?.engine?.let { e ->
-            // Local mode: the pipe-read job reflects liveness. Daemon mode: there is no local job, so
-            // consult the daemon-recording flag instead (else this is always false while the daemon records).
-            e.audioPipeReadJob?.isActive == true || e.daemonRecording
+            // Local mode: the pipe-read job reflects liveness. Daemon mode / resilient handoff mode: there
+            // is no local job, so consult the mode flags instead (else this is always false while recording).
+            e.audioPipeReadJob?.isActive == true || e.daemonRecording || e.handoffRecording
         } == true
 
     // ── Service lifecycle ──────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/baba/callvault/services/recording/handoff/AudioHandoffNative.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/handoff/AudioHandoffNative.kt
@@ -1,0 +1,94 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording.handoff
+
+import com.baba.callvault.utils.AppLogger
+import java.io.File
+
+/**
+ * JNI bridge to `libaudiohandoff.so`, the native half of "Resilient recording".
+ *
+ * Loaded in BOTH processes, by different means (see [ensureLoaded] / [ensureLoadedFromApk]):
+ *  • the DAEMON extracts the `IAudioRecord` binder + cblk ashmem fd from a privileged `AudioRecord`;
+ *  • the APP mmaps the delivered cblk and drains its ring, which is what lets a recording outlive the
+ *    daemon.
+ */
+object AudioHandoffNative {
+    private const val TAG = "CV:HandoffNative"
+    private const val LIB_NAME = "audiohandoff"
+    private const val SO_NAME = "lib$LIB_NAME.so"
+
+    @Volatile private var loaded = false
+
+    /** Loads the library once via the app classloader (APP process); returns availability. */
+    fun ensureLoaded(): Boolean {
+        if (loaded) return true
+        return runCatching { System.loadLibrary(LIB_NAME); loaded = true; true }.getOrDefault(false)
+    }
+
+    /**
+     * Loads the library in the DAEMON. app_process has no classloader library-search path, so
+     * `System.loadLibrary` cannot find it — it must be loaded by absolute path from the extracted
+     * native-lib dir that sits next to the APK ([apkPath] = `applicationInfo.sourceDir`).
+     */
+    fun ensureLoadedFromApk(apkPath: String): Boolean {
+        if (loaded) return true
+        val so = findExtractedLib(apkPath)
+        if (so == null) {
+            AppLogger.e(TAG, "$SO_NAME not found under ${File(apkPath).parentFile}/lib — handoff unavailable")
+            return false
+        }
+        return runCatching { System.load(so.absolutePath); loaded = true; true }
+            .onFailure { AppLogger.e(TAG, "System.load($so) failed: ${it.message}") }
+            .getOrDefault(false)
+    }
+
+    /**
+     * Locates the extracted `libaudiohandoff.so` next to the APK, by SEARCHING `lib/` rather than
+     * assuming the subdirectory's name.
+     *
+     * That directory is named after the **instruction set** (`arm64`), not the build ABI
+     * (`arm64-v8a`) — a difference that once silently disabled the whole feature, because a failed
+     * load only makes `startHandoff` return false and the engine then falls back to the daemon
+     * recording path, so the call still records and nothing looks broken from outside. Searching
+     * costs one directory listing, once per daemon lifetime.
+     */
+    internal fun findExtractedLib(apkPath: String): File? {
+        val libRoot = File(File(apkPath).parentFile, "lib")
+        return libRoot.listFiles()
+            ?.asSequence()
+            ?.map { File(it, SO_NAME) }
+            ?.firstOrNull { it.isFile }
+    }
+
+    /** True if `ptr` is a native android::AudioRecord (ptr+0x190 -> +0x10 is a BpBinder). */
+    external fun nativeValidateArPtr(ptr: Long): Boolean
+
+    /** Extracts the IAudioRecord BpBinder from the native AudioRecord + wraps it as a Java IBinder. */
+    external fun nativeExtractBinder(ptr: Long): android.os.IBinder?
+
+    /** Finds + dups the cblk ashmem fd in this process, identified by its frameCount header (-1 if none). */
+    external fun nativeFindCblkFd(expectedFrameCount: Int): Int
+
+    /** ioctl ASHMEM_GET_SIZE on `fd` — the app uses this to mmap the cblk at its true (rate-dependent) size. */
+    external fun nativeAshmemSize(fd: Int): Int
+
+    /**
+     * Drains the cblk ring until STOPPED, streaming ORDERED interleaved PCM-16 to `writeFd` (a pipe
+     * write end whose ownership is transferred to native — closed there to signal EOF). Ring geometry:
+     * `frameCount` frames of `frameSize` bytes (2 mono / 4 stereo) starting at byte `dataOff`.
+     * `guardFrames` holds back the freshest N frames each cycle (avoids torn reads at the write cursor).
+     * `stopFlag` is a direct ByteBuffer whose first int the caller flips non-zero to stop; `maxSeconds`
+     * is a safety cap in case a stop signal is ever lost.
+     */
+    external fun nativeDrainToPipe(
+        fd: Int, size: Int, frameCount: Int, dataOff: Int, frameSize: Int,
+        guardFrames: Int, writeFd: Int, stopFlag: java.nio.ByteBuffer, maxSeconds: Int,
+    )
+}

--- a/app/src/main/java/com/baba/callvault/services/recording/handoff/HandoffEncoder.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/handoff/HandoffEncoder.kt
@@ -1,0 +1,159 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording.handoff
+
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import com.baba.callvault.utils.AppLogger
+import com.baba.callvault.utils.PcmDownmix
+import java.io.FileDescriptor
+import java.io.InputStream
+
+/**
+ * APP-side encoder for a handed-off capture: reads raw interleaved PCM-16 from [pcmIn] (the cblk drain,
+ * streamed over a pipe by `nativeDrainToPipe`) and encodes it to [outFd] via `MediaCodec` → `MediaMuxer`.
+ *
+ * This is the SAME synchronous drive as [com.baba.callvault.server.DirectAudioRecorderSession], but it
+ * runs in the always-alive APP process and takes its input from a stream instead of an `AudioRecord` —
+ * which is what lets the encode survive the privileged daemon dying mid-call.
+ */
+class HandoffEncoder(
+    private val pcmIn: InputStream,
+    private val outFd: FileDescriptor,
+    private val sampleRate: Int = 16_000,
+    /** Channels in the incoming PCM stream (1 mono, 2 interleaved stereo). */
+    private val captureChannels: Int = 1,
+    /** true → downmix stereo to mono (prod). false → encode all captured channels (diagnostic: keep L/R). */
+    private val downmixToMono: Boolean = true,
+    private val mime: String = MediaFormat.MIMETYPE_AUDIO_AAC,
+    private val muxerFormat: Int = MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4,
+    private val bitRate: Int = 64_000,
+) {
+    /**
+     * Runs the read → encode → mux loop on the CALLING thread until [pcmIn] reaches EOF (native closed the
+     * pipe write end at drain-end / stop), then flushes EOS and finalises the container. Blocking.
+     */
+    fun encodeBlocking() {
+        val downmix = downmixToMono && captureChannels == 2
+        val encodeChannels = if (downmix) 1 else captureChannels
+        val outFrameBytes = encodeChannels * 2 // PCM-16 output frame size
+        val format = MediaFormat.createAudioFormat(mime, sampleRate, encodeChannels).apply {
+            setInteger(MediaFormat.KEY_BIT_RATE, bitRate)
+            if (mime == MediaFormat.MIMETYPE_AUDIO_AAC) {
+                setInteger(MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC)
+            }
+            setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, MAX_INPUT_SIZE)
+        }
+        val enc = MediaCodec.createEncoderByType(mime).apply {
+            configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+        }
+        val mux = MediaMuxer(outFd, muxerFormat)
+        enc.start()
+        AppLogger.i(TAG, "HandoffEncoder started: mime=$mime rate=$sampleRate captureCh=$captureChannels encodeCh=$encodeChannels bitRate=$bitRate")
+
+        val info = MediaCodec.BufferInfo()
+        var muxerStarted = false
+        var totalFrames = 0L
+        val pcm = ByteArray(READ_CHUNK_BYTES)
+        val mono = ByteArray(READ_CHUNK_BYTES / 2) // downmix target (stereo → half the bytes)
+
+        try {
+            while (true) {
+                val read = readFull(pcm, captureChannels * 2) // whole frames only (avoids split-frame downmix)
+                if (read < 0) break // native closed the pipe → end of capture
+                if (read == 0) continue
+
+                // Downmix interleaved stereo (average L+R), or pass the captured PCM through unchanged.
+                val (buf, len) = if (downmix) mono to PcmDownmix.stereoToMono(pcm, read, mono) else pcm to read
+
+                // Feed the chunk — NEVER drop it. The pipe is bursty, so all input buffers can be briefly
+                // busy; if dequeue times out we drain output (frees a buffer) and retry, rather than
+                // discarding audio (which caused periodic dropouts = choppiness).
+                var inIdx = enc.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
+                while (inIdx < 0) {
+                    muxerStarted = drainEncoder(enc, mux, info, muxerStarted)
+                    inIdx = enc.dequeueInputBuffer(DEQUEUE_TIMEOUT_US)
+                }
+                val inBuf = enc.getInputBuffer(inIdx)!!
+                inBuf.clear(); inBuf.put(buf, 0, len)
+                val ptsUs = totalFrames * 1_000_000L / sampleRate
+                enc.queueInputBuffer(inIdx, 0, len, ptsUs, 0)
+                totalFrames += len / outFrameBytes // output frames (across all encoded channels)
+                muxerStarted = drainEncoder(enc, mux, info, muxerStarted)
+            }
+
+            // Flush the encoder tail, then drain to EOS so the container trailer is complete.
+            val inIdx = enc.dequeueInputBuffer(END_OF_STREAM_TIMEOUT_US)
+            if (inIdx >= 0) enc.queueInputBuffer(inIdx, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+            drainEncoder(enc, mux, info, muxerStarted, drainToEos = true)
+            AppLogger.i(TAG, "HandoffEncoder finished: ${totalFrames} frames (${totalFrames / sampleRate.toFloat()}s)")
+        } finally {
+            runCatching { enc.stop() }
+            runCatching { enc.release() }
+            runCatching { mux.stop() }   // writes the container trailer (without it the file won't play)
+            runCatching { mux.release() }
+            runCatching { pcmIn.close() }
+        }
+    }
+
+    /** Reads into [buf] and returns a byte count that is a whole multiple of [align] (or -1 at EOF). */
+    private fun readFull(buf: ByteArray, align: Int): Int {
+        var n = pcmIn.read(buf, 0, buf.size)
+        if (n < 0) return -1
+        while (n % align != 0) { // top up so a frame is never split across the downmix boundary
+            val r = pcmIn.read(buf, n, align - (n % align))
+            if (r < 0) break
+            n += r
+        }
+        return n
+    }
+
+    /** Drains available encoder output into the muxer. Returns whether the muxer is (now) started. */
+    private fun drainEncoder(
+        enc: MediaCodec, mux: MediaMuxer, info: MediaCodec.BufferInfo,
+        muxerStartedIn: Boolean, drainToEos: Boolean = false,
+    ): Boolean {
+        var muxerStarted = muxerStartedIn
+        var track = if (muxerStarted) 0 else -1
+        while (true) {
+            val outIdx = enc.dequeueOutputBuffer(info, if (drainToEos) END_OF_STREAM_TIMEOUT_US else 0)
+            when {
+                outIdx == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                    track = mux.addTrack(enc.outputFormat) // format carries codec-specific data (CSD)
+                    mux.start()
+                    muxerStarted = true
+                }
+                outIdx == MediaCodec.INFO_TRY_AGAIN_LATER -> {
+                    if (drainToEos) continue else return muxerStarted
+                }
+                outIdx >= 0 -> {
+                    val outBuf = enc.getOutputBuffer(outIdx)!!
+                    val isConfig = info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0
+                    if (!isConfig && info.size > 0 && muxerStarted) {
+                        outBuf.position(info.offset)
+                        outBuf.limit(info.offset + info.size)
+                        mux.writeSampleData(track, outBuf, info)
+                    }
+                    enc.releaseOutputBuffer(outIdx, false)
+                    if (info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) return muxerStarted
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "CV:HandoffEnc"
+        private const val READ_CHUNK_BYTES = 4096
+        private const val MAX_INPUT_SIZE = 16_384
+        private const val DEQUEUE_TIMEOUT_US = 10_000L
+        private const val END_OF_STREAM_TIMEOUT_US = 100_000L
+    }
+}

--- a/app/src/main/java/com/baba/callvault/services/recording/handoff/HandoffGeometry.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/handoff/HandoffGeometry.kt
@@ -1,0 +1,93 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording.handoff
+
+/**
+ * Shape of a delivered capture control block: where the audio ring sits inside the cblk ashmem region
+ * and how the drain must walk it.
+ *
+ * Every field arrives over IPC and is fed straight into native pointer arithmetic, so this type exists
+ * to keep that arithmetic — and the validation that must precede it — in one pure, testable place.
+ * Nothing may mmap or drain a cblk before [validationError] has returned null for it.
+ *
+ * @param frameCount frames the track was allocated (`AudioRecord.bufferSizeInFrames`).
+ * @param sampleRate capture rate in Hz.
+ * @param channels   captured channels (1 mono, 2 interleaved stereo).
+ * @param cblkSize   true byte size of the ashmem region, from `ASHMEM_GET_SIZE`.
+ */
+data class HandoffGeometry(
+    val frameCount: Int,
+    val sampleRate: Int,
+    val channels: Int,
+    val cblkSize: Int,
+) {
+    /** Bytes per frame across all captured channels (PCM-16). */
+    val frameSize: Int get() = channels * BYTES_PER_SAMPLE
+
+    /**
+     * The frame count the ring PHYSICALLY wraps at: positions are masked with `wrapFrames - 1`, so the
+     * ring rounds up to the next power of two rather than wrapping at [frameCount].
+     *
+     * This mirrors `AudioRecordClientProxy::obtainBuffer` (`front &= mFrameCountP2 - 1`). Wrapping at
+     * [frameCount] instead reads the untouched region between [frameCount] and the rounded-up size,
+     * which is exactly the periodic-gap bug this constant was introduced to fix — every 48 kHz
+     * configuration has a non-power-of-two frame count.
+     */
+    val wrapFrames: Int
+        get() {
+            var p2 = 1
+            while (p2 < frameCount) p2 = p2 shl 1
+            return p2
+        }
+
+    /** Last byte of the ring, exclusive — must fit inside [cblkSize]. */
+    val ringEndOffset: Long get() = DATA_OFF + wrapFrames.toLong() * frameSize
+
+    /**
+     * Why this geometry must not be used, or null if it is safe to drain.
+     *
+     * The delivery arrives over an exported provider. Callers already reject untrusted UIDs, but the
+     * values still get turned into native offsets, so a corrupt or hostile payload must be refused here
+     * rather than becoming an out-of-bounds read.
+     */
+    fun validationError(): String? = when {
+        channels !in MIN_CHANNELS..MAX_CHANNELS -> "bad channels=$channels"
+        sampleRate !in MIN_SAMPLE_RATE..MAX_SAMPLE_RATE -> "bad rate=$sampleRate"
+        frameCount <= 0 -> "bad frameCount=$frameCount"
+        cblkSize <= 0 -> "fd is not a sized ashmem region (size=$cblkSize)"
+        ringEndOffset > cblkSize ->
+            "geometry doesn't fit ashmem (dataOff=$DATA_OFF wrapFrames=$wrapFrames frameSize=$frameSize > $cblkSize)"
+        else -> null
+    }
+
+    companion object {
+        /** Byte offset of the audio buffer within `audio_track_cblk_t` (Android 16). */
+        const val DATA_OFF = 232
+
+        /** Freshest frames held back each drain cycle — they may still be mid-write by the server. */
+        const val GUARD_FRAMES = 32
+
+        private const val BYTES_PER_SAMPLE = 2 // PCM-16
+        private const val MIN_CHANNELS = 1
+        private const val MAX_CHANNELS = 2
+        private const val MIN_SAMPLE_RATE = 8_000
+        private const val MAX_SAMPLE_RATE = 192_000
+
+        /** Frame count assumed when the daemon could not report one. */
+        const val FRAME_COUNT_FALLBACK = 2048
+
+        /** Builds a geometry, substituting [FRAME_COUNT_FALLBACK] for a missing frame count. */
+        fun of(frameCount: Int, sampleRate: Int, channels: Int, cblkSize: Int) = HandoffGeometry(
+            frameCount = if (frameCount > 0) frameCount else FRAME_COUNT_FALLBACK,
+            sampleRate = sampleRate,
+            channels = channels,
+            cblkSize = cblkSize,
+        )
+    }
+}

--- a/app/src/main/java/com/baba/callvault/services/recording/handoff/HandoffReceiver.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/handoff/HandoffReceiver.kt
@@ -1,0 +1,214 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording.handoff
+
+import android.os.IBinder
+import android.os.ParcelFileDescriptor
+import com.baba.callvault.utils.AppLogger
+import java.io.FileDescriptor
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * App-side receiver + controller for the audio-capture handoff ("Resilient recording", Option B).
+ *
+ * The recording engine calls [begin] with the output target BEFORE asking the daemon to start the
+ * handoff. The daemon then pushes the `IAudioRecord` binder + cblk ashmem fd, which lands in [onReceived]
+ * (routed by `RecorderBinderProvider`) on a binder thread. This object holds the binder — an independent
+ * ref in the APP's binder_proc = keep-alive — and runs the full app-side capture: a native thread drains
+ * the cblk ring to a pipe while [HandoffEncoder] reads the pipe and encodes into the engine's SAF output
+ * fd. Killing the daemon mid-capture does NOT stop it: the track survives on the app's ref and the encode
+ * is local. [stop] flips the stop flag and waits for the container to finalise.
+ */
+object HandoffReceiver {
+    private const val T = "CV:HandoffRecv"
+
+    private const val MAX_SECONDS = 4 * 60 * 60 // safety cap if a stop signal is ever lost
+    private const val ENCODE_JOIN_MS = 8000L    // bound the wait for the encoder to finalise the container
+
+    /** Output target the engine hands over (via [begin]) before starting the handoff. */
+    data class Target(
+        val outputFd: FileDescriptor,
+        val mime: String,
+        val muxerFormat: Int,
+        val bitRate: Int,
+        val downmixToMono: Boolean,
+    )
+
+    @Volatile private var pending: Target? = null
+    // Strong ref so the app's binder_proc keeps the RecordHandle ref (keep-alive after the daemon dies).
+    @Volatile private var held: IBinder? = null
+    @Volatile private var cblk: ParcelFileDescriptor? = null
+    @Volatile private var stopFlag: ByteBuffer? = null
+    @Volatile private var encodeThread: Thread? = null
+
+    /** True while a handoff capture is live in the app (survives daemon death). */
+    @Volatile
+    var isLive: Boolean = false
+        private set
+
+    /** Engine sets the output target BEFORE calling `IRecorderService.startHandoff`, so the push finds it. */
+    fun begin(target: Target) {
+        pending = target
+        isLive = false
+    }
+
+    /** Clears a pending/failed handoff without a live capture (used when establishment fails → fall back). */
+    fun abort() {
+        pending = null
+        releaseRefs()
+        isLive = false
+    }
+
+    /**
+     * Push entry point (called from `RecorderBinderProvider` on a binder thread when the daemon delivers).
+     * Holds the binder + cblk and starts the drain + encode into the pending target's output fd.
+     */
+    fun onReceived(binder: IBinder?, cblkFd: ParcelFileDescriptor?, frameCount: Int, sampleRate: Int, channels: Int) {
+        val target = pending
+        if (target == null) {
+            AppLogger.w(T, "onReceived with no pending target — ignoring handoff")
+            runCatching { cblkFd?.close() }
+            return
+        }
+        // Idempotency: a spurious/duplicate delivery must NOT spin up a second drain+encode against the
+        // same output fd (dual-writer corruption). Only the first delivery for this session captures.
+        if (isLive) {
+            AppLogger.w(T, "onReceived while already capturing — ignoring duplicate handoff")
+            runCatching { cblkFd?.close() }
+            return
+        }
+        // Lazily load libaudiohandoff.so on the app side the first time a handoff actually arrives (the
+        // native drain + ashmem-size calls need it). Idempotent.
+        if (!AudioHandoffNative.ensureLoaded()) {
+            AppLogger.e(T, "libaudiohandoff.so not available — cannot capture handoff")
+            runCatching { cblkFd?.close() }
+            return
+        }
+        val cblkFdNum = cblkFd?.fd ?: -1
+        val ping = runCatching { binder?.pingBinder() }.getOrNull()
+        AppLogger.i(T, "handoff received ping(alive)=$ping cblkFd=$cblkFdNum frameCount=$frameCount rate=$sampleRate ch=$channels")
+
+        // Validate the geometry BEFORE any native mmap/drain. The trusted daemon always sends valid
+        // values; this rejects a malicious or corrupt payload that could drive an out-of-bounds native
+        // read (frameCount/channels/cblk size are otherwise fed straight into pointer arithmetic).
+        if (cblkFdNum < 0) { AppLogger.w(T, "handoff missing cblk fd — cannot capture"); runCatching { cblkFd?.close() }; return }
+        val geometry = HandoffGeometry.of(
+            frameCount = frameCount,
+            sampleRate = sampleRate,
+            channels = channels,
+            cblkSize = AudioHandoffNative.nativeAshmemSize(cblkFdNum),
+        )
+        geometry.validationError()?.let { reason ->
+            AppLogger.w(T, "handoff rejected: $reason")
+            runCatching { cblkFd?.close() }
+            return
+        }
+
+        // Validated — hold the refs (app keep-alive) and start the drain + encode into the target fd.
+        held = binder
+        cblk = cblkFd
+        startCapture(target, cblkFdNum, geometry)
+    }
+
+    /** Ends the capture: flips the stop flag, waits for the encoder to finalise the container, releases refs. */
+    fun stop() {
+        AppLogger.i(T, "stop requested")
+        stopFlag?.putInt(0, 1) // drain exits within one poll cycle → closes writeFd → encoder hits EOF
+        val enc = encodeThread
+        runCatching { enc?.join(ENCODE_JOIN_MS) }
+        if (enc?.isAlive == true) {
+            // The encoder didn't finish flushing/finalising the container in time. The caller is about to
+            // close the output fd, so log it — a truncated recording is then diagnosable rather than
+            // silently mis-attributed. (Expected only under severe load; normal finalise is sub-second.)
+            AppLogger.e(T, "handoff encoder still running after ${ENCODE_JOIN_MS}ms — recording may be truncated")
+        }
+        releaseRefs()
+        isLive = false
+        pending = null
+    }
+
+    private fun releaseRefs() {
+        val had = held != null
+        held = null
+        runCatching { cblk?.close() }
+        cblk = null
+        stopFlag = null
+        encodeThread = null
+        if (had) forceReleaseCaptureInput()
+    }
+
+    /**
+     * Drops the handed-off capture for real.
+     *
+     * The `IAudioRecord` is kept alive purely by THIS process's binder REFCOUNT — that is precisely what
+     * makes the capture survive the daemon's death. Nulling [held] is therefore NOT enough: the native
+     * ref is only released when the `BinderProxy` is finalized, so without a collection the RecordTrack
+     * stays alive and keeps the (exclusive) VOICE_CALL input open — silently starving the NEXT recording,
+     * which then produces an empty file.
+     *
+     * In the normal flow the daemon's `stopHandoff` stops its own track and frees the input; but when the
+     * daemon has DIED — the case this whole feature exists for — nothing else can release it. So force a
+     * collection here, off the caller's thread (this runs once per recording, at call end).
+     */
+    private fun forceReleaseCaptureInput() {
+        Thread {
+            runCatching {
+                System.gc()
+                System.runFinalization()
+                System.gc() // second pass: finalizer-enqueued proxies are reclaimed on the following cycle
+            }
+            AppLogger.i(T, "handoff capture input released (forced collection of the IAudioRecord ref)")
+        }.apply { isDaemon = true; name = "cv-handoff-release" }.start()
+    }
+
+    /**
+     * Wires the native cblk drain to [HandoffEncoder] through a pipe: native writes ordered interleaved
+     * PCM to the pipe (its write end is detached to native ownership, close()=EOF), the encoder reads the
+     * pipe, downmixes if asked, and muxes into [Target.outputFd]. The output fd is NOT closed here — the
+     * engine owns its lifecycle and closes it after [stop] (once the container trailer is written).
+     */
+    private fun startCapture(target: Target, cblkFdNum: Int, geometry: HandoffGeometry) {
+        val flag = ByteBuffer.allocateDirect(4).order(ByteOrder.nativeOrder())
+        stopFlag = flag
+        val pipe = ParcelFileDescriptor.createPipe() // [0]=read, [1]=write
+        val readPfd = pipe[0]
+        val writeFd = pipe[1].detachFd()             // ownership → native (it close()s = EOF)
+        AppLogger.i(T, "handoff capture → SAF fd (pipe writeFd=$writeFd frameSize=${geometry.frameSize} rate=${geometry.sampleRate} ch=${geometry.channels})")
+
+        val encoder = Thread {
+            runCatching {
+                HandoffEncoder(
+                    pcmIn = ParcelFileDescriptor.AutoCloseInputStream(readPfd),
+                    outFd = target.outputFd,
+                    sampleRate = geometry.sampleRate,
+                    captureChannels = geometry.channels,
+                    downmixToMono = target.downmixToMono,
+                    mime = target.mime,
+                    muxerFormat = target.muxerFormat,
+                    bitRate = target.bitRate,
+                ).encodeBlocking()
+                AppLogger.i(T, "handoff encode DONE")
+            }.onFailure { AppLogger.w(T, "handoff encode error: ${it.message}") }
+        }.apply { isDaemon = true; name = "cv-handoff-encode" }
+        encodeThread = encoder
+        encoder.start()
+
+        Thread {
+            runCatching {
+                AudioHandoffNative.nativeDrainToPipe(
+                    cblkFdNum, geometry.cblkSize, geometry.frameCount, HandoffGeometry.DATA_OFF,
+                    geometry.frameSize, HandoffGeometry.GUARD_FRAMES, writeFd, flag, MAX_SECONDS,
+                )
+            }.onFailure { AppLogger.w(T, "handoff drain error: ${it.message}") }
+        }.apply { isDaemon = true; name = "cv-handoff-drain" }.start()
+
+        isLive = true
+    }
+}

--- a/app/src/main/java/com/baba/callvault/services/recording/handoff/HandoffSource.kt
+++ b/app/src/main/java/com/baba/callvault/services/recording/handoff/HandoffSource.kt
@@ -1,0 +1,127 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording.handoff
+
+import android.media.AudioFormat
+import android.media.AudioRecord
+import com.baba.callvault.integrations.scrcpy.androidAudioSourceForKey
+import com.baba.callvault.server.BinderDelivery
+import com.baba.callvault.utils.AppLogger
+
+/**
+ * DAEMON-side half of "Resilient recording": creates the privileged capture and hands it to the app.
+ *
+ * Only the shell-uid daemon can open `VOICE_CALL`, so the `AudioRecord` must be created here. What it
+ * hands over is the capture ITSELF, not the audio: the native `IAudioRecord` binder (whose refcount is
+ * what keeps the track alive) plus the control-block ashmem fd holding the ring buffer. Once the app
+ * holds its own ref to that binder, killing this daemon does not stop the capture — the app keeps
+ * draining the ring and encoding locally. That is the entire point of the feature.
+ *
+ * Counterpart: [HandoffReceiver] in the app process.
+ */
+object HandoffSource {
+    private const val T = "CV:HandoffSource"
+
+    private const val DEFAULT_SAMPLE_RATE = 48_000
+
+    /**
+     * Ring size multiplier over the minimum buffer, matching `DirectAudioRecorderSession`. We advance
+     * `mFront` manually without the ClientProxy's futex wake, so a ring small enough to fill makes the
+     * server stall → periodic micro-gaps (choppy audio). A large ring never fills under our drain.
+     */
+    private const val BUFFER_FACTOR = 4
+
+    /**
+     * The daemon's own reference to the delivered track. Held so the native track cannot be torn down
+     * between creation and the app taking its own ref; released by [releaseHeld] at call end.
+     */
+    @Volatile private var heldRecord: AudioRecord? = null
+
+    /**
+     * Creates the privileged capture for [sourceCliKey] and delivers the `IAudioRecord` binder + cblk fd
+     * to the app's provider at [authority]. Returns true once the app has been handed the capture.
+     *
+     * For voice-call we try STEREO first — that reliably yields BOTH directions (uplink on one channel,
+     * the remote party's downlink on the other) — and fall back to mono. The ACTUAL channel count and
+     * frame count are part of the delivery, so the receiver adapts to whatever the device gave us.
+     */
+    fun deliverToApp(authority: String, sourceCliKey: String, sampleRate: Int, preferredChannels: Int): Boolean = runCatching {
+        val rate = if (sampleRate > 0) sampleRate else DEFAULT_SAMPLE_RATE
+        val source = androidAudioSourceForKey(sourceCliKey)
+            ?: run { AppLogger.w(T, "deliver: source '$sourceCliKey' has no direct AudioSource"); return@runCatching false }
+
+        var ar: AudioRecord? = null
+        var channelCount = 1
+        var minBuffer = 0
+        val masks = if (preferredChannels >= 2)
+            intArrayOf(AudioFormat.CHANNEL_IN_STEREO, AudioFormat.CHANNEL_IN_MONO)
+        else intArrayOf(AudioFormat.CHANNEL_IN_MONO)
+        for (mask in masks) {
+            val ch = if (mask == AudioFormat.CHANNEL_IN_STEREO) 2 else 1
+            val mb = AudioRecord.getMinBufferSize(rate, mask, AudioFormat.ENCODING_PCM_16BIT)
+            if (mb <= 0) continue
+            @Suppress("MissingPermission")
+            val rec = runCatching {
+                AudioRecord(source, rate, mask, AudioFormat.ENCODING_PCM_16BIT, mb * BUFFER_FACTOR)
+            }.getOrNull()
+            if (rec != null && rec.state == AudioRecord.STATE_INITIALIZED) {
+                ar = rec; channelCount = ch; minBuffer = mb; break
+            }
+            runCatching { rec?.release() }
+        }
+        val record = ar ?: run {
+            AppLogger.w(T, "deliver: $sourceCliKey AudioRecord not initialized (stereo or mono)")
+            return@runCatching false
+        }
+        AppLogger.i(T, "deliver: handoff source=$sourceCliKey capture channels=$channelCount rate=$rate")
+        record.startRecording()
+        heldRecord = record
+
+        // The native android::AudioRecord* lives in an obfuscation-proof-but-unnamed long field; pick the
+        // one that actually points at a native AudioRecord rather than trusting a field name.
+        val arPtr = record.javaClass.declaredFields
+            .filter { it.type == java.lang.Long.TYPE }
+            .mapNotNull { f -> f.isAccessible = true; runCatching { f.getLong(record) }.getOrNull() }
+            .firstOrNull { it != 0L && AudioHandoffNative.nativeValidateArPtr(it) }
+        if (arPtr == null) { AppLogger.w(T, "deliver: no native AudioRecord ptr"); return@runCatching false }
+
+        val binder = AudioHandoffNative.nativeExtractBinder(arPtr)
+            ?: run { AppLogger.w(T, "deliver: extractBinder null"); return@runCatching false }
+
+        // Authoritative ring frame count straight from the AudioRecord: the app-side drain wraps on it,
+        // and it also IDENTIFIES the cblk ashmem region (whose byte size varies with the sample rate).
+        val frameCount = runCatching { record.bufferSizeInFrames }.getOrDefault(0)
+        AppLogger.i(T, "deliver: bufferSizeInFrames=$frameCount rate=$rate ch=$channelCount (minBuf=$minBuffer bytes)")
+
+        val cblkPfd = runCatching {
+            val fd = AudioHandoffNative.nativeFindCblkFd(frameCount)
+            if (fd >= 0) android.os.ParcelFileDescriptor.adoptFd(fd) else null
+        }.getOrNull()
+        AppLogger.i(T, "deliver: extracted IAudioRecord ping=${runCatching { binder.pingBinder() }.getOrNull()} cblkFd=${cblkPfd?.fd} — delivering to app")
+
+        val ok = BinderDelivery.deliverHandoffToApp(binder, authority, cblkPfd, frameCount, rate, channelCount)
+        AppLogger.i(T, "deliver: BinderDelivery.deliverHandoffToApp ok=$ok")
+        ok
+    }.onFailure { AppLogger.e(T, "deliverToApp failed: ${it.message}", it) }.getOrDefault(false)
+
+    /**
+     * Releases the daemon's own reference to the handed-off track. The app owns the capture after a
+     * successful handoff, so this only frees the daemon's now-redundant hold. Idempotent.
+     */
+    fun releaseHeld() {
+        val rec = heldRecord ?: return
+        heldRecord = null
+        runCatching { rec.stop() }
+        runCatching { rec.release() }
+        AppLogger.i(T, "releaseHeld: daemon handoff AudioRecord released")
+    }
+
+    /** Whether [cliKey] can be captured via a direct handoff AudioRecord (else use the daemon path). */
+    fun supportsHandoff(cliKey: String): Boolean = androidAudioSourceForKey(cliKey) != null
+}

--- a/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/HomeScreen.kt
@@ -92,6 +92,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.baba.callvault.R
+import com.baba.callvault.data.AppPreferences
 import com.baba.callvault.data.recordings.RecordingDirection
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingItem
 import com.baba.callvault.data.recordings.RecordingsRepository.RecordingSource
@@ -165,15 +166,18 @@ fun HomeScreen(
             }
         }
     ) { innerPadding ->
-        if (uiState.showWhatsNew) {
-            WhatsNewDialog(
-                onDismiss = {
-                    // Persist "seen" so the one-time off-Wi-Fi intro never reappears on later updates,
-                    // and clear the small "updated" banner too.
-                    viewModel.markWhatsNewSeen()
-                    viewModel.dismissUpdatedBanner()
-                },
-            )
+        uiState.whatsNew?.let { note ->
+            // Persist "seen" so this one-time feature intro never reappears on later updates, and clear
+            // the small "updated" banner too.
+            val dismiss = {
+                viewModel.markWhatsNewSeen(note)
+                viewModel.dismissUpdatedBanner()
+            }
+            when (note) {
+                HomeViewModel.WhatsNewNote.OFF_WIFI -> WhatsNewDialog(onDismiss = dismiss)
+                HomeViewModel.WhatsNewNote.RESILIENT_RECORDING ->
+                    ResilientRecordingWhatsNewDialog(onDismiss = dismiss)
+            }
         }
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -317,6 +321,45 @@ private fun WhatsNewDialog(onDismiss: () -> Unit) {
             onClose = { showOfflineDialog = false },
         )
     }
+}
+
+/**
+ * Post-update "What's new" note introducing **Resilient recording**, with a one-tap opt-in.
+ *
+ * The feature is off by default and lives in Settings ▸ Reliability, so without this note almost
+ * nobody would find it. Enabling is a plain preference write with no side effects (unlike off-Wi-Fi,
+ * which opens a port and needs a security warning), so the CTA turns it on directly and then just
+ * confirms in place.
+ */
+@Composable
+private fun ResilientRecordingWhatsNewDialog(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val prefs = remember { AppPreferences(context) }
+    var enabled by remember { mutableStateOf(prefs.isHandoffPersistEnabled()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.home_whatsnew_resilient_title)) },
+        text = {
+            Text(
+                if (enabled) stringResource(R.string.home_whatsnew_resilient_enabled)
+                else stringResource(R.string.home_whatsnew_resilient_body)
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.general_ok)) }
+        },
+        dismissButton = {
+            if (!enabled) {
+                TextButton(onClick = {
+                    prefs.setHandoffPersistEnabled(true)
+                    enabled = true
+                }) {
+                    Text(stringResource(R.string.home_whatsnew_resilient_cta))
+                }
+            }
+        },
+    )
 }
 
 /**

--- a/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/baba/callvault/ui/screens/SettingsScreen.kt
@@ -98,6 +98,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Gavel
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.WifiOff
 import com.baba.callvault.ui.common.OfflineDialogMode
@@ -1015,7 +1016,34 @@ private fun ReliabilitySection(expanded: Boolean, onToggle: () -> Unit) {
         OfflineRecordingToggle()
         SettingsDivider()
         UsbDefaultConfigRow()
+        SettingsDivider()
+        HandoffPersistToggle()
     }
+}
+
+/**
+ * Opt-in "Resilient recording" toggle (audio-capture handoff, Option B). Default OFF — the recording
+ * path is byte-identical to daemon mode. When ON (and the source is handoff-compatible) the daemon hands
+ * its live capture to the always-alive app, so a recording keeps going and finalises even if the
+ * background helper (daemon) is killed mid-call (e.g. screen-lock restarts adbd). A plain preference with
+ * no arming side effects, so — unlike the offline toggle — it writes straight from the switch.
+ */
+@Composable
+private fun HandoffPersistToggle() {
+    val context = LocalContext.current
+    val prefs = remember { AppPreferences(context) }
+    var enabled by remember { mutableStateOf(prefs.isHandoffPersistEnabled()) }
+
+    SettingsToggleRow(
+        icon = Icons.Filled.Shield,
+        label = stringResource(R.string.settings_handoff_persist_label),
+        description = stringResource(R.string.settings_handoff_persist_description),
+        checked = enabled,
+        onCheckedChange = { turnOn ->
+            enabled = turnOn
+            prefs.setHandoffPersistEnabled(turnOn)
+        },
+    )
 }
 
 /**

--- a/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/baba/callvault/ui/viewmodels/HomeViewModel.kt
@@ -97,6 +97,14 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     enum class DirectionFilter { ALL, INCOMING, OUTGOING }
 
     /**
+     * A one-time, post-update introduction to a feature the user may not know exists.
+     *
+     * Deliberately per-feature rather than per-release: these features are opt-in and easy to miss in
+     * Settings, so the note exists to surface them once — not to narrate every release.
+     */
+    enum class WhatsNewNote { OFF_WIFI, RESILIENT_RECORDING }
+
+    /**
      * Aggregate UI state for Home.
      *
      * Four independent filter facets — [sourceFilter], [directionFilter], [contactFilter] and
@@ -127,8 +135,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         val updateProgressPercent: Int = -1,
         /** Version name to show a dismissable "updated successfully" banner for, or null. */
         val updatedToVersion: String? = null,
-        /** Whether to show the one-time "What's new: off-Wi-Fi" intro modal (updated AND not seen yet). */
-        val showWhatsNew: Boolean = false,
+        /** The one-time feature-intro note to show after an update, or null when there is none due. */
+        val whatsNew: WhatsNewNote? = null,
         /** True when the USB default is a data mode → locking the screen mid-call can stop recording. */
         val usbScreenLockRisk: Boolean = false,
         /** True while the one-tap "set USB to Charging only" fix is running. */
@@ -294,13 +302,26 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
-     * Marks the one-time "What's new: off-Wi-Fi" intro modal as seen so it never reappears on later
-     * updates. Persists the flag; the small "updated successfully" banner is dismissed separately.
+     * Marks [note] as seen so it never reappears on later updates. Persists the flag; the small
+     * "updated successfully" banner is dismissed separately.
+     *
+     * Another note may still be due (a user who skipped a release can have more than one unseen), so
+     * this re-selects rather than simply clearing.
      */
-    fun markWhatsNewSeen() {
-        preferences.setSeenOffWifiWhatsNew(true)
-        _uiState.update { it.copy(showWhatsNew = false) }
+    fun markWhatsNewSeen(note: WhatsNewNote) {
+        when (note) {
+            WhatsNewNote.OFF_WIFI -> preferences.setSeenOffWifiWhatsNew(true)
+            WhatsNewNote.RESILIENT_RECORDING -> preferences.setSeenResilientWhatsNew(true)
+        }
+        _uiState.update { it.copy(whatsNew = pendingWhatsNew(it.updatedToVersion)) }
     }
+
+    /** The feature-intro note due after an update, or null when none is pending. */
+    private fun pendingWhatsNew(updatedToVersion: String?): WhatsNewNote? = selectWhatsNew(
+        justUpdated = updatedToVersion != null,
+        seenResilient = preferences.hasSeenResilientWhatsNew(),
+        seenOffWifi = preferences.hasSeenOffWifiWhatsNew(),
+    )
 
     /**
      * Recomputes the [HomeStatus] (synchronous, cheap) and reloads the recordings list off the main
@@ -315,9 +336,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                 isLoading = true,
                 availableUpdateTag = preferences.getAvailableUpdateTag(),
                 updatedToVersion = updatedTo,
-                // The off-Wi-Fi "What's new" is a ONE-TIME feature intro: show it only after an update
-                // AND only until it's been seen once, so it never recurs on every later release.
-                showWhatsNew = updatedTo != null && !preferences.hasSeenOffWifiWhatsNew(),
+                // ONE-TIME feature intros: shown only after an update, and only until each has been
+                // seen once, so they never recur on every later release.
+                whatsNew = pendingWhatsNew(updatedTo),
                 // Advisory when the USB default is a data mode (cheap cached read; never blocks/forces ADB).
                 usbScreenLockRisk = UsbDefaultConfig.isScreenLockRisk(appContext)
             )
@@ -503,5 +524,25 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         preferences.unregisterChangeListener(prefsListener)
         playbackController.release()
         super.onCleared()
+    }
+
+    companion object {
+        /**
+         * Picks the feature-intro note to show, newest feature first, or null when none is due.
+         *
+         * Notes appear only right after an update, and each feature has its OWN seen-flag rather than
+         * a single "last version seen". That way someone who skips several releases still meets every
+         * feature they missed — one per update — instead of only the most recent one.
+         */
+        fun selectWhatsNew(
+            justUpdated: Boolean,
+            seenResilient: Boolean,
+            seenOffWifi: Boolean,
+        ): WhatsNewNote? = when {
+            !justUpdated -> null
+            !seenResilient -> WhatsNewNote.RESILIENT_RECORDING
+            !seenOffWifi -> WhatsNewNote.OFF_WIFI
+            else -> null
+        }
     }
 }

--- a/app/src/main/java/com/baba/callvault/utils/PcmDownmix.kt
+++ b/app/src/main/java/com/baba/callvault/utils/PcmDownmix.kt
@@ -1,0 +1,42 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.utils
+
+/** PCM-16 helpers shared by both capture pipelines (the daemon's direct recorder and the handoff). */
+object PcmDownmix {
+
+    /**
+     * Downmixes interleaved stereo PCM-16 (little-endian) into mono by AVERAGING each L/R pair, writing
+     * to [dst] and returning the number of mono bytes written (= [srcLen] / 2, rounded down to a whole
+     * frame).
+     *
+     * A stereo call capture carries the two directions on separate channels (uplink on one, the remote
+     * party's downlink on the other). Averaging rather than summing is deliberate: it can never clip,
+     * and double-talk — both parties speaking at once — is common enough on real calls that summing
+     * would hard-clip constantly. The cost is ~6 dB against a single full-scale voice, but both voices
+     * stay intelligible through the overlap.
+     *
+     * A trailing partial frame in [src] is left unconsumed; callers read whole frames so this only
+     * guards against a truncated final chunk.
+     */
+    fun stereoToMono(src: ByteArray, srcLen: Int, dst: ByteArray): Int {
+        var di = 0
+        var si = 0
+        while (si + 3 < srcLen) {
+            val l = (src[si].toInt() and 0xFF or (src[si + 1].toInt() shl 8)).toShort().toInt()
+            val r = (src[si + 2].toInt() and 0xFF or (src[si + 3].toInt() shl 8)).toShort().toInt()
+            val m = (l + r) / 2
+            dst[di] = (m and 0xFF).toByte()
+            dst[di + 1] = ((m shr 8) and 0xFF).toByte()
+            di += 2
+            si += 4
+        }
+        return di
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -165,6 +165,8 @@
     <string name="folder_cloud_warning">⚠ Dieser Aufnahmeordner liegt in der Cloud, was für die Aufnahme unzuverlässig ist. Wählen Sie einen Ordner auf dem Gerät.</string>
     <string name="settings_offline_recording_label">Offline-Aufnahme (ohne Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Anrufe auch dann aufnehmen, wenn kein Wi-Fi-Netzwerk verfügbar ist.</string>
+    <string name="settings_handoff_persist_label">Robuste Aufnahme</string>
+    <string name="settings_handoff_persist_description">Aufnahme fortsetzen, selbst wenn der Hintergrunddienst während des Anrufs beendet wird (z. B. beim Sperren des Bildschirms). Experimentell.</string>
     <string name="settings_usb_default_label">USB beim Entsperren</string>
     <string name="settings_usb_default_hint">„Nur Laden“ hält die Aufnahme am Leben, wenn du während eines Anrufs den Bildschirm sperrst. Andere Modi erlauben Datenübertragung per USB, können aber eine Aufnahme beim Sperren unterbrechen.</string>
     <string name="settings_usb_default_applying">Wird angewendet…</string>

--- a/app/src/main/res/values-de/strings_home.xml
+++ b/app/src/main/res/values-de/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">USB ist auf einen Datenmodus eingestellt. Tippe, um „Nur Laden“ zu wählen.</string>
     <string name="home_usb_advisory_fix">Beheben</string>
     <string name="home_whatsnew_resilient_title">Neu: Robuste Aufnahme</string>
-    <string name="home_whatsnew_resilient_body">Sobald eine Aufnahme begonnen hat, wird sie jetzt auch beendet — selbst wenn Android CallVaults Hintergrunddienst mittendrin stoppt, was die Aufnahme bisher abgeschnitten hat.\n\nStandardmäßig ausgeschaltet. Du kannst sie auch später unter Einstellungen ▸ Zuverlässigkeit aktivieren.</string>
+    <string name="home_whatsnew_resilient_body">Macht die Anrufaufnahme widerstandsfähiger gegen Unterbrechungen.\n\nAndroid kann CallVaults Hintergrunddienst jederzeit stoppen. Wenn dies aktiviert ist, bleibt eine bereits laufende Aufnahme davon unberührt.\n\nStandardmäßig ausgeschaltet — du kannst sie auch später unter Einstellungen ▸ Zuverlässigkeit aktivieren.</string>
     <string name="home_whatsnew_resilient_cta">Aktivieren</string>
-    <string name="home_whatsnew_resilient_enabled">Robuste Aufnahme ist aktiv. Deine Anrufe werden jetzt bis zum Ende aufgenommen, auch wenn der Hintergrunddienst zwischendurch gestoppt wird.</string>
+    <string name="home_whatsnew_resilient_enabled">Robuste Aufnahme ist aktiv. Eine bereits laufende Aufnahme bleibt unberührt, wenn Android CallVaults Hintergrunddienst stoppt.</string>
 </resources>

--- a/app/src/main/res/values-de/strings_home.xml
+++ b/app/src/main/res/values-de/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">Aufnahme kann bei Sperrbildschirm stoppen</string>
     <string name="home_usb_advisory_text">USB ist auf einen Datenmodus eingestellt. Tippe, um „Nur Laden“ zu wählen.</string>
     <string name="home_usb_advisory_fix">Beheben</string>
+    <string name="home_whatsnew_resilient_title">Neu: Robuste Aufnahme</string>
+    <string name="home_whatsnew_resilient_body">Sobald eine Aufnahme begonnen hat, wird sie jetzt auch beendet — selbst wenn Android CallVaults Hintergrunddienst mittendrin stoppt, was die Aufnahme bisher abgeschnitten hat.\n\nStandardmäßig ausgeschaltet. Du kannst sie auch später unter Einstellungen ▸ Zuverlässigkeit aktivieren.</string>
+    <string name="home_whatsnew_resilient_cta">Aktivieren</string>
+    <string name="home_whatsnew_resilient_enabled">Robuste Aufnahme ist aktiv. Deine Anrufe werden jetzt bis zum Ende aufgenommen, auch wenn der Hintergrunddienst zwischendurch gestoppt wird.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -165,6 +165,8 @@
     <string name="folder_cloud_warning">⚠ Esta carpeta de grabación está en la nube, lo que no es fiable para la captura. Elige una carpeta en el dispositivo.</string>
     <string name="settings_offline_recording_label">Grabación sin conexión (sin Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Graba llamadas incluso cuando no hay red Wi-Fi.</string>
+    <string name="settings_handoff_persist_label">Grabación resistente</string>
+    <string name="settings_handoff_persist_description">Mantiene la grabación en curso aunque el proceso auxiliar en segundo plano se cierre durante la llamada (p. ej. al bloquear la pantalla). Experimental.</string>
     <string name="settings_usb_default_label">USB al desbloquear</string>
     <string name="settings_usb_default_hint">"Solo carga" mantiene la grabación activa si bloqueas la pantalla durante una llamada. Los otros modos permiten transferir datos por USB, pero pueden interrumpir una grabación al bloquear el teléfono.</string>
     <string name="settings_usb_default_applying">Aplicando…</string>

--- a/app/src/main/res/values-es/strings_home.xml
+++ b/app/src/main/res/values-es/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">La grabación puede detenerse al bloquear</string>
     <string name="home_usb_advisory_text">USB está en un modo de datos. Toca para ponerlo en Solo carga.</string>
     <string name="home_usb_advisory_fix">Corregir</string>
+    <string name="home_whatsnew_resilient_title">Novedad: Grabación resistente</string>
+    <string name="home_whatsnew_resilient_body">Una vez que una llamada empieza a grabarse, ahora termina — incluso si Android detiene a mitad el proceso en segundo plano de CallVault, lo que antes cortaba la grabación.\n\nEstá desactivada por defecto. También puedes activarla más tarde en Ajustes ▸ Fiabilidad.</string>
+    <string name="home_whatsnew_resilient_cta">Activar</string>
+    <string name="home_whatsnew_resilient_enabled">La grabación resistente está activada. Tus llamadas se grabarán hasta el final, aunque el proceso en segundo plano se detenga a mitad.</string>
 </resources>

--- a/app/src/main/res/values-es/strings_home.xml
+++ b/app/src/main/res/values-es/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">USB está en un modo de datos. Toca para ponerlo en Solo carga.</string>
     <string name="home_usb_advisory_fix">Corregir</string>
     <string name="home_whatsnew_resilient_title">Novedad: Grabación resistente</string>
-    <string name="home_whatsnew_resilient_body">Una vez que una llamada empieza a grabarse, ahora termina — incluso si Android detiene a mitad el proceso en segundo plano de CallVault, lo que antes cortaba la grabación.\n\nEstá desactivada por defecto. También puedes activarla más tarde en Ajustes ▸ Fiabilidad.</string>
+    <string name="home_whatsnew_resilient_body">Hace que la grabación de llamadas sea más resistente a las interrupciones.\n\nAndroid puede detener el proceso en segundo plano de CallVault en cualquier momento. Con esto activado, una grabación ya en curso no se ve afectada cuando eso ocurre.\n\nDesactivado por defecto: también puedes activarlo más tarde en Ajustes ▸ Fiabilidad.</string>
     <string name="home_whatsnew_resilient_cta">Activar</string>
-    <string name="home_whatsnew_resilient_enabled">La grabación resistente está activada. Tus llamadas se grabarán hasta el final, aunque el proceso en segundo plano se detenga a mitad.</string>
+    <string name="home_whatsnew_resilient_enabled">La grabación resistente está activada. Una grabación ya en curso no se ve afectada si Android detiene el proceso en segundo plano de CallVault.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -170,6 +170,8 @@
     <string name="folder_cloud_warning">⚠ Ce dossier d\'enregistrement se trouve dans le cloud, ce qui n\'est pas fiable pour la capture. Choisissez un dossier sur l\'appareil.</string>
     <string name="settings_offline_recording_label">Enregistrement hors ligne (sans Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Enregistrer les appels même en l\'absence de réseau Wi-Fi.</string>
+    <string name="settings_handoff_persist_label">Enregistrement résilient</string>
+    <string name="settings_handoff_persist_description">Poursuit l\'enregistrement même si le service d\'arrière-plan est arrêté pendant l\'appel (par ex. lorsque vous verrouillez l\'écran). Expérimental.</string>
     <string name="settings_usb_default_label">USB au déverrouillage</string>
     <string name="settings_usb_default_hint">« Charge uniquement » maintient l\'enregistrement actif si tu verrouilles l\'écran pendant un appel. Les autres modes permettent le transfert de données en USB mais peuvent interrompre un enregistrement au verrouillage.</string>
     <string name="settings_usb_default_applying">Application…</string>

--- a/app/src/main/res/values-fr/strings_home.xml
+++ b/app/src/main/res/values-fr/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">L\'enregistrement peut s\'arrêter au verrouillage</string>
     <string name="home_usb_advisory_text">L\'USB est en mode données. Appuie pour choisir Charge uniquement.</string>
     <string name="home_usb_advisory_fix">Corriger</string>
+    <string name="home_whatsnew_resilient_title">Nouveau : enregistrement résilient</string>
+    <string name="home_whatsnew_resilient_body">Une fois qu\'un appel commence à être enregistré, il va désormais jusqu\'au bout — même si Android arrête en cours de route le service d\'arrière-plan de CallVault, ce qui coupait l\'enregistrement auparavant.\n\nDésactivé par défaut. Vous pouvez aussi l\'activer plus tard dans Paramètres ▸ Fiabilité.</string>
+    <string name="home_whatsnew_resilient_cta">Activer</string>
+    <string name="home_whatsnew_resilient_enabled">L\'enregistrement résilient est activé. Vos appels seront enregistrés jusqu\'au bout, même si le service d\'arrière-plan est arrêté en cours de route.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_home.xml
+++ b/app/src/main/res/values-fr/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">L\'USB est en mode données. Appuie pour choisir Charge uniquement.</string>
     <string name="home_usb_advisory_fix">Corriger</string>
     <string name="home_whatsnew_resilient_title">Nouveau : enregistrement résilient</string>
-    <string name="home_whatsnew_resilient_body">Une fois qu\'un appel commence à être enregistré, il va désormais jusqu\'au bout — même si Android arrête en cours de route le service d\'arrière-plan de CallVault, ce qui coupait l\'enregistrement auparavant.\n\nDésactivé par défaut. Vous pouvez aussi l\'activer plus tard dans Paramètres ▸ Fiabilité.</string>
+    <string name="home_whatsnew_resilient_body">Rend l\'enregistrement des appels plus résistant aux interruptions.\n\nAndroid peut arrêter le service d\'arrière-plan de CallVault à tout moment. Avec cette option activée, un enregistrement déjà en cours n\'en est plus affecté.\n\nDésactivé par défaut — vous pouvez aussi l\'activer plus tard dans Paramètres ▸ Fiabilité.</string>
     <string name="home_whatsnew_resilient_cta">Activer</string>
-    <string name="home_whatsnew_resilient_enabled">L\'enregistrement résilient est activé. Vos appels seront enregistrés jusqu\'au bout, même si le service d\'arrière-plan est arrêté en cours de route.</string>
+    <string name="home_whatsnew_resilient_enabled">L\'enregistrement résilient est activé. Un enregistrement déjà en cours n\'est plus affecté si Android arrête le service d\'arrière-plan de CallVault.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -165,6 +165,8 @@
     <string name="folder_cloud_warning">⚠ Ez a rögzítési mappa a felhőben van, ami megbízhatatlan a rögzítéshez. Válasszon egy eszközön lévő mappát.</string>
     <string name="settings_offline_recording_label">Offline rögzítés (Wi-Fi nélkül)</string>
     <string name="settings_offline_recording_desc">Hívások rögzítése akkor is, ha nincs Wi-Fi hálózat.</string>
+    <string name="settings_handoff_persist_label">Ellenálló rögzítés</string>
+    <string name="settings_handoff_persist_description">A rögzítés akkor is folytatódik, ha a háttérsegéd hívás közben leáll (pl. amikor lezárja a képernyőt). Kísérleti.</string>
     <string name="settings_usb_default_label">USB a képernyő feloldásakor</string>
     <string name="settings_usb_default_hint">A „Csak töltés“ életben tartja a rögzítést, ha hívás közben zárolod a képernyőt. A többi mód engedi az USB-adatátvitelt, de megszakíthatja a rögzítést a telefon zárolásakor.</string>
     <string name="settings_usb_default_applying">Alkalmazás…</string>

--- a/app/src/main/res/values-hu/strings_home.xml
+++ b/app/src/main/res/values-hu/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">Az USB adatmódban van. Koppints a Csak töltés beállításához.</string>
     <string name="home_usb_advisory_fix">Javítás</string>
     <string name="home_whatsnew_resilient_title">Új: Ellenálló rögzítés</string>
-    <string name="home_whatsnew_resilient_body">Ha egy hívás rögzítése elindult, mostantól be is fejeződik — akkor is, ha az Android menet közben leállítja a CallVault háttérfolyamatát, ami korábban félbevágta a felvételt.\n\nAlapértelmezés szerint ki van kapcsolva. Később is bekapcsolhatod: Beállítások ▸ Megbízhatóság.</string>
+    <string name="home_whatsnew_resilient_body">Ellenállóbbá teszi a hívásrögzítést a megszakításokkal szemben.\n\nAz Android bármikor leállíthatja a CallVault háttérfolyamatát. Ha ez be van kapcsolva, a már folyamatban lévő felvételt ez többé nem érinti.\n\nAlapértelmezés szerint kikapcsolva — később is bekapcsolhatod: Beállítások ▸ Megbízhatóság.</string>
     <string name="home_whatsnew_resilient_cta">Bekapcsolom</string>
-    <string name="home_whatsnew_resilient_enabled">Az ellenálló rögzítés be van kapcsolva. A hívásaid mostantól végig rögzülnek, akkor is, ha a háttérfolyamat menet közben leáll.</string>
+    <string name="home_whatsnew_resilient_enabled">Az ellenálló rögzítés be van kapcsolva. A már folyamatban lévő felvételt nem érinti, ha az Android leállítja a CallVault háttérfolyamatát.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings_home.xml
+++ b/app/src/main/res/values-hu/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">A rögzítés leállhat a képernyő zárolásakor</string>
     <string name="home_usb_advisory_text">Az USB adatmódban van. Koppints a Csak töltés beállításához.</string>
     <string name="home_usb_advisory_fix">Javítás</string>
+    <string name="home_whatsnew_resilient_title">Új: Ellenálló rögzítés</string>
+    <string name="home_whatsnew_resilient_body">Ha egy hívás rögzítése elindult, mostantól be is fejeződik — akkor is, ha az Android menet közben leállítja a CallVault háttérfolyamatát, ami korábban félbevágta a felvételt.\n\nAlapértelmezés szerint ki van kapcsolva. Később is bekapcsolhatod: Beállítások ▸ Megbízhatóság.</string>
+    <string name="home_whatsnew_resilient_cta">Bekapcsolom</string>
+    <string name="home_whatsnew_resilient_enabled">Az ellenálló rögzítés be van kapcsolva. A hívásaid mostantól végig rögzülnek, akkor is, ha a háttérfolyamat menet közben leáll.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -165,6 +165,8 @@
     <string name="folder_cloud_warning">⚠ Questa cartella di registrazione si trova nel cloud, il che non è affidabile per l\'acquisizione. Scelga una cartella sul dispositivo.</string>
     <string name="settings_offline_recording_label">Registrazione offline (senza Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Registra le chiamate anche quando non è disponibile una rete Wi-Fi.</string>
+    <string name="settings_handoff_persist_label">Registrazione resiliente</string>
+    <string name="settings_handoff_persist_description">Mantiene attiva la registrazione anche se il processo in background viene chiuso durante la chiamata (ad es. quando blocchi lo schermo). Sperimentale.</string>
     <string name="settings_usb_default_label">USB allo sblocco</string>
     <string name="settings_usb_default_hint">"Solo ricarica" mantiene attiva la registrazione se blocchi lo schermo durante una chiamata. Le altre modalità consentono il trasferimento dati via USB ma possono interrompere una registrazione al blocco.</string>
     <string name="settings_usb_default_applying">Applicazione…</string>

--- a/app/src/main/res/values-it/strings_home.xml
+++ b/app/src/main/res/values-it/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">La registrazione può fermarsi al blocco</string>
     <string name="home_usb_advisory_text">L\'USB è in modalità dati. Tocca per impostare Solo ricarica.</string>
     <string name="home_usb_advisory_fix">Correggi</string>
+    <string name="home_whatsnew_resilient_title">Novità: registrazione resiliente</string>
+    <string name="home_whatsnew_resilient_body">Una volta che una chiamata inizia a essere registrata, ora arriva fino in fondo — anche se Android interrompe a metà il processo in background di CallVault, cosa che prima troncava la registrazione.\n\nÈ disattivata per impostazione predefinita. Puoi attivarla anche in seguito da Impostazioni ▸ Affidabilità.</string>
+    <string name="home_whatsnew_resilient_cta">Attiva</string>
+    <string name="home_whatsnew_resilient_enabled">La registrazione resiliente è attiva. Le tue chiamate verranno registrate fino alla fine, anche se il processo in background viene interrotto a metà.</string>
 </resources>

--- a/app/src/main/res/values-it/strings_home.xml
+++ b/app/src/main/res/values-it/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">L\'USB è in modalità dati. Tocca per impostare Solo ricarica.</string>
     <string name="home_usb_advisory_fix">Correggi</string>
     <string name="home_whatsnew_resilient_title">Novità: registrazione resiliente</string>
-    <string name="home_whatsnew_resilient_body">Una volta che una chiamata inizia a essere registrata, ora arriva fino in fondo — anche se Android interrompe a metà il processo in background di CallVault, cosa che prima troncava la registrazione.\n\nÈ disattivata per impostazione predefinita. Puoi attivarla anche in seguito da Impostazioni ▸ Affidabilità.</string>
+    <string name="home_whatsnew_resilient_body">Rende la registrazione delle chiamate più resistente alle interruzioni.\n\nAndroid può interrompere il processo in background di CallVault in qualsiasi momento. Con questa opzione attiva, una registrazione già in corso non ne risente più.\n\nDisattivata per impostazione predefinita — puoi attivarla anche in seguito da Impostazioni ▸ Affidabilità.</string>
     <string name="home_whatsnew_resilient_cta">Attiva</string>
-    <string name="home_whatsnew_resilient_enabled">La registrazione resiliente è attiva. Le tue chiamate verranno registrate fino alla fine, anche se il processo in background viene interrotto a metà.</string>
+    <string name="home_whatsnew_resilient_enabled">La registrazione resiliente è attiva. Una registrazione già in corso non risente dell\'interruzione del processo in background di CallVault da parte di Android.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -165,6 +165,8 @@
     <string name="folder_cloud_warning">⚠ Ten folder nagrań znajduje się w chmurze, co jest zawodne przy nagrywaniu. Wybierz folder na urządzeniu.</string>
     <string name="settings_offline_recording_label">Nagrywanie offline (bez Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Nagrywaj połączenia nawet wtedy, gdy nie ma sieci Wi-Fi.</string>
+    <string name="settings_handoff_persist_label">Odporne nagrywanie</string>
+    <string name="settings_handoff_persist_description">Kontynuuje nagrywanie nawet wtedy, gdy pomocniczy proces w tle zostanie zamknięty w trakcie połączenia (np. po zablokowaniu ekranu). Eksperymentalne.</string>
     <string name="settings_usb_default_label">USB po odblokowaniu</string>
     <string name="settings_usb_default_hint">„Tylko ładowanie“ utrzymuje nagrywanie, gdy zablokujesz ekran podczas rozmowy. Inne tryby pozwalają na przesyłanie danych przez USB, ale mogą przerwać nagrywanie po zablokowaniu telefonu.</string>
     <string name="settings_usb_default_applying">Stosowanie…</string>

--- a/app/src/main/res/values-pl/strings_home.xml
+++ b/app/src/main/res/values-pl/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">Nagrywanie może się zatrzymać po zablokowaniu</string>
     <string name="home_usb_advisory_text">USB jest w trybie danych. Dotknij, aby ustawić Tylko ładowanie.</string>
     <string name="home_usb_advisory_fix">Napraw</string>
+    <string name="home_whatsnew_resilient_title">Nowość: odporne nagrywanie</string>
+    <string name="home_whatsnew_resilient_body">Gdy nagrywanie rozmowy już się zacznie, teraz zostanie dokończone — nawet jeśli Android zatrzyma w trakcie proces działający w tle, co wcześniej ucinało nagranie.\n\nDomyślnie wyłączone. Możesz je włączyć również później w Ustawieniach ▸ Niezawodność.</string>
+    <string name="home_whatsnew_resilient_cta">Włącz</string>
+    <string name="home_whatsnew_resilient_enabled">Odporne nagrywanie jest włączone. Twoje rozmowy będą teraz nagrywane do końca, nawet jeśli proces w tle zostanie zatrzymany w trakcie.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_home.xml
+++ b/app/src/main/res/values-pl/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">USB jest w trybie danych. Dotknij, aby ustawić Tylko ładowanie.</string>
     <string name="home_usb_advisory_fix">Napraw</string>
     <string name="home_whatsnew_resilient_title">Nowość: odporne nagrywanie</string>
-    <string name="home_whatsnew_resilient_body">Gdy nagrywanie rozmowy już się zacznie, teraz zostanie dokończone — nawet jeśli Android zatrzyma w trakcie proces działający w tle, co wcześniej ucinało nagranie.\n\nDomyślnie wyłączone. Możesz je włączyć również później w Ustawieniach ▸ Niezawodność.</string>
+    <string name="home_whatsnew_resilient_body">Sprawia, że nagrywanie rozmów jest bardziej odporne na przerwania.\n\nAndroid może w każdej chwili zatrzymać proces CallVault działający w tle. Gdy ta opcja jest włączona, trwające już nagranie nie jest tym dotknięte.\n\nDomyślnie wyłączone — możesz je włączyć również później w Ustawieniach ▸ Niezawodność.</string>
     <string name="home_whatsnew_resilient_cta">Włącz</string>
-    <string name="home_whatsnew_resilient_enabled">Odporne nagrywanie jest włączone. Twoje rozmowy będą teraz nagrywane do końca, nawet jeśli proces w tle zostanie zatrzymany w trakcie.</string>
+    <string name="home_whatsnew_resilient_enabled">Odporne nagrywanie jest włączone. Trwające już nagranie nie jest dotknięte, jeśli Android zatrzyma proces CallVault działający w tle.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -165,6 +165,8 @@
     <string name="folder_cloud_warning">⚠ Эта папка для записей находится в облаке, что ненадёжно для записи. Выберите папку на устройстве.</string>
     <string name="settings_offline_recording_label">Запись без сети (без Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Записывать звонки даже при отсутствии сети Wi-Fi.</string>
+    <string name="settings_handoff_persist_label">Устойчивая запись</string>
+    <string name="settings_handoff_persist_description">Продолжает запись, даже если фоновый помощник завершается во время звонка (например, при блокировке экрана). Экспериментально.</string>
     <string name="settings_usb_default_label">USB при разблокировке</string>
     <string name="settings_usb_default_hint">«Только зарядка» сохраняет запись, если вы блокируете экран во время звонка. Другие режимы позволяют передавать данные по USB, но могут прервать запись при блокировке телефона.</string>
     <string name="settings_usb_default_applying">Применение…</string>

--- a/app/src/main/res/values-ru/strings_home.xml
+++ b/app/src/main/res/values-ru/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">USB в режиме передачи данных. Нажмите, чтобы выбрать «Только зарядка».</string>
     <string name="home_usb_advisory_fix">Исправить</string>
     <string name="home_whatsnew_resilient_title">Новое: устойчивая запись</string>
-    <string name="home_whatsnew_resilient_body">Если запись звонка началась, теперь она доводится до конца — даже если Android остановит фоновый процесс CallVault на середине, из-за чего запись раньше обрывалась.\n\nПо умолчанию выключено. Включить можно и позже: Настройки ▸ Надёжность.</string>
+    <string name="home_whatsnew_resilient_body">Делает запись звонков более устойчивой к прерываниям.\n\nAndroid может остановить фоновый процесс CallVault в любой момент. Когда эта опция включена, уже идущая запись от этого не страдает.\n\nПо умолчанию выключено — включить можно и позже: Настройки ▸ Надёжность.</string>
     <string name="home_whatsnew_resilient_cta">Включить</string>
-    <string name="home_whatsnew_resilient_enabled">Устойчивая запись включена. Теперь звонки записываются до конца, даже если фоновый процесс остановится на середине.</string>
+    <string name="home_whatsnew_resilient_enabled">Устойчивая запись включена. Уже идущая запись не пострадает, если Android остановит фоновый процесс CallVault.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings_home.xml
+++ b/app/src/main/res/values-ru/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">Запись может остановиться при блокировке</string>
     <string name="home_usb_advisory_text">USB в режиме передачи данных. Нажмите, чтобы выбрать «Только зарядка».</string>
     <string name="home_usb_advisory_fix">Исправить</string>
+    <string name="home_whatsnew_resilient_title">Новое: устойчивая запись</string>
+    <string name="home_whatsnew_resilient_body">Если запись звонка началась, теперь она доводится до конца — даже если Android остановит фоновый процесс CallVault на середине, из-за чего запись раньше обрывалась.\n\nПо умолчанию выключено. Включить можно и позже: Настройки ▸ Надёжность.</string>
+    <string name="home_whatsnew_resilient_cta">Включить</string>
+    <string name="home_whatsnew_resilient_enabled">Устойчивая запись включена. Теперь звонки записываются до конца, даже если фоновый процесс остановится на середине.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -165,6 +165,8 @@
     <string name="folder_cloud_warning">⚠ Thư mục ghi âm này nằm trên đám mây, vốn không đáng tin cậy cho việc ghi âm. Hãy chọn một thư mục trên thiết bị.</string>
     <string name="settings_offline_recording_label">Ghi âm ngoại tuyến (không có Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Ghi âm cuộc gọi ngay cả khi không có mạng Wi-Fi.</string>
+    <string name="settings_handoff_persist_label">Ghi âm bền bỉ</string>
+    <string name="settings_handoff_persist_description">Tiếp tục ghi âm ngay cả khi tiến trình trợ giúp nền bị tắt giữa cuộc gọi (ví dụ khi bạn khóa màn hình). Thử nghiệm.</string>
     <string name="settings_usb_default_label">USB khi mở khóa màn hình</string>
     <string name="settings_usb_default_hint">"Chỉ sạc" giữ cho bản ghi tiếp tục nếu bạn khóa màn hình khi đang gọi. Các chế độ khác cho phép truyền dữ liệu qua USB nhưng có thể làm gián đoạn bản ghi khi bạn khóa máy.</string>
     <string name="settings_usb_default_applying">Đang áp dụng…</string>

--- a/app/src/main/res/values-vi/strings_home.xml
+++ b/app/src/main/res/values-vi/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">USB đang ở chế độ dữ liệu. Nhấn để đặt Chỉ sạc.</string>
     <string name="home_usb_advisory_fix">Sửa</string>
     <string name="home_whatsnew_resilient_title">Mới: Ghi âm bền bỉ</string>
-    <string name="home_whatsnew_resilient_body">Một khi cuộc gọi đã bắt đầu được ghi, giờ đây nó sẽ ghi trọn vẹn — kể cả khi Android dừng tiến trình nền của CallVault giữa chừng, điều trước đây làm bản ghi bị cắt ngang.\n\nMặc định tắt. Bạn cũng có thể bật sau trong Cài đặt ▸ Độ tin cậy.</string>
+    <string name="home_whatsnew_resilient_body">Giúp việc ghi âm cuộc gọi chống chịu tốt hơn với các gián đoạn.\n\nAndroid có thể dừng tiến trình nền của CallVault bất cứ lúc nào. Khi bật tùy chọn này, bản ghi đang diễn ra sẽ không còn bị ảnh hưởng khi điều đó xảy ra.\n\nMặc định tắt — bạn cũng có thể bật sau trong Cài đặt ▸ Độ tin cậy.</string>
     <string name="home_whatsnew_resilient_cta">Bật</string>
-    <string name="home_whatsnew_resilient_enabled">Ghi âm bền bỉ đang bật. Các cuộc gọi của bạn sẽ được ghi đến hết, kể cả khi tiến trình nền bị dừng giữa chừng.</string>
+    <string name="home_whatsnew_resilient_enabled">Ghi âm bền bỉ đang bật. Bản ghi đang diễn ra sẽ không bị ảnh hưởng nếu Android dừng tiến trình nền của CallVault.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings_home.xml
+++ b/app/src/main/res/values-vi/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">Ghi âm có thể dừng khi khóa màn hình</string>
     <string name="home_usb_advisory_text">USB đang ở chế độ dữ liệu. Nhấn để đặt Chỉ sạc.</string>
     <string name="home_usb_advisory_fix">Sửa</string>
+    <string name="home_whatsnew_resilient_title">Mới: Ghi âm bền bỉ</string>
+    <string name="home_whatsnew_resilient_body">Một khi cuộc gọi đã bắt đầu được ghi, giờ đây nó sẽ ghi trọn vẹn — kể cả khi Android dừng tiến trình nền của CallVault giữa chừng, điều trước đây làm bản ghi bị cắt ngang.\n\nMặc định tắt. Bạn cũng có thể bật sau trong Cài đặt ▸ Độ tin cậy.</string>
+    <string name="home_whatsnew_resilient_cta">Bật</string>
+    <string name="home_whatsnew_resilient_enabled">Ghi âm bền bỉ đang bật. Các cuộc gọi của bạn sẽ được ghi đến hết, kể cả khi tiến trình nền bị dừng giữa chừng.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -165,6 +165,8 @@
     <string name="folder_cloud_warning">⚠ 此录音文件夹位于云端，用于录音并不可靠。请选择设备本地的文件夹。</string>
     <string name="settings_offline_recording_label">离线录音（无 Wi-Fi）</string>
     <string name="settings_offline_recording_desc">即使没有 Wi-Fi 网络也能录制通话。</string>
+    <string name="settings_handoff_persist_label">弹性录音</string>
+    <string name="settings_handoff_persist_description">即使后台助手在通话中被终止（例如锁定屏幕时），也能继续录音。实验性功能。</string>
     <string name="settings_usb_default_label">解锁时的 USB 模式</string>
     <string name="settings_usb_default_hint">“仅充电”可在通话中锁屏时保持录音不中断。其他模式允许 USB 传输数据，但在锁定手机时可能中断录音。</string>
     <string name="settings_usb_default_applying">正在应用…</string>

--- a/app/src/main/res/values-zh-rCN/strings_home.xml
+++ b/app/src/main/res/values-zh-rCN/strings_home.xml
@@ -29,4 +29,8 @@
     <string name="home_usb_advisory_title">锁屏时录音可能中断</string>
     <string name="home_usb_advisory_text">USB 处于数据模式。点按设为仅充电。</string>
     <string name="home_usb_advisory_fix">修复</string>
+    <string name="home_whatsnew_resilient_title">新功能：弹性录音</string>
+    <string name="home_whatsnew_resilient_body">通话一旦开始录音，现在就会录到结束——即使 Android 中途停止了 CallVault 的后台进程，而这在以前会让录音被截断。\n\n默认关闭。你也可以稍后在“设置 ▸ 可靠性”中开启。</string>
+    <string name="home_whatsnew_resilient_cta">开启</string>
+    <string name="home_whatsnew_resilient_enabled">弹性录音已开启。即使后台进程中途被停止，你的通话现在也会完整录制到结束。</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_home.xml
+++ b/app/src/main/res/values-zh-rCN/strings_home.xml
@@ -30,7 +30,7 @@
     <string name="home_usb_advisory_text">USB 处于数据模式。点按设为仅充电。</string>
     <string name="home_usb_advisory_fix">修复</string>
     <string name="home_whatsnew_resilient_title">新功能：弹性录音</string>
-    <string name="home_whatsnew_resilient_body">通话一旦开始录音，现在就会录到结束——即使 Android 中途停止了 CallVault 的后台进程，而这在以前会让录音被截断。\n\n默认关闭。你也可以稍后在“设置 ▸ 可靠性”中开启。</string>
+    <string name="home_whatsnew_resilient_body">让通话录音更能抵御中断。\n\nAndroid 可能随时停止 CallVault 的后台进程。开启后，已在进行中的录音不再受此影响。\n\n默认关闭——你也可以稍后在“设置 ▸ 可靠性”中开启。</string>
     <string name="home_whatsnew_resilient_cta">开启</string>
-    <string name="home_whatsnew_resilient_enabled">弹性录音已开启。即使后台进程中途被停止，你的通话现在也会完整录制到结束。</string>
+    <string name="home_whatsnew_resilient_enabled">弹性录音已开启。若 Android 停止 CallVault 的后台进程，已在进行中的录音不再受影响。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,6 +157,8 @@
     <!-- Offline recording (loopback) opt-in + security warning -->
     <string name="settings_offline_recording_label">Offline recording (no Wi-Fi)</string>
     <string name="settings_offline_recording_desc">Record calls even when there is no Wi-Fi network.</string>
+    <string name="settings_handoff_persist_label">Resilient recording</string>
+    <string name="settings_handoff_persist_description">Keep a recording going even if the background helper is killed mid-call (e.g. when you lock the screen). Experimental.</string>
     <string name="settings_usb_default_label">USB when screen unlocks</string>
     <string name="settings_usb_default_hint">"Charging only" keeps recording alive if you lock the screen during a call. Other modes let USB transfer data but can interrupt a recording when you lock the phone.</string>
     <string name="settings_usb_default_applying">Applying…</string>

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -37,6 +37,10 @@
     <string name="home_whatsnew_offline_enabled">Offline recording enabled.</string>
     <string name="home_whatsnew_offline_failed">Couldn\'t enable — connect to Wi-Fi once, then try from Settings.</string>
     <string name="home_whatsnew_offline_enabling">Enabling off-Wi-Fi recording…</string>
+    <string name="home_whatsnew_resilient_title">New: Resilient recording</string>
+    <string name="home_whatsnew_resilient_body">Once a call starts recording, it now finishes — even if Android stops CallVault\'s background helper part-way through, which used to cut the recording short.\n\nIt is off by default. You can also turn it on later in Settings ▸ Reliability.</string>
+    <string name="home_whatsnew_resilient_cta">Turn it on</string>
+    <string name="home_whatsnew_resilient_enabled">Resilient recording is on. Your calls will now keep recording to the end, even if the background helper is stopped part-way through.</string>
     <string name="offline_recording_on">Off-Wi-Fi recording is on.</string>
     <string name="offline_recording_disabling">Turning off off-Wi-Fi recording…</string>
 </resources>

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -38,9 +38,9 @@
     <string name="home_whatsnew_offline_failed">Couldn\'t enable — connect to Wi-Fi once, then try from Settings.</string>
     <string name="home_whatsnew_offline_enabling">Enabling off-Wi-Fi recording…</string>
     <string name="home_whatsnew_resilient_title">New: Resilient recording</string>
-    <string name="home_whatsnew_resilient_body">Once a call starts recording, it now finishes — even if Android stops CallVault\'s background helper part-way through, which used to cut the recording short.\n\nIt is off by default. You can also turn it on later in Settings ▸ Reliability.</string>
+    <string name="home_whatsnew_resilient_body">Makes call recording more resistant to interruptions.\n\nAndroid can stop CallVault\'s background helper at any time. With this on, a recording already in progress is no longer affected when that happens.\n\nOff by default — you can also turn it on later in Settings ▸ Reliability.</string>
     <string name="home_whatsnew_resilient_cta">Turn it on</string>
-    <string name="home_whatsnew_resilient_enabled">Resilient recording is on. Your calls will now keep recording to the end, even if the background helper is stopped part-way through.</string>
+    <string name="home_whatsnew_resilient_enabled">Resilient recording is on. A recording already in progress is no longer affected if Android stops CallVault\'s background helper.</string>
     <string name="offline_recording_on">Off-Wi-Fi recording is on.</string>
     <string name="offline_recording_disabling">Turning off off-Wi-Fi recording…</string>
 </resources>

--- a/app/src/test/java/com/baba/callvault/integrations/scrcpy/ScrcpyAudioSourceMappingTest.kt
+++ b/app/src/test/java/com/baba/callvault/integrations/scrcpy/ScrcpyAudioSourceMappingTest.kt
@@ -1,0 +1,81 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.integrations.scrcpy
+
+import android.media.MediaRecorder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the cliKey → AudioSource map that decides whether a source can be captured directly (daemon
+ * recorder or handoff) or must go through scrcpy.
+ *
+ * The map used to be duplicated, and the copy in the direct recorder keyed VOICE_PERFORMANCE off a
+ * cliKey that does not exist — so the source silently fell back to scrcpy. These tests pin the keys to
+ * the enum itself so a typo cannot come back unnoticed.
+ */
+class ScrcpyAudioSourceMappingTest {
+
+    @Test
+    fun `voice call maps to the privileged call source`() {
+        assertEquals(MediaRecorder.AudioSource.VOICE_CALL, ScrcpyAudioSource.VOICE_CALL.androidAudioSource)
+    }
+
+    @Test
+    fun `every mapped key belongs to a real source`() {
+        // Arrange: the keys the mapping claims to support.
+        val mappedKeys = ScrcpyAudioSource.entries.filter { it.androidAudioSource != null }.map { it.cliKey }
+
+        // Assert: the map is keyed off cliKey strings, so a stale key would silently map nothing.
+        assertTrue("expected several directly-capturable sources", mappedKeys.size >= 5)
+        mappedKeys.forEach { key ->
+            assertNotNull("'$key' must resolve back to a source", androidAudioSourceForKey(key))
+        }
+    }
+
+    @Test
+    fun `voice performance is directly capturable`() {
+        // The regression: this mapped off "mic-voice-performance", which is not a cliKey.
+        assertEquals(
+            MediaRecorder.AudioSource.VOICE_PERFORMANCE,
+            ScrcpyAudioSource.VOICE_PERFORMANCE.androidAudioSource,
+        )
+        assertEquals(
+            MediaRecorder.AudioSource.VOICE_PERFORMANCE,
+            androidAudioSourceForKey("voice-performance"),
+        )
+    }
+
+    @Test
+    fun `playback capture sources have no direct AudioRecord source`() {
+        // output/playback are scrcpy-only — an AudioRecord cannot open them.
+        assertNull(ScrcpyAudioSource.OUTPUT.androidAudioSource)
+        assertNull(ScrcpyAudioSource.PLAYBACK.androidAudioSource)
+    }
+
+    @Test
+    fun `an unknown key resolves to no source rather than throwing`() {
+        assertNull(androidAudioSourceForKey("not-a-source"))
+        assertNull(androidAudioSourceForKey(""))
+    }
+
+    @Test
+    fun `key lookup agrees with the enum property for every source`() {
+        ScrcpyAudioSource.entries.forEach { source ->
+            assertEquals(
+                "lookup by cliKey must match the enum for ${source.cliKey}",
+                source.androidAudioSource,
+                androidAudioSourceForKey(source.cliKey),
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/baba/callvault/services/recording/handoff/AudioHandoffNativeTest.kt
+++ b/app/src/test/java/com/baba/callvault/services/recording/handoff/AudioHandoffNativeTest.kt
@@ -1,0 +1,99 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording.handoff
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Covers how the daemon locates the extracted native library.
+ *
+ * This is worth pinning because the failure is invisible from outside: a library the daemon cannot
+ * load makes `startHandoff` return false, the engine quietly falls back to the daemon recording path,
+ * and the call still records — so "Resilient recording" is off while everything looks healthy. That
+ * is exactly what happened when the lookup assumed the build ABI name (`arm64-v8a`) instead of the
+ * instruction-set directory Android actually extracts to (`arm64`).
+ */
+class AudioHandoffNativeTest {
+
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    /** Builds an install layout: `<root>/<pkg>/base.apk` alongside `<root>/<pkg>/lib/<abiDir>/…`. */
+    private fun installLayout(abiDir: String?, soName: String = "libaudiohandoff.so"): File {
+        val pkgDir = temp.newFolder("pkg")
+        val apk = File(pkgDir, "base.apk").apply { writeText("apk") }
+        if (abiDir != null) {
+            File(pkgDir, "lib/$abiDir").mkdirs()
+            File(pkgDir, "lib/$abiDir/$soName").writeText("so")
+        }
+        return apk
+    }
+
+    @Test
+    fun `finds the library in the instruction-set directory Android actually uses`() {
+        // Arrange: the real on-device layout — lib/arm64, NOT lib/arm64-v8a.
+        val apk = installLayout("arm64")
+
+        // Act
+        val found = AudioHandoffNative.findExtractedLib(apk.absolutePath)
+
+        // Assert
+        assertEquals(File(apk.parentFile, "lib/arm64/libaudiohandoff.so"), found)
+    }
+
+    @Test
+    fun `finds the library whatever the abi directory is called`() {
+        // Not assuming a name is the whole point — any of these must work.
+        listOf("arm64-v8a", "arm", "armeabi-v7a", "x86_64").forEach { abiDir ->
+            temp.delete()
+            temp.create()
+            val apk = installLayout(abiDir)
+            assertEquals(
+                "should have found the library under lib/$abiDir",
+                File(apk.parentFile, "lib/$abiDir/libaudiohandoff.so"),
+                AudioHandoffNative.findExtractedLib(apk.absolutePath),
+            )
+        }
+    }
+
+    @Test
+    fun `returns null when the library was not extracted`() {
+        // Arrange: a lib dir exists but holds a different library.
+        val apk = installLayout("arm64", soName = "libsomethingelse.so")
+
+        // Act + Assert
+        assertNull(AudioHandoffNative.findExtractedLib(apk.absolutePath))
+    }
+
+    @Test
+    fun `returns null when there is no lib directory at all`() {
+        assertNull(AudioHandoffNative.findExtractedLib(installLayout(abiDir = null).absolutePath))
+    }
+
+    @Test
+    fun `returns null for a nonexistent apk path rather than throwing`() {
+        assertNull(AudioHandoffNative.findExtractedLib("/does/not/exist/base.apk"))
+    }
+
+    @Test
+    fun `ignores a directory entry that is not a regular file`() {
+        // Arrange: a DIRECTORY named like the library must not be mistaken for it.
+        val pkgDir = temp.newFolder("pkg")
+        val apk = File(pkgDir, "base.apk").apply { writeText("apk") }
+        File(pkgDir, "lib/arm64/libaudiohandoff.so").mkdirs()
+
+        // Act + Assert
+        assertNull(AudioHandoffNative.findExtractedLib(apk.absolutePath))
+    }
+}

--- a/app/src/test/java/com/baba/callvault/services/recording/handoff/HandoffGeometryTest.kt
+++ b/app/src/test/java/com/baba/callvault/services/recording/handoff/HandoffGeometryTest.kt
@@ -1,0 +1,157 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.services.recording.handoff
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the geometry the native drain is driven with. Two things are load-bearing here: the ring wraps
+ * at a power of two (getting this wrong produced periodic audio gaps), and every delivered value is
+ * bounds-checked before it becomes a native offset.
+ */
+class HandoffGeometryTest {
+
+    // A realistic 48 kHz stereo delivery: non-power-of-two frame count, comfortably sized ashmem.
+    private fun realistic(
+        frameCount: Int = 3840,
+        sampleRate: Int = 48_000,
+        channels: Int = 2,
+        cblkSize: Int = 64 * 1024,
+    ) = HandoffGeometry(frameCount, sampleRate, channels, cblkSize)
+
+    // --- frame size ---
+
+    @Test
+    fun `frame size is two bytes per channel for PCM-16`() {
+        assertEquals(2, realistic(channels = 1).frameSize)
+        assertEquals(4, realistic(channels = 2).frameSize)
+    }
+
+    // --- ring wrap ---
+
+    @Test
+    fun `ring wraps at the next power of two above a non-power-of-two frame count`() {
+        // The bug this guards: wrapping at 3840 reads the untouched 3840..4096 region every lap.
+        assertEquals(4096, realistic(frameCount = 3840).wrapFrames)
+        assertEquals(8192, realistic(frameCount = 4097).wrapFrames)
+    }
+
+    @Test
+    fun `ring wraps at the frame count itself when it is already a power of two`() {
+        assertEquals(2048, realistic(frameCount = 2048).wrapFrames)
+        assertEquals(1, realistic(frameCount = 1).wrapFrames)
+    }
+
+    @Test
+    fun `ring end offset accounts for the data offset and the rounded-up ring`() {
+        // Arrange
+        val geometry = realistic(frameCount = 3840, channels = 2)
+
+        // Act
+        val end = geometry.ringEndOffset
+
+        // Assert
+        assertEquals(HandoffGeometry.DATA_OFF + 4096L * 4, end)
+    }
+
+    // --- validation: accepted ---
+
+    @Test
+    fun `accepts a realistic delivery`() {
+        assertNull(realistic().validationError())
+    }
+
+    @Test
+    fun `accepts a ring that exactly fills the ashmem region`() {
+        // Arrange: size the region to the last byte the drain will touch.
+        val exact = HandoffGeometry.DATA_OFF + 4096 * 4
+
+        // Act + Assert
+        assertNull(realistic(frameCount = 4096, channels = 2, cblkSize = exact).validationError())
+    }
+
+    // --- validation: rejected ---
+
+    @Test
+    fun `rejects a ring one byte larger than the ashmem region`() {
+        // Arrange
+        val oneByteShort = HandoffGeometry.DATA_OFF + 4096 * 4 - 1
+
+        // Act
+        val error = realistic(frameCount = 4096, channels = 2, cblkSize = oneByteShort).validationError()
+
+        // Assert
+        assertNotNull("an over-long ring must be refused before it becomes a native offset", error)
+        assertTrue(error!!, error.contains("doesn't fit"))
+    }
+
+    @Test
+    fun `rejects a frame count whose rounded-up ring overflows the region`() {
+        // frameCount 2049 rounds up to 4096 frames — the unrounded 2049 would have fit.
+        val sizedForUnrounded = HandoffGeometry.DATA_OFF + 2049 * 4
+
+        assertNotNull(realistic(frameCount = 2049, channels = 2, cblkSize = sizedForUnrounded).validationError())
+    }
+
+    @Test
+    fun `rejects channel counts outside mono and stereo`() {
+        assertNotNull(realistic(channels = 0).validationError())
+        assertNotNull(realistic(channels = 3).validationError())
+        assertNotNull(realistic(channels = -1).validationError())
+    }
+
+    @Test
+    fun `rejects sample rates outside the supported range`() {
+        assertNotNull(realistic(sampleRate = 0).validationError())
+        assertNotNull(realistic(sampleRate = 7_999).validationError())
+        assertNotNull(realistic(sampleRate = 192_001).validationError())
+    }
+
+    @Test
+    fun `accepts sample rates at the range boundaries`() {
+        assertNull(realistic(sampleRate = 8_000).validationError())
+        assertNull(realistic(sampleRate = 192_000).validationError())
+    }
+
+    @Test
+    fun `rejects an unsized or unreadable ashmem region`() {
+        assertNotNull(realistic(cblkSize = 0).validationError())
+        assertNotNull(realistic(cblkSize = -1).validationError())
+    }
+
+    @Test
+    fun `rejects a non-positive frame count`() {
+        assertNotNull(HandoffGeometry(0, 48_000, 2, 64 * 1024).validationError())
+        assertNotNull(HandoffGeometry(-8, 48_000, 2, 64 * 1024).validationError())
+    }
+
+    // --- construction ---
+
+    @Test
+    fun `substitutes the fallback when the daemon reported no frame count`() {
+        // Arrange + Act
+        val geometry = HandoffGeometry.of(frameCount = 0, sampleRate = 48_000, channels = 1, cblkSize = 64 * 1024)
+
+        // Assert
+        assertEquals(HandoffGeometry.FRAME_COUNT_FALLBACK, geometry.frameCount)
+        assertNull(geometry.validationError())
+    }
+
+    @Test
+    fun `keeps a reported frame count`() {
+        assertEquals(
+            3840,
+            HandoffGeometry.of(frameCount = 3840, sampleRate = 48_000, channels = 2, cblkSize = 64 * 1024).frameCount,
+        )
+    }
+}

--- a/app/src/test/java/com/baba/callvault/ui/viewmodels/WhatsNewSelectionTest.kt
+++ b/app/src/test/java/com/baba/callvault/ui/viewmodels/WhatsNewSelectionTest.kt
@@ -1,0 +1,66 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.ui.viewmodels
+
+import com.baba.callvault.ui.viewmodels.HomeViewModel.WhatsNewNote
+import com.baba.callvault.ui.viewmodels.HomeViewModel.Companion.selectWhatsNew
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Covers which one-time feature note is shown after an update.
+ *
+ * The rules that matter: a note never appears outside an update, each note appears at most once, and
+ * someone who skipped a release still meets the feature they missed rather than having it swallowed by
+ * the newer one.
+ */
+class WhatsNewSelectionTest {
+
+    @Test
+    fun `shows nothing when the app was not just updated`() {
+        assertNull(selectWhatsNew(justUpdated = false, seenResilient = false, seenOffWifi = false))
+    }
+
+    @Test
+    fun `shows the newest unseen feature first`() {
+        // The common case: an existing user who already met off-Wi-Fi updates into this release.
+        assertEquals(
+            WhatsNewNote.RESILIENT_RECORDING,
+            selectWhatsNew(justUpdated = true, seenResilient = false, seenOffWifi = true),
+        )
+    }
+
+    @Test
+    fun `still shows an older feature the user skipped past`() {
+        // Someone who saw the resilient note but never the off-Wi-Fi one must not lose it.
+        assertEquals(
+            WhatsNewNote.OFF_WIFI,
+            selectWhatsNew(justUpdated = true, seenResilient = true, seenOffWifi = false),
+        )
+    }
+
+    @Test
+    fun `shows one note at a time when several are unseen`() {
+        // Arrange: a user updating across both releases at once.
+        val first = selectWhatsNew(justUpdated = true, seenResilient = false, seenOffWifi = false)
+
+        // Assert: the newest comes first; the other is still pending for the next update.
+        assertEquals(WhatsNewNote.RESILIENT_RECORDING, first)
+        assertEquals(
+            WhatsNewNote.OFF_WIFI,
+            selectWhatsNew(justUpdated = true, seenResilient = true, seenOffWifi = false),
+        )
+    }
+
+    @Test
+    fun `shows nothing once every note has been seen`() {
+        assertNull(selectWhatsNew(justUpdated = true, seenResilient = true, seenOffWifi = true))
+    }
+}

--- a/app/src/test/java/com/baba/callvault/utils/PcmDownmixTest.kt
+++ b/app/src/test/java/com/baba/callvault/utils/PcmDownmixTest.kt
@@ -1,0 +1,129 @@
+/*
+ * CallVault: FOSS call recording, self-contained over embedded ADB
+ *  Copyright (C) 2026-present The CallVault Authors
+ *  This software is licensed under the GNU General Public License v3 or later, with additional terms as permitted under Section 7.
+ *  The full license text is available in the LICENSE file at the root of this project.
+ *  This software is distributed WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package com.baba.callvault.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the stereo→mono downmix both capture pipelines run every call. The properties that matter are
+ * that the two call directions are averaged (never summed, which would clip on double-talk) and that a
+ * truncated final chunk can't walk off the end of the buffer.
+ */
+class PcmDownmixTest {
+
+    /** Builds interleaved little-endian stereo PCM-16 from (left, right) sample pairs. */
+    private fun stereo(vararg pairs: Pair<Int, Int>): ByteArray {
+        val out = ByteArray(pairs.size * 4)
+        pairs.forEachIndexed { i, (l, r) ->
+            out[i * 4] = (l and 0xFF).toByte()
+            out[i * 4 + 1] = ((l shr 8) and 0xFF).toByte()
+            out[i * 4 + 2] = (r and 0xFF).toByte()
+            out[i * 4 + 3] = ((r shr 8) and 0xFF).toByte()
+        }
+        return out
+    }
+
+    /** Reads the mono PCM-16 samples written to a destination buffer. */
+    private fun monoSamples(dst: ByteArray, len: Int): List<Int> =
+        (0 until len step 2).map { (dst[it].toInt() and 0xFF or (dst[it + 1].toInt() shl 8)).toShort().toInt() }
+
+    @Test
+    fun `averages each left-right pair`() {
+        // Arrange
+        val src = stereo(1000 to 2000, -400 to 400, 32767 to 32767)
+        val dst = ByteArray(src.size / 2)
+
+        // Act
+        val written = PcmDownmix.stereoToMono(src, src.size, dst)
+
+        // Assert
+        assertEquals(src.size / 2, written)
+        assertEquals(listOf(1500, 0, 32767), monoSamples(dst, written))
+    }
+
+    @Test
+    fun `loud double-talk keeps the waveform intact instead of wrapping`() {
+        // Arrange: both parties loud at once — the case that made summing unusable. A sum overflows
+        // PCM-16 and wraps to the opposite sign, which is an audible click on every loud moment.
+        val pairs = listOf(32767 to 32767, -32768 to -32768, 30000 to 20000, -30000 to -20000)
+        val src = stereo(*pairs.toTypedArray())
+        val dst = ByteArray(src.size / 2)
+
+        // Act
+        val written = PcmDownmix.stereoToMono(src, src.size, dst)
+
+        // Assert: the mix stays on the same side of zero as the two inputs it came from.
+        monoSamples(dst, written).zip(pairs).forEach { (mixed, pair) ->
+            val bothPositive = pair.first > 0 && pair.second > 0
+            assertTrue(
+                "downmix of ${pair.first}/${pair.second} was $mixed — the sign flipped, so it wrapped",
+                if (bothPositive) mixed > 0 else mixed < 0,
+            )
+        }
+    }
+
+    @Test
+    fun `preserves a single active direction at half amplitude`() {
+        // Arrange: only the far party is speaking, our uplink is silent.
+        val src = stereo(0 to 10000)
+        val dst = ByteArray(src.size / 2)
+
+        // Act
+        val written = PcmDownmix.stereoToMono(src, src.size, dst)
+
+        // Assert
+        assertEquals(listOf(5000), monoSamples(dst, written))
+    }
+
+    @Test
+    fun `writes exactly half the consumed bytes`() {
+        // Arrange
+        val src = stereo(1 to 1, 2 to 2, 3 to 3, 4 to 4)
+        val dst = ByteArray(src.size / 2)
+
+        // Act + Assert
+        assertEquals(8, PcmDownmix.stereoToMono(src, src.size, dst))
+    }
+
+    @Test
+    fun `ignores a trailing partial frame instead of reading past it`() {
+        // Arrange: one whole stereo frame plus three stray bytes (a truncated final chunk).
+        val whole = stereo(100 to 300)
+        val src = whole + byteArrayOf(1, 2, 3)
+        val dst = ByteArray(src.size / 2)
+
+        // Act
+        val written = PcmDownmix.stereoToMono(src, src.size, dst)
+
+        // Assert
+        assertEquals(2, written)
+        assertEquals(listOf(200), monoSamples(dst, written))
+    }
+
+    @Test
+    fun `writes nothing for an empty chunk`() {
+        assertEquals(0, PcmDownmix.stereoToMono(ByteArray(0), 0, ByteArray(8)))
+    }
+
+    @Test
+    fun `honours the length argument rather than the buffer size`() {
+        // Arrange: a reusable read buffer that is only partly filled.
+        val src = stereo(1000 to 2000, 6000 to 8000) + ByteArray(64)
+        val dst = ByteArray(src.size / 2)
+
+        // Act: report only the first frame as read.
+        val written = PcmDownmix.stereoToMono(src, 4, dst)
+
+        // Assert
+        assertEquals(2, written)
+        assertEquals(listOf(1500), monoSamples(dst, written))
+    }
+}

--- a/docs/dev-notes/capture-research-directions.md
+++ b/docs/dev-notes/capture-research-directions.md
@@ -1,0 +1,168 @@
+# Capture & Persistence — Research Directions
+
+**Status:** forward-looking investigation tracks. **Nothing here is proven or built.** These are the "what if" paths worth probing, each with a code-grounded read of *what it would let us replace* and the *open risks that gate it*.
+
+Companion to `spike-audio-handoff.md` (which proved **Option B** — the app can hold a handed-off `IAudioRecord`+cblk and keep capturing after the daemon dies). That proof unlocks the tracks below. Read §7 of that doc first for the CREATE-vs-SUSTAIN framing this builds on.
+
+**Devices:** primary OnePlus 12 / A16 / SDK 36 (`6011b07e`); secondary OnePlus 9 Pro / A14.
+
+---
+
+## Track A — Pre-created idle capture track (persistence via a permanently-held handoff)
+
+### The idea
+
+Option B proved the app can *hold* a live capture track after the daemon dies. Track A asks: what if the app holds the track **from before the call even starts** — created once by a briefly-alive daemon (post-boot / post-onboarding), handed off, then kept indefinitely? If an idle `VOICE_CALL` track simply begins yielding audio when a call becomes active, **no daemon is needed at call start at all.** The daemon collapses from a per-call requirement to a once-per-boot "track factory."
+
+### Code investigation — what a working Track A would replace
+
+Grounded in the current bootstrap + recording paths:
+
+| Today's machinery | Why it exists | Track A effect |
+|---|---|---|
+| `RecorderServerLauncher.ensureServerRunning` at ring/standby (`RecordingForegroundService.kt:248`) and at record start (`AudioRecordingEngine.kt:340`) | launch/confirm the daemon so it can create the track when a call fires | **gone at call time** — the app already holds the track; it just starts draining its cblk |
+| `DaemonKeepAliveService` — persistent FGS + 60s watchdog + immediate relaunch | its own docstring: keep the daemon *"WARM … so a call is captured instantly instead of paying a cold-start that outlasts a short call"* | **collapses** to "create the track once per boot, re-create only if the held track is lost" — no per-call warmth needed |
+| Cold-start latency (first call after reboot/reap missed — see `post-reboot-daemon-coldstart-latency` memory) | daemon launches lazily, slower than a short call's first seconds | **gone**, except the single post-boot creation |
+| **Loopback / classic-tcpip off-WiFi opt-in** (`AdbShell.connectLoopback`/`armLoopbackIfNeeded`, `OFFLINE_RECORDING_ENABLED`, `LOOPBACK_ADB_PORT`) | the only way to (re)launch the daemon at call time without WiFi, since WD is WiFi-only | **potentially RETIRED** — see below |
+| WD-enable churn (`AdbShell.enableWirelessDebugging`) — memory's *primary* self-inflicted daemon killer | re-enabled transiently on every launch/relaunch | **minimized to once-per-boot** (one create), so the adbd-restart churn that kills daemons all but disappears |
+
+### The headline payoff: off-WiFi **without** loopback
+
+Off-WiFi recording today needs loopback *only because* the daemon must be (re)launched at call time and WD dies off-WiFi. But if the app is **already holding a live capture track** created earlier while on WiFi, then **no ADB is needed at call time at all** — the call records straight from the held cblk. A track created once on WiFi and held across the WiFi→cellular transition means **off-WiFi calls record with no loopback, no `0.0.0.0` open port.**
+
+That would resolve the loopback security tradeoff outright (the `adb tcpip` listener binds all interfaces and can't be loopback-bound without root — see `loopback-tcpip-offwifi` memory). Track A is the one path that makes off-WiFi *free and safe* instead of a warned opt-in.
+
+### What still needs the daemon (honest limit)
+
+**CREATE, once per boot.** `service.adb.tcp.port` and any tcpip state clear on reboot, and a fresh capture track is needed after a reboot anyway. So the model is **"daemon + ADB once per boot"** (a single create+handoff at BootReceiver / first connectivity), not "daemon never." The bootstrap doesn't vanish — it de-escalates from per-call to per-boot.
+
+### Open risks — must validate before betting on it
+
+1. **Idle silencing over hours** — the appop/UID-state monitor may zero-fill (or the RecordThread may STANDBY) a track whose creator uid (shell) is gone and that has no active reader for a long time. This is the M3e silencing risk, but stretched from seconds to hours. **The decisive unknown.**
+2. **Does `VOICE_CALL` gate on an active call at CREATE or only at data-time?** If `getInputForAttr` refuses to *create* a `VOICE_CALL` input when no call is active, you can't pre-create it — you'd have to create at call start (defeating the point), OR hold a different source and switch. Needs a direct probe.
+3. **Multi-hour track validity** — does the `IAudioRecord`+cblk survive doze, audio-policy reconfig, and audio route changes (BT/speaker/wired) for hours, and resume cleanly when a call starts?
+4. **Battery** — cost of an always-open capture track.
+5. **Reboot re-arm** — needs one connectivity moment post-boot to re-create; a persisted "held" flag can't be trusted across reboot (detect real state by probing the held cblk).
+
+### Cheap first probe (no productionization)
+
+On the main device: daemon creates a `VOICE_CALL` `AudioRecord` with **no call active**, hands off to the app, app holds it idle **10–30 min through screen-off/doze**, then place a real call and check whether the held track produces real audio **without re-touching the daemon**. Green here = risks 1–3 mostly cleared; then measure battery (risk 4).
+
+### Decision gate
+
+If the probe shows a held `VOICE_CALL` track goes silent or invalid over idle → Track A is dead, fall back to Option B's SUSTAIN-only win (keep WD/loopback/keep-alive as today). If it survives → this is a *bigger* architectural win than Option B alone: it retires per-call bootstrap, cold-start, and the loopback security surface in one move.
+
+---
+
+## Track B — VoIP call capture (WhatsApp / Signal / Telegram / etc.)
+
+### Grounding — do NOT re-derive the known dead ends
+
+Prior feasibility work (`voip-recording-feasibility` memory, 2026-07-22) concluded, for **non-root** VoIP both-sides capture:
+- **Bluetooth SCO/HFP software proxy** — doesn't get the downlink (that source is mic/uplink only); `startBluetoothSco` deprecated/no-op on A16. Dead.
+- **AI acoustic reconstruction** (denoise earpiece bleed) — fatal physics (earpiece bleed is below the mic noise floor except on speakerphone); denoisers *remove* the faint remote voice. Dead.
+- **Only honest cheap path evaluated then:** "records **speakerphone** VoIP acoustically + light denoise," marketed truthfully — after confirming mic-concurrency isn't blocked.
+
+### The angle that was NOT evaluated: our privileged daemon + output/playback capture
+
+We already ship (debug-only) two **downlink** capture sources via the shell-uid scrcpy path, which a normal app can't use the same way:
+- **`OUTPUT`** → `REMOTE_SUBMIX` — the final mixed audio rendered to the speaker (`ScrcpyAudioSource.kt:104-117`).
+- **`PLAYBACK`** → `AudioPlaybackCapture` API — other apps' audio output, *respecting `allowAudioPlaybackCapture` opt-out* (`ScrcpyAudioSource.kt:120-133`).
+
+Both capture the **remote VoIP party's rendered voice (downlink)**. Combined with an uplink source we already support — `VOICE_COMMUNICATION` (`DirectAudioRecorderSession.kt:267`, tuned for VoIP with AEC/AGC) or plain MIC — that is **both directions, captured digitally (not acoustically)**. The prior analysis dismissed non-acoustic VoIP for *normal apps*; it never evaluated the **privileged daemon + REMOTE_SUBMIX** specifically.
+
+### Investigation questions (in order)
+
+1. **Uplink mic-concurrency first (20 min, cheapest kill-switch).** Start a `VOICE_COMMUNICATION` capture in the daemon while a WhatsApp/Signal call owns the mic — does Android silence/deny our track (A10+ concurrency rules)? If silenced, the uplink half is blocked and the rest is moot. *(This is the "test this FIRST" from the VoIP memory.)*
+2. **Does daemon-side `OUTPUT`/REMOTE_SUBMIX capture the VoIP remote party during a live call?** VoIP audio routes with usage `VOICE_COMMUNICATION`, which is often *excluded* from submix/capture even for privileged capture. Empirically test whether the shell/scrcpy submix actually contains the far-end voice, or silence.
+3. **Does `PLAYBACK`/`AudioPlaybackCapture` capture it, or is VoIP audio non-capturable?** `VOICE_COMMUNICATION`-usage playback is capture-exempt for normal MediaProjection clients and apps can set `allowAudioPlaybackCapture=false`. Does the daemon's privileged context bypass either? Test per-app (Signal is stricter than WhatsApp, likely).
+4. **Separation quality** — do we get clean L/R directions (like `VOICE_CALL` stereo — proven independent in the handoff work) or only a downmixed blob? Downlink-only + mic gives two streams we control; submix gives one mixed stream (includes our own mic echo).
+
+### If a working path exists
+
+Downlink via `OUTPUT` or `PLAYBACK` + uplink via `VOICE_COMMUNICATION` (not silenced) → **VoIP both-sides becomes viable non-acoustically**, using capture sources already in the codebase, gated behind the same daemon we already run for cellular. This would be a genuinely new capability, not a rehash of the dead BT/AI paths.
+
+### Caveats to keep honest
+
+- **Per-app opt-outs and usage exemptions** may make it work for some apps and not others → must be surfaced honestly per app, never "records all VoIP."
+- **Ties into Track A:** a held `OUTPUT`/`PLAYBACK` track could be pre-created and held the same way — a daemon-free VoIP capture once the track exists.
+- Legal/consent framing for VoIP is stricter than cellular in many jurisdictions.
+
+---
+
+## Track C — Toward a native install (kill the Developer-Options / Wireless-Debugging / USB ceremony)
+
+**The dream:** no developer options, no wireless-debugging pairing, no USB — the app is *install + grant permissions*, like any native app.
+
+### The hard wall (state it first, so we don't chase ghosts)
+
+On **stock, non-root** Android, privileged call-audio capture (`VOICE_CALL` / `CAPTURE_AUDIO_OUTPUT`) requires a **privileged process** (shell-uid or system). The **only non-root vector to spawn one is ADB.** There is **no app-grantable permission, no consent dialog, and no default-app role — including default dialer — that gives an app-uid process `VOICE_CALL` capture.** Proven twice in our own code:
+- The Option B spike: the app process can't even `dlopen` the audio libs; the permission is uid-checked at `AudioFlinger::createRecord`, not appop-grantable to an app uid.
+- The dialer work (`dialer-mode-status` memory): even as the **forced default dialer with `InCallService` bound**, recording still rode the ADB daemon — `DialerDefaultEnforcer.enforce()` must call `AdbShell.ensureConnected()`. Being the dialer gives call *control/state*, not call *audio*.
+
+So **full both-sides cellular capture with zero ADB is not achievable on stock non-root.** Every credible non-root recorder (SCR, etc.) hits this exact wall. Don't promise otherwise.
+
+### Vectors investigated — honest verdicts (don't re-derive)
+
+| Vector | Gives an app-uid process call audio without ADB? | Verdict |
+|---|---|---|
+| Request `CAPTURE_AUDIO_OUTPUT` at runtime | No — `signature\|privileged`, not requestable | ❌ dead |
+| Default dialer / `InCallService` role | No — control/state only; still needs the daemon (proven) | ❌ dead for audio |
+| Device Owner / DPC | Can grant *runtime* perms silently but NOT signature/privileged; setup needs ADB or QR-factory-reset anyway | ❌ dead + more friction |
+| Carrier privileges (cert on SIM) | Cert must be whitelisted on the carrier's SIM; no call-audio API in the surface | ❌ dead |
+| Assistant / `VoiceInteractionService` role | Hotword/assist audio, not `VOICE_CALL` | ❌ dead |
+| Accessibility service | No audio-capture capability at all | ❌ dead |
+| One-time `pm grant`/`appops` to bless the app uid | Perm is uid-checked at AudioFlinger, not appop-grantable; app uid can't reach the libs | ❌ dead |
+| `sharedUserId=android.uid.shell` | Signature-checked, deprecated | ❌ dead |
+| **MediaProjection `AudioPlaybackCapture`** | **Yes for VoIP/media *downlink*** (app-uid, one consent) — but **CANNOT** capture telephony `VOICE_CALL` (exempt), and A14+ re-consents per session | 🟡 **partial — VoIP/media only** |
+| **On-device wireless pairing (Android 11+)** | Removes the *computer* from setup (pairing code entered in-app), not ADB itself | 🟢 **friction reducer** |
+| **Root (optional tier)** | Yes — truly install + grant-su, no ADB ceremony | 🟢 **viable for rooted users** |
+
+### The creative reframe — a tiered capability model (this is the real out-of-the-box output)
+
+Instead of one all-or-nothing path, ship **tiers**, so the app is *useful on first launch with zero ceremony* and power users opt up:
+
+- **Tier 0 — true "install + permissions", ZERO developer options.**
+  - **VoIP:** MediaProjection `AudioPlaybackCapture` (remote downlink) + MIC (local uplink) — app-uid, one consent, no ADB. (This is Track B done *app-side*, respecting per-app opt-outs.)
+  - **Cellular:** become the default dialer (already-built machinery), force **speakerphone**, capture acoustically via MIC (`RECORD_AUDIO` only). Honest, limited (speakerphone only).
+  - Net: the app **records *something* for a user who will never touch developer options** — the true native-install experience, at reduced capability. Strong default first-run.
+- **Tier 1 — one-time on-device pairing, then autonomous ("feels native after onboarding").**
+  - Current ADB daemon path, but: (a) **on-device wireless pairing** (no computer — pairing code in-app), (b) **Track A** held-track so ADB is touched *at most once per boot*, (c) app silently self-manages WD/loopback thereafter. After a ~2-min onboarding the user never sees developer options again → full-quality both-sides cellular that *feels* native day-to-day.
+  - Irreducible friction: the **one-time** WRITE_SECURE_SETTINGS grant, and reinstall dropping it (`reinstall-drops-write-secure-settings` memory; in-place updates preserve it).
+- **Tier 2 — root (optional).** Truly install + grant-su, no ceremony, best persistence. Rooted users only; auto-detect root and offer it.
+
+**Product framing:** Tier 0 is the zero-friction default that works immediately (VoIP + speakerphone). An in-app "unlock full call recording" flow upgrades to Tier 1 for users who want both-sides cellular quality. The daemon becomes *invisible infrastructure* the average user opts into once — not a barrier at the door.
+
+### What to probe / decide
+
+1. **Tier 0 VoIP viability** = Track B's mic-concurrency + `allowAudioPlaybackCapture` tests, but done **app-side via MediaProjection** (no daemon) — cheapest, unlocks a real zero-ADB feature.
+2. **Tier 0 cellular** = confirm default-dialer + force-speakerphone + MIC gives an acceptable acoustic recording (honest quality bar).
+3. **Tier 1 onboarding** = polish on-device wireless pairing so no PC is ever required; measure real onboarding drop-off.
+4. **A14+ MediaProjection re-consent** — check whether a persistent foreground-service capture token survives, or if each VoIP call needs a fresh consent tap (UX cost of Tier 0 VoIP).
+
+---
+
+## Creative ideas / cross-cutting
+
+1. **Universal capture abstraction — daemon as a "track factory."** If Track A holds, generalize the handoff: the app holds handed-off tracks for *any* source (`VOICE_CALL`, `OUTPUT`, `PLAYBACK`), and the daemon's entire runtime role shrinks to "create N tracks once per boot and hand them off." Everything else (encode, mux, lifecycle, output file) is already app-side (`AudioRecordingEngine` owns the SAF fd + codec today).
+
+2. **Reframe bootstrap from per-call to per-boot.** The whole ADB/WD/loopback dependency exists to have a privileged process *ready at call time*. Track A moves that to *once at boot* — `BootReceiver` does a single create+handoff, and there is no ADB/WD/loopback in the hot path ever again. This is the strategic prize: it doesn't just improve persistence, it removes the per-call attack/failure surface.
+
+3. **Loopback retirement.** If Track A works, `OFFLINE_RECORDING_ENABLED` + the `0.0.0.0` tcpip listener can be deleted, closing the one real security surface in the product (see `loopback-tcpip-offwifi` memory). Document this as an explicit payoff of Track A, not an afterthought.
+
+4. **Dual-hold redundancy.** Hold both a `VOICE_CALL` track (cellular) and an `OUTPUT`/`PLAYBACK` track (VoIP) simultaneously, so *any* call type is covered without knowing in advance which will ring. Cost = two idle tracks' battery (measure in Track A's probe).
+
+5. **Proactive re-create on state change.** Rather than a periodic watchdog, listen for audio-route / call-state / screen transitions and refresh a stale held track *before* the next call, so a track that silently went invalid during idle is renewed at the cheapest moment (device already awake, possibly on WiFi).
+
+6. **Graceful degradation ladder.** If a held track is invalid at call start and we're off-WiFi with no loopback, fall back to: (a) fast daemon relaunch if any transport exists → (b) Option B SUSTAIN-only (launch at call start, survive mid-call death) → (c) honest "not recorded" state. A clear ladder keeps the UX truthful when the ideal path isn't available.
+
+---
+
+## Relationship to what's shipped / proven
+
+- **Option B (proven):** SUSTAIN fix — every *started* recording completes through daemon death. Keeps WD/loopback/keep-alive.
+- **Track A (unproven):** CREATE fix — collapses bootstrap to once-per-boot, could retire loopback and off-WiFi opt-in. Gated on idle-track survival.
+- **Track B (unproven):** new capability — non-acoustic VoIP via privileged output/playback capture. Gated on mic-concurrency + capture-exemption tests.
+- **Track C (reframe):** tiered capability model toward a native install. Hard wall confirmed — zero-ADB full cellular capture is impossible on stock non-root. But Tier 0 (MediaProjection VoIP + speakerphone acoustic, zero dev-options) + Tier 1 (one-time on-device pairing, then autonomous via Track A) + Tier 2 (root) make the daemon *invisible infrastructure* rather than a door barrier.
+
+Update this doc as each probe runs. Cross-referenced from `spike-audio-handoff.md` §7 and memory `spike-audio-handoff-status`.

--- a/docs/dev-notes/spike-audio-handoff.md
+++ b/docs/dev-notes/spike-audio-handoff.md
@@ -1,0 +1,504 @@
+# Spike: Persistence Option B — Audio-Capture Handoff
+
+**Branch:** `spike/audio-handoff` (off `main` @ v1.4.5). `main` is UNTOUCHED and released.
+**Status:** M1–M2c ✅ · **M3a ✅** · **M3b-1/-2 ✅** · **M3d ✅ (refcount keep-alive)** · **M3b-3 ✅ (daemon→app binder handoff via manual symbol resolution + BinderDelivery)** · **M3c ✅ (track SURVIVES a real daemon kill — keep-alive PROVEN end-to-end on A16)** · **M3e ✅✅ OPTION B FULLY PROVEN** — after a real daemon kill the app keeps the track CAPTURING REAL audio (survives + drives the FIFO via w46 drain + not silenced). The whole chain works end-to-end on A16.
+**Devices:** primary = OnePlus 12 / CPH2581 (`OP595DL1`), **Android 16 / SDK 36**, serial `6011b07e`. Secondary portability check = OnePlus 9 Pro / LE2121, **Android 14 / SDK 34**, serial `daabf34f`. Both `arm64-v8a`.
+**OUTCOME: the spike concluded and SHIPPED.** Option B is now the "Resilient recording" opt-in (default OFF); the throwaway scaffolding has been removed and the surviving code lives in production packages — see [What shipped](#8-what-shipped).
+
+This file stays as the research record: the milestones below describe probes that no longer exist in the tree, and the paths they cite are pre-productionisation.
+
+> Living document — appended each session. Newest milestone last. Keep the [Scorecard](#scorecard) and [Resume checklist](#resume-checklist) current.
+
+---
+
+## 1. Why this spike exists
+
+CallVault records calls via a **shell-uid (2000) `app_process` daemon** launched over embedded ADB. The daemon holds the privileged audio-capture permission the app process lacks. Two things kill the daemon:
+
+1. **Screen-off / lock** restarts `adbd` on OnePlus/Xiaomi/Samsung → kills the shell daemon. *Mitigated* in v1.4.5 by the USB "Charging only" default (stops the USB gadget cycling). Universal, unfixable in-app otherwise (even Shizuku hits this).
+2. **Idle reap** (~3–30 min). *Mitigated* by the keep-alive foreground service (validated ~30 min).
+
+Both are mitigations, not cures. **Option B** is the ambition to make a recording *survive the daemon dying mid-call* — i.e. hand the live capture to the always-alive app process so killing the daemon doesn't stop it. If it works, it beats every non-root competitor (SCR, Shizuku-based) on mid-call resilience.
+
+### The AudioFlinger theory (from AOSP `frameworks/av` review)
+
+- A record track is torn down by the **RecordHandle binder REFCOUNT**, *not* a death-recipient. When the client's `sp<media::IAudioRecord>` (a `BpBinder` proxy) is destroyed, the binder driver notifies the server → refcount drops → track destroyed.
+- The `CAPTURE_AUDIO_OUTPUT` / `VOICE_CALL` permission is checked **only at `createRecord`**, against the pinned shell uid. There is **no per-read check**.
+- Reading audio = a **shared-memory FIFO** (`audio_track_cblk_t` + data in one ashmem region) — pure `mmap`, no permission.
+
+**⇒ If the always-alive app co-holds the `IAudioRecord` binder (a second client ref), the shell dying won't destroy the track, and the app can keep reading the FIFO.** The #1 risk is **appop SILENCING** (zero-filling the track after the shell uid dies) — untested until we have a live track.
+
+---
+
+## 2. The core obstacle: linker namespaces
+
+To hand off the `IAudioRecord` binder + cblk fd, *some* code we control must touch platform binder/audio objects (`libaudioclient`, `libbinder`). Android's `nativeloader` decides a library's linker namespace from the **classloader that loads it**, not the process uid. A normal-app APK → **isolated namespace** with no access to `/apex` platform libs. This is the wall the whole spike navigates.
+
+---
+
+## 3. Milestone log
+
+### M1 — App process can't reach platform audio libs ✅ (commit `1feb9ac`)
+
+Set up NDK `27.2.12479018` + CMake `3.22.1`, `externalNativeBuild`, a JNI `.so` (`libaudiohandoff.so`), and a probe called from `CallVaultApplication.onCreate` (the **app** process).
+
+**Result:** the `.so` loads (toolchain OK) but the app process **cannot** dlopen platform libs:
+```
+dlopen FAIL: libaudioclient.so (library "libaudioclient.so" not found)   [namespace clns-9]
+```
+**Conclusion:** capture-creation cannot happen in the app process.
+
+---
+
+### M2 — JVM daemon `.so` is ALSO sealed ✅ (decisive)
+
+Loaded the same `.so` into the **daemon** (`app_process`, uid 2000) by explicit path (`useLegacyPackaging=true` extracts it to `<apkDir>/lib/arm64/`, then `System.load(path)`), and probed there.
+
+**Result — a *different*, decisive failure:**
+```
+Load libaudiohandoff.so using isolated ns clns-1
+  (default_library_paths=/system/lib64:/system_ext/lib64, permitted_paths=/data:/mnt/expand)
+dlopen FAIL: libaudioclient.so
+  (libdl_android.so ... not accessible for the namespace "clns-1")
+dlopen NOLOAD libandroid_runtime.so : not reachable
+dlopen NOLOAD libbinder.so          : not reachable
+dlsym RTLD_DEFAULT javaObjectForIBinder : null
+dlsym RTLD_DEFAULT defaultServiceManager: null
+```
+The daemon **finds** `libaudioclient` in `/system/lib64` but can't resolve its `/apex` transitive dep. And the escape hatch (borrow framework libs `app_process` already loaded) is **closed** — `RTLD_NOLOAD`/`RTLD_DEFAULT` see nothing, because a `System.load`-ed lib is sealed in an isolated namespace regardless of uid or what's resident in the process.
+
+**Conclusion:** the **vessel** (a `.so` loaded into the JVM via the app classloader) is the problem, not the privilege. The daemon *can* create captures via the **Java** `AudioRecord` (that's how recording works today — the *framework* loads `libaudioclient` in its own bootclasspath namespace) — we just can't reach those platform objects from our own loaded code.
+
+---
+
+### M2b — Standalone native executable IS the vessel ✅ (green light)
+
+A raw ARM64 ELF, `exec`'d **directly** by the daemon (not loaded via the JVM classloader), gets the linker **default** namespace — like any `/system/bin` tool. Packaging trick: build an `add_executable` target but name it `libaudiohandoffprobe.so` so gradle ships it in `lib/arm64/` (extracted `0755` = executable).
+
+**Result (uid 2000):**
+```
+dlopen OK  : libbinder.so
+dlopen OK  : libaudioclient.so          ← all transitive deps resolved
+dlopen OK  : libutils.so / libaudioclient_aidl_conversion.so / libpermission.so / libaudiofoundation.so
+dlsym  OK  : IPCThreadState::self
+VERDICT: standalone-exec default-namespace platform access = AVAILABLE (green light)
+```
+**Conclusion:** the standalone-exec vessel bypasses the namespace seal entirely. Option B is buildable through it.
+
+---
+
+### M2c — The namespace-restricted app CAN be the surviving reader ✅ (green light)
+
+Validated the app-side read path in isolation. The **daemon** creates an ashmem FIFO (via public `ASharedMemory_create` — a public NDK lib, allowed even in the isolated app namespace) + a writer thread advancing a magic + frame counter, and hands the fd to the **app** over the existing `IRecorderService` binder as a `ParcelFileDescriptor` (new spike AIDL `spikeStartFifoProbe(int)`). The app `mmap`s and reads it natively.
+
+**Result — two separate processes, live:**
+```
+[daemon uid 2000] nativeCreateFifo: fd=63 size=8192 writer started
+[app   untrusted] m2c APP-SIDE FIFO READ: magic=0xCA11F1F0 (MATCH) w0=1 w1=30 advanced=YES dataByte0=30
+```
+The app saw the writer's counter advance `1 → 30` over 300 ms, using only libc `mmap` + atomics (no `libaudioclient`). fd delivery over binder is SELinux-safe (no raw cross-uid socket).
+
+**Conclusion:** the app can survive as the reader of an ashmem cblk. The entire app-side crux is proven. Only the binder-refcount keep-alive + silencing remain (need a real track).
+
+---
+
+### M3a — Native `android::AudioRecord` in the helper 🟡 (in progress, ~80%; commit `8cb1b18`)
+
+The helper (`libaudiohandoffprobe.so capture mic`) creates a real `android::AudioRecord` by dlsym'ing libaudioclient's **mangled C++ symbols** (pulled with `llvm-nm` from the device's `/system/lib64/libaudioclient.so`).
+
+**Proven working:**
+- ✅ **ABI binding correct** — `set()` logs back the exact 18 params I passed; no crashes.
+- ✅ **`ProcessState::self()` via the x8 struct-return trick** — returns a valid pointer. (An `sp<>` is returned in memory via x8 on AAPCS64; modelled with a non-trivially-copyable 1-pointer struct so the compiler uses x8.)
+- ✅ Over-allocated object (`calloc(8192)`) + placement ctor; `getMinFrameCount`=640 → frameCount 1280.
+- ✅ **Permission works** — uid 2000 gets *past* the audio policy `getInputForAttr` (no `PERMISSION_DENIED`), reaching `AudioFlinger::createRecord`.
+
+**Blocker:** `createRecord` returns **`-22` (BAD_VALUE)**:
+```
+set(): inputSource 1, sampleRate 16000, format 0x1, channelMask 0x10, frameCount 1280, transferType 3,
+       attributionSource AttributionSourceState{pid: N, uid: 2000, deviceId: 0, packageName: (null),
+       attributionTag: (null), token: (null), ...}
+createRecord_l(0): AudioFlinger could not create record track, status: -22
+```
+The attribution has `packageName=(null)` + `token=(null)`. The Java path always supplies them (AppOps needs the package to attribute `RECORD_AUDIO` to uid 2000).
+
+**Why hand-writing the attribution failed:** `AttributionSourceState` is a polymorphic `Parcelable` (vtable @ 0). Setting fields by byte offset works for `pid`/`uid` (ints) but is fragile for `std::optional<std::string>` / `sp<IBinder>`. A test write of `packageName` at a guessed offset landed in **`deviceId`** instead — proving the real memory field order is `pid, uid, deviceId, packageName, …` (= toString order, NOT the AIDL declaration order). See the evidence: `deviceId: 1836016418` = `0x6D6F632E` = ASCII bytes of the package string.
+
+**Fix CODED + COMPILED offline (commit `5782d23`), not yet run on device:** built the `AttributionSourceState` via a **`Parcel` round-trip** in `buildAttribution()`. The AIDL **wire format order was derived by disassembling the device's own `writeToParcel`** (`llvm-objdump` on the pulled `libpermission.so`):
+```
+int32 parcelable_size (patched) · int32 pid · int32 uid · int32 deviceId ·
+writeUtf8AsUtf16 packageName · writeUtf8AsUtf16 attributionTag ·
+writeStrongBinder token · writeUtf8VectorAsUtf16Vector renouncedPermissions · <array> next
+```
+The helper writes that exact layout with low-level `Parcel` methods (so it never constructs a platform `optional<std::string>`): `writeInt32` for the ints; `packageName` as a raw String16 wire (`writeInt32(len)` + `Parcel::write` of `(len+1)` UTF-16 units); `attributionTag`/`renouncedPermissions` as `writeInt32(-1)` (null); `token` via `writeStrongBinder(&null)`; `next` as `writeInt32(0)` (empty). Then it patches `parcelable_size`, rewinds, and calls the exported virtual `readFromParcel` on the vtable-initialised object → **the platform's own libc++ constructs the members correctly, zero layout guessing.** Sets `packageName="com.android.shell"`, `uid=2000`; **token still null this pass**.
+
+All Parcel/readFromParcel symbols verified present in the device binaries (see table). Compiles + packages clean.
+
+**Validated on a 2nd device (OnePlus 9 Pro, Android 14 / SDK 34) via `adb shell` push+run** — see M3a-portability below. The Parcel round-trip WORKS (packageName + token now correctly populate), but `createRecord` **still returns `-22` with a COMPLETE attribution** → the `-22` is NOT attribution completeness; the cause is elsewhere in the `createRecord` request.
+
+**⏭️ NEXT SESSION (main device, Android 16 / OnePlus 12):** diff my native `createRecord` request against the **working Java `DirectAudioRecorderSession`** (log the Java path's attribution + params, or capture what the framework passes to native `set()`), to find what differs and causes `-22`. Also test `capture voicecall` (the real target) during an active call.
+
+---
+
+### M3a-portability — cross-check on Android 14 (OnePlus 9 Pro, SDK 34)
+
+Tested the native capture on a second device with **`adb shell` push+run** — no app/daemon/pairing needed, because `adb shell` already runs as uid 2000 (shell) in the default namespace, the exact daemon context:
+```bash
+unzip -o -j app/build/outputs/apk/release/*.apk lib/arm64-v8a/libaudiohandoffprobe.so -d /tmp/
+adb push /tmp/libaudiohandoffprobe.so /data/local/tmp/cvprobe && adb shell chmod 755 /data/local/tmp/cvprobe
+adb shell /data/local/tmp/cvprobe capture mic        # stdout shows the CV log lines directly
+```
+This is the **preferred M3a test harness** going forward (simpler than the app/daemon path).
+
+**Findings (all valuable, portability-relevant):**
+1. **Symbols identical across Android 14 & 16** — every AudioRecord/Parcel/readFromParcel/ProcessState symbol resolved with the same mangling. The native approach is portable at the symbol level.
+2. **`AttributionSourceState` wire format is version-specific.** Android **15+ (API 35)** inserts an `int32 deviceId` after `uid`; **Android 14 has no such field**. My Android-16 wire format broke A14's `readFromParcel` (`status=0x80000008`). Fixed: `buildAttribution(withDeviceId)` — picks by SDK (`>=35`) and **retries the other variant** if `readFromParcel` fails, so it auto-adapts to any version. On A14 it selects no-`deviceId` and `readFromParcel` returns 0. *(Derived A14's order by disassembling its `writeToParcel`: `size,pid,uid,packageName,attributionTag,token,renouncedPermissions,next`.)*
+3. **Parcel round-trip PROVEN on-device** — `packageName` correctly reads back as `com.android.shell` (couldn't verify offline last session).
+4. **Added a local `BBinder` token** (a null token was the suspect). No refcount gymnastics: `readStrongBinder` re-wraps it into an `sp` (incStrong), pinning it via the attribution. `BBinder : public IBinder` → `BBinder* == IBinder*` (first non-virtual base). Token now populates: `token: binder:0x...`.
+5. **`createRecord` STILL returns `-22` with a COMPLETE attribution** (uid=2000 + `com.android.shell` + valid token). ⇒ **the `-22` is not attribution completeness.** AudioFlinger verbose logging was drowned by OnePlus `EffectDapController` spam; the server-side reason didn't surface. Deferred to the main device to diff against the working Java path.
+
+**Guidance honoured:** stopped here rather than deep-debugging `-22` on the non-primary device (it's not Android-14-specific — it also `-22`'d on A16 — so it's a main-path issue best cracked where the working Java reference lives).
+
+---
+
+### M3a — SOLVED ✅ (native AudioRecord captures real PCM; OnePlus 9 Pro / Android 14)
+
+Root cause of `createRecord=-22`: **`AUDIO_SESSION_ALLOCATE` was hardcoded as `-1`, but it is `0`.** `-1` is `AUDIO_SESSION_OUTPUT_STAGE` — an invalid session for a record track, so `createRecord` rejected it. It was constant across every sweep config, which is why *all* of them failed identically.
+
+**How it was found — the Java-reference diff (reusable technique).** The native `AudioRecord::set()` logs its full request under tag `AudioRecord` *regardless of caller*. So a **working shell-uid Java `AudioRecord`** run via `app_process` produces a directly-comparable `set():` line — the ground truth. Build + run:
+```bash
+# scratchpad/javaref/Ref.java (saved in repo at docs/dev-notes/spike-tools/Ref.java)
+javac -cp $ANDROID_HOME/platforms/android-34/android.jar -d classes Ref.java
+$ANDROID_HOME/build-tools/34.0.0/d8 --lib .../android.jar --output cvref.jar classes/cvref/Ref.class
+adb push cvref.jar /data/local/tmp/cvref.jar
+adb shell "CLASSPATH=/data/local/tmp/cvref.jar app_process /data/local/tmp cvref.Ref"
+adb logcat -d | grep -E "CVRef|AudioRecord: set\(\)"
+```
+The Java ref **worked** as shell (uid 2000) on Android 14: `getState=INITIALIZED`, `RECORDING`, `CAPTURE peak=5572 REAL` — proving shell *can* record here and isolating the `-22` to the raw-native request.
+
+**The diff table (the ground truth for any device):**
+
+| Variable (native `set()`) | Java ✅ works | native ❌ `-22` | native ✅ fixed | Notes |
+|---|---|---|---|---|
+| inputSource | 1 (MIC) | 1 | 1 | same |
+| sampleRate | 16000 | 16000 | 16000 | same |
+| format | 0x1 (PCM_16) | 0x1 | 0x1 | same |
+| channelMask | 0x10 (IN_MONO) | 0x10 | 0x10 | same |
+| frameCount | 2048 | 1280 | 1280 | both ≥ min(640); not the cause |
+| notificationFrames | 0 | 0 | 0 | same |
+| **sessionId** | **0** | **-1** ❌ | **0** ✅ | **THE BUG.** `AUDIO_SESSION_ALLOCATE=0`, not -1 |
+| transferType | 0 (DEFAULT) | 3 (SYNC) | 3 | 3 is fine (SYNC = read-based); not the cause |
+| flags | 0 | 0 | 0 | same |
+| attribution uid / pkg / token | 2000 / com.android.shell / binder | identical | identical | attribution was never the issue |
+
+**Result after fix (native, adb shell push+run):** `set()=0`, `start()=0`, `CAPTURE 51200 bytes peak=14033 REAL`. **Native privileged capture in the helper works.**
+
+**Constants double-checked (stable across versions — reuse on the main device as-is):** `AUDIO_SOURCE_MIC=1`, `AUDIO_SOURCE_VOICE_CALL=4`, `AUDIO_FORMAT_PCM_16_BIT=0x1`, `AUDIO_CHANNEL_IN_MONO=0x10`, `AUDIO_CHANNEL_IN_STEREO=0xc`, **`AUDIO_SESSION_ALLOCATE=0`**, `TRANSFER_SYNC=3`, `AUDIO_INPUT_FLAG_NONE=0`, `AUDIO_UID_INVALID=(uint32)-1`.
+
+**For the main device (OnePlus 12 / Android 16) — should be zero-friction:** the session fix is a universal constant, symbols are identical (verified), and the attribution is version-adaptive. Just `adb shell /data/local/tmp/cvprobe capture mic` → expect `capture=WORKS audio=REAL`. If anything differs, re-run the Java ref (`cvref.jar`) and diff the `set():` line the same way. Then test `capture voicecall` during a live call (source=4, same path).
+
+---
+
+### M3b — the handoff (in progress)
+
+**M3b-1 ✅ (OnePlus 9 Pro / Android 14): extract the cblk fd offset-free + prove a 2nd mapping reads live audio.**
+After the native `AudioRecord` starts, the cblk ashmem is mapped and its fd is open in-process — so it's discoverable **without any member offsets** by scanning `/proc/self/fd` + `/proc/self/maps`:
+- `/proc/self/fd`: the cblk fd shows as `fd N -> /dev/ashmem<uuid>` (`fstat` size reads 0 for ashmem — use `ioctl(fd, ASHMEM_GET_SIZE=0x7704)` → **8192**).
+- `/proc/self/maps`: the region is `rw-s … /dev/ashmem/MemoryHeapBase (deleted)`, size `0x2000` (8192).
+
+Independently `mmap`-ing that fd (PROT_READ, MAP_SHARED — what the app will do) sees the **live** cblk: control words advance (`word[0] 0→1280`, etc. = `audio_track_cblk_t` positions) and **real PCM is present** (`peak=31742`). **The `audio_track_cblk_t` header + the audio ring buffer share the SAME 8192-byte ashmem** → one fd carries everything.
+
+⇒ Combined with **M2c** (passing an ashmem fd to the app over the daemon binder as a `ParcelFileDescriptor`), the **cross-process cblk read is effectively solved**: helper discovers the cblk fd via `/proc/self/fd` → hands it to the app (PFD or `SCM_RIGHTS`) → app `mmap`s + reads. *(Proper in-order FIFO extraction — driving front/rear via the `AudioRecordClientProxy` obtainBuffer/releaseBuffer protocol — is a productionization detail; the spike only needs "2nd mapping sees live audio", which is proven.)*
+
+**M3b-2 ⏭️ (the keep-alive crux — the big remaining chunk): extract + transfer the `IAudioRecord` binder.** The cblk fd does NOT keep the track alive — the AudioFlinger RecordTrack lifetime is tied to the **`IAudioRecord` binder refcount** (`mAudioRecord`, a private `sp<media::IAudioRecord>` in `android::AudioRecord`). The always-alive app must hold a ref on it (a shell-uid helper can't survive screen-lock/idle-reap — only the app process does).
+
+**✅ Binder LOCATED (commit `a8d4e1e`, Android 14) — the SIGSEGV-guarded scan works.** `mAudioRecord` is at **`ar+0x190`** → the `BpAudioRecord`; its `BpRefBase::mRemote` (the `IAudioRecord` `BpBinder`) is at **`+0x10`** (a secondary binder is at `+0x50` — a cached/death ref). This matches the `0x190` offset from the `stop()` disasm. Two techniques were required and are **reusable for any binder extraction**:
+- **Empirical BpBinder vptr** (don't guess the vtable address point). `BpBinder : IBinder : virtual RefBase` has virtual-base-offset entries before the address point, so `symbol+16` is WRONG. Instead get a real BpBinder at runtime — `ProcessState::self()->getContextObject(null)` (servicemanager proxy) — and read its first word as the reference vptr (`_ZN7android12ProcessState16getContextObjectERKNS_2spINS_7IBinderEEE`, returns `sp<IBinder>` via x8).
+- **Allow scudo-tagged pointers.** Android tags heap pointers in the top byte (e.g. `0xb4…`); the CPU ignores it on deref (TBI). Range-check the **untagged** address (`v & 0x00FFFFFFFFFFFFFF`), else every real pointer is rejected.
+
+Guard the scan with a `sigsetjmp`/SIGSEGV+SIGBUS handler. Safe to run single-threaded: `TRANSFER_SYNC` + null callback means **no** concurrent `AudioRecordThread`.
+
+**Alternative (cleaner binder, heavier marshalling):** call **`AudioFlinger::createRecord` directly** via AIDL — the `CreateRecordResponse` has `.audioRecord` (IAudioRecord) + `.cblk` (SharedFileRegion→fd) + `.buffers`, bypassing the `AudioRecord` helper. Reuses the Parcel machinery already built for the attribution. Consider this if the member offset (`ar+0x190`/`+0x10`) proves unstable across devices — but the offset-free scan should re-derive it per device anyway.
+
+**Transfer:** hand the binder to the app via a binder transaction (the app hosts a receiver AIDL and survives; the helper `writeStrongBinder`s the IAudioRecord to it), or register it with servicemanager. The app then holds the ref (keep-alive) + mmaps the cblk fd (M3b-1) + drives the FIFO read.
+
+**M3c** = kill the creator (daemon+helper) → confirm the RecordTrack survives (cblk `server` pos keeps advancing = refcount theory holds) + audio stays REAL, not zero-filled (appop **silencing** — risk #1). MIC first, then VOICE_CALL.
+
+**⏭️ M3b-3 + M3c — the final phase (needs app integration, can't be done in the `adb shell` harness).** All extraction is proven; what remains is transferring the binder to a *surviving* process and the kill/survive test. Two real binder endpoints are required — shell likely can't `addService` arbitrary names, and `fork()` in a binder process is unsafe. Plan in the real architecture:
+1. Wire the capture helper into the daemon (daemon `exec`s it; or fold the native code into the daemon path). Helper extracts cblk fd (`/proc/self/fd`) + `IAudioRecord` binder (`ar+0x190`→`+0x10`).
+2. Helper/daemon hands both to the **app** over the existing `IRecorderService` binder: cblk fd as a `ParcelFileDescriptor` (proven in m2c); the `IAudioRecord` `IBinder` via a new spike AIDL method (`writeStrongBinder` — the app is a real binder endpoint).
+3. App holds the `IBinder` (keep-alive ref) + `mmap`s the cblk fd + drives the FIFO read (port `AudioRecordClientProxy` obtainBuffer/releaseBuffer, ~50 lines).
+4. **Kill the daemon + helper.** Observe in the app: does the cblk `server` position keep advancing (track alive → refcount theory holds)? Is the audio REAL or ZERO-filled (silencing)? MIC first, then VOICE_CALL during a live call.
+This is the decisive Option-B validation; do it on the **main device (A16/OnePlus 12)** where the daemon/app/pairing already exist.
+
+**M3c-fork — a preliminary kill-and-observe on OP9 (commit `4ba5f49`).** Since a real cross-process transfer needs the app, I did the tractable approximation: `fork()`, parent captures ~3s then `_exit`s with **no `stop()`/dtor** (real-kill sim), child (inheriting the cblk mmap + binder fd) watches the cblk.
+- **Result:** the cumulative frame counter (`cblk w0`/`w18`/`w20`) advances while the parent lives (`1280→19200→35200`), then **FREEZES ~1s after the parent dies** (`48640`, stays frozen), and a flag word `w2` flips `0→1` at death. `peak` stays high only because that's **stale** ring audio (no new frames).
+- **This does NOT disprove Option B.** `fork()` is not a valid keep-alive vector — the child shares the parent's `binder_proc` (whose binder buffer is tied to the dead parent's `mm`), so it never held a genuine independent driver ref. A proper transfer gives the **app its own `binder_proc` ref**, which fork can't replicate.
+- **Value:** (1) a clean **liveness monitor** for the real test — watch `cblk w0`/`w18`/`w20` (cumulative captured frames); alive ⇒ advancing, dead/stopped ⇒ frozen. (2) It sharpens the decisive question: is the freeze from the **refcount dropping** (a proper app ref prevents it → Option B works) or the **framework stopping the track on client-death** (kills Option B regardless of refs)? Only the app transfer distinguishes these — that's THE thing to determine on the main device.
+- Note: shell can't toggle appops (`appops set` needs `MANAGE_APP_OPS_MODES`), so the appop-silencing *proxy* test isn't runnable as shell; silencing must be observed via the real kill on the main device.
+
+### M3d — refcount keep-alive CONFIRMED ✅ (in-process, ping-based; OP12/A16, commit `4f8e309`)
+
+The decisive mechanism question — *does an independent ref keep the track alive after the creator's client ref goes away?* — answered **YES** in-process, cleanly:
+- Create `AudioRecord` + start. Take an **independent** strong ref on the `IAudioRecord` via a `Parcel` `writeStrongBinder`→`readStrongBinder` round-trip (adds a real local strong ref; no vbase math for my ref).
+- **Release the `AudioRecord`'s own client ref** by destroying its `BpAudioRecord` — `RefBase::decStrong` on it, located via the **vbase offset** (`vptr-24` → `vbase=40` → `RefBase*`, validated by `mRefs` being a plausible pointer). This drops the client ref **without** an explicit `stop()`.
+- **Liveness via a REAL transaction:** `BpBinder::pingBinder()` (`_ZN7android8BpBinder10pingBinderEv`) to the `RecordHandle` returns **`0` (alive)** for the full 6s afterward, held only by the independent ref. (`isBinderAlive()` agreed, but it's a cached flag — the ping is the trustworthy signal.)
+
+⇒ **Track lifetime = `IAudioRecord` binder refcount, PROVEN on the real device.** Releasing the client ref does not tear down the track while another ref is held. This is a **major de-risk**: a proper app-held ref should keep the track alive when the daemon drops its ref on death.
+
+**Corrects the M3c-fork reading:** its `w0` freeze meant *the reader (parent) died* (no one draining the FIFO), NOT that the track died — `w0` is a read-driven position. The ping-based signal supersedes it.
+
+**The ONE remaining risk (still needs real cross-process death):** does the **appop `finishOp` on the creating uid/pid's DEATH** silence/stop the track even with a ref held? The refcount teardown — the likeliest killer — does *not* fire on ref release, so this is now the sole open question, and it's answered only by the app-transfer + real-kill test.
+
+New reusable symbols (A16): `RefBase::inc/decStrong` (libutils) `_ZNK7android7RefBase9inc/decStrongEPKv`; `BpBinder::pingBinder` `_ZN7android8BpBinder10pingBinderEv`, `isBinderAlive` `_ZNK7android8BpBinder13isBinderAliveEv`; `Parcel::readStrongBinder` `_ZNK7android6Parcel16readStrongBinderEPNS_2spINS_7IBinderEEE`. Technique: locate a virtual-`RefBase` subobject via the vtable vbase-offset slot at `vptr-24`.
+
+*(Note: USB "Charging only" already prevents the screen-lock adbd-kill in prod (v1.4.5); Option B targets the idle-reap case + general resilience, where only the app reliably survives — hence the binder must live in the app.)*
+
+### M3b-3 + M3c — APP INTEGRATION: track SURVIVES daemon death ✅ (OP12/A16, commits `716f3f4`,`a1b7f42`,`b2b1334`)
+
+The full cross-process handoff, built on the real app/daemon:
+
+1. **Manual symbol resolution** (`audiohandoff.cpp` `manualResolve`): the daemon's `.so` is in the isolated classloader namespace (can't dlsym `libandroid_runtime`), so compute a function's runtime address = `/proc/self/maps` load base + on-disk ELF `.dynsym` `st_value`. Resolved `javaObjectForIBinder` @ `base+0x1faa70`. ✅
+2. **Daemon extracts + wraps** (`HandoffSpike` + `nativeExtractBinder`): create a Java `AudioRecord(MIC)` (framework loads `libaudioclient` in ITS namespace), find the native `android::AudioRecord*` in the Java object's `mNativeAudioRecordHandle` long field (auto-validated via `nativeValidateArPtr`), read the `IAudioRecord` `BpBinder` at `ar+0x190→+0x10`, and wrap it into a Java `IBinder` (BinderProxy) via the manually-resolved `javaObjectForIBinder`. `pingBinder()`=true → it's the real live RecordHandle. ✅
+3. **Deliver to the app** over the EXISTING `BinderDelivery` (new `sendHandoff` method + `RecorderBinderProvider` handler): the `IAudioRecord` (in a `BinderContainer`) + the cblk fd (as a `ParcelFileDescriptor`). The app (`HandoffReceiver`) holds the `IBinder` in ITS OWN `binder_proc` — a proper independent ref. Trigger: app calls `IRecorderService.spikeStartHandoff()`.
+4. **KILL the daemon** (`pkill app_process RecorderServer`).
+
+**RESULT (decisive):**
+```
+t=6s  ping(alive)=true
+CV:RecorderConn: Daemon binder died; clearing RecorderConnection   ← daemon process confirmed dead
+t=7s..t=34s  ping(alive)=true   ← IAudioRecord RecordHandle STILL ALIVE
+```
+⇒ **The privileged capture track SURVIVES the creating daemon's death, held alive by the app's independent ref. Option B's keep-alive is PROVEN end-to-end on the real device.** (Matches M3d's in-process refcount result, now demonstrated cross-process with a real kill.)
+
+**Silencing / active-capture — STILL OPEN, and harder than expected.** RE'd the record cblk via the probe read loop @16kHz: `w[0]`/`w[18]`/`w[20]` = frame position (advance 16000/sec while reading; `w[0]` = server "rear" cumulative frames), `w[2]=1`/`w[3]=320`/`w[4]=0xE0006000` = const flags, `w[15]` = slow poll counter, `w[28..31]` = a ns timestamp. **But a memory-only drain does NOT sustain capture:** in the `CV_DRAIN` test (read 2s to keep the track active, then stop `AudioRecord::read` and manually advance `w18=w20=rear`), `w[0]` FREEZES (buffer full at `mFront+frameCount`) and the ring peak goes stale — the server stopped capturing. Advancing `w18`/`w20` doesn't restart it: either they aren't the effective `mFront`, or (likely) **the RecordThread STANDBYs once no *active* (libaudioclient) client is reading**, and a raw memory poke doesn't register as active.
+
+⇒ *(Initial worry — RESOLVED below.)* The "standby" read was a **red herring**: it was the wrong `mFront` word.
+
+### M3e — SOLVED: OPTION B FULLY PROVEN ✅✅✅ (OP12/A16, commits `e45b207`,`ca4556e`)
+
+**Found the real `mFront`.** Diffing 64 cblk words, reading vs no-read: `w0`/`w18`/`w20`/`w47` = server "rear"; **`w46` = client `mFront`** (0 when no reader, advances with reads). `w46`/`w47` are the `AudioTrackSharedStreaming` `mFront`/`mRear` pair @ offset 184/188.
+
+**Memory drain sustains capture.** Advancing `w46=w47` every 40ms — even with **no `AudioRecord::read` ever** (pure `mmap`, no `libaudioclient`) — keeps `rear(w0)` climbing 16000/sec with real audio. **NOT standby.** The namespace-restricted app can drive the FIFO itself.
+
+**THE COMPLETE TEST (app drives the FIFO across a real daemon kill):**
+```
+t=1..7s   rear(w0) +16000/sec  ringPeak~1400-1900  CAPTURING REAL
+[t~7s]    Daemon binder died         ← daemon process killed
+t=8..17s  rear(w0) +16000/sec  ringPeak~1525-2051  CAPTURING REAL   (daemon DEAD)
+```
+After the daemon dies, the app **keeps capturing new frames** (`rear` advancing) with **real audio** (`ringPeak` non-zero, varying — not zeros). **No silencing.** The appop `finishOp` on the creator's death did NOT zero-fill the track.
+
+⇒ **ALL THREE remaining questions = YES: keep-alive · active-capture-from-the-app · no-silencing. Option B is fully viable on the real device** — a recording continues, with real audio, after the privileged daemon is killed, held + read entirely by the always-alive app. App-side read = pure cblk `mmap` + `w46`→`w47` drain (`nativeMonitorCblk`); this is also the productionization read path.
+
+**New reusable pieces:** `manualResolve` (ELF `.dynsym` runtime resolution — bypasses nativeloader), `nativeExtractBinder`/`nativeValidateArPtr` (Java-AudioRecord → IAudioRecord Java IBinder), method-parametrized `BinderDelivery` + `sendHandoff`. Java-AudioRecord native ptr field on A16 = `mNativeAudioRecordHandle`.
+
+## 4. Reference
+
+### Verified symbols (Android 16 / SDK 36, `libaudioclient.so` unless noted)
+
+| Purpose | Mangled symbol |
+|---|---|
+| AudioRecord ctor (AttributionSource) | `_ZN7android11AudioRecordC1ERKNS_7content22AttributionSourceStateE` |
+| AudioRecord::set (18 args) | `_ZN7android11AudioRecord3setE14audio_source_tj14audio_format_t20audio_channel_mask_tmRKNS_2wpINS0_20IAudioRecordCallbackEEEjb15audio_session_tNS0_13transfer_typeE19audio_input_flags_tjiPK18audio_attributes_ti28audio_microphone_direction_tfi` |
+| AudioRecord::start | `_ZN7android11AudioRecord5startENS_11AudioSystem12sync_event_tE15audio_session_t` |
+| AudioRecord::read | `_ZN7android11AudioRecord4readEPvmb` |
+| AudioRecord::stop | `_ZN7android11AudioRecord4stopEv` |
+| AudioRecord::getMinFrameCount (static) | `_ZN7android11AudioRecord16getMinFrameCountEPmj14audio_format_t20audio_channel_mask_t` |
+| ProcessState::self (libbinder) | `_ZN7android12ProcessState4selfEv` |
+| ProcessState::startThreadPool (libbinder) | `_ZN7android12ProcessState15startThreadPoolEv` |
+| AttributionSourceState vtable (libpermission) | `_ZTVN7android7content22AttributionSourceStateE` (vptr = symbol + 16) |
+| AttributionSourceState::readFromParcel (libpermission) | `_ZN7android7content22AttributionSourceState14readFromParcelEPKNS_6ParcelE` |
+| AttributionSourceState::writeToParcel (libpermission) | `_ZNK7android7content22AttributionSourceState13writeToParcelEPNS_6ParcelE` |
+| Parcel ctor (libbinder) | `_ZN7android6ParcelC1Ev` |
+| Parcel::writeInt32 (libbinder) | `_ZN7android6Parcel10writeInt32Ei` |
+| Parcel::write(void*,size_t) (libbinder) | `_ZN7android6Parcel5writeEPKvm` |
+| Parcel::writeStrongBinder (libbinder) | `_ZN7android6Parcel17writeStrongBinderERKNS_2spINS_7IBinderEEE` |
+| Parcel::dataPosition (libbinder) | `_ZNK7android6Parcel12dataPositionEv` |
+| Parcel::setDataPosition (libbinder) | `_ZNK7android6Parcel15setDataPositionEm` |
+| BBinder ctor — for a token (libbinder) | `_ZN7android7BBinderC1Ev` |
+| RefBase::incStrong — hold the token (libbinder) | `_ZN7android7RefBase9incStrongEPKv` |
+| BpBinder vtable — find IAudioRecord in the object (libbinder) | `_ZTVN7android8BpBinderE` (vptr = symbol + 16) |
+
+M3b-2 note: `media::BpAudioRecord` vtable is NOT exported (can't scan for it); scan for the inner `BpBinder` instead. `ASHMEM_GET_SIZE` ioctl = `0x7704`.
+
+Note: `Parcel::writeString16(const char16_t*, size_t)` is NOT exported → the String16 wire format is reproduced manually with `writeInt32(len)` + raw `Parcel::write`.
+
+- `initCheck()` and `getCblk()` are **inline** (no exported symbol). Gate health on `set()`/`start()` return codes. For M3b, read `mCblk` via a member offset.
+- Get symbols: `~/Library/Android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/*/bin/llvm-nm -D --defined-only <lib>`.
+
+### `AttributionSourceState` memory layout (empirical, Android 16)
+
+```
+offset 0  : vtable ptr        (Parcelable is polymorphic)
+offset 8  : pid   (int32)
+offset 12 : uid   (int32)
+offset 16 : deviceId (int32)
+offset ~24: packageName      std::optional<std::string>
+   then     attributionTag   std::optional<std::string>
+            token            sp<IBinder>
+            renouncedPermissions
+            next             std::vector<AttributionSourceState>
+```
+**Do not** rely on this for writes — use the Parcel round-trip. Layout is here only to interpret logs.
+
+### Key parameter values used (MIC path)
+
+`source=AUDIO_SOURCE_MIC(1)`, `sampleRate=16000`, `format=AUDIO_FORMAT_PCM_16_BIT(0x1)`, `channelMask=AUDIO_CHANNEL_IN_MONO(0x10)`, `frameCount=minFrames*2`, `callback=null wp`, `sessionId=AUDIO_SESSION_ALLOCATE(-1)`, `transferType=TRANSFER_SYNC(3)`, `flags=AUDIO_INPUT_FLAG_NONE(0)`, `uid=pid=-1` (defer to attribution). Switch `source` to `AUDIO_SOURCE_VOICE_CALL(4)` after MIC mechanics work (needs an active call).
+
+### Files (as they were DURING the spike — see [What shipped](#8-what-shipped) for where this code lives now)
+
+| File | Role |
+|---|---|
+| `app/src/main/cpp/CMakeLists.txt` | builds `libaudiohandoff.so` (JNI) + `libaudiohandoffprobe.so` (executable) |
+| `app/src/main/cpp/audiohandoff.cpp` | app/daemon JNI probe (m1/m2) + m2c ashmem FIFO create/read (`ASharedMemory`) |
+| `app/src/main/cpp/audiohandoffprobe.cpp` | standalone exec: m2b reachability probe + **m3a native capture** (`capture mic`) |
+| `app/src/main/java/.../spike/AudioHandoffNative.kt` | JNI bridge (`loadFromPath`, `nativeProbe`, `nativeCreateFifo`, `nativeReadFifo`) |
+| `app/src/main/java/.../server/RecorderServer.kt` | daemon: runs the m2 probe + m2c FIFO create (AIDL) + **execs the m3a capture helper** |
+| `app/src/main/java/.../CallVaultApplication.kt` | app: m1 probe + m2c FIFO app-side read |
+| `app/src/main/aidl/.../IRecorderService.aidl` | spike method `spikeStartFifoProbe(int)` |
+| `app/build.gradle.kts` | `ndkVersion`, `abiFilters arm64-v8a`, `externalNativeBuild`, `packaging{ jniLibs{ useLegacyPackaging=true } }` |
+
+### Build / install / test recipe
+
+```bash
+export JAVA_HOME=/opt/homebrew/opt/openjdk@17
+export ANDROID_HOME=~/Library/Android/sdk
+export PATH="$ANDROID_HOME/platform-tools:$PATH"
+cd ~/Desktop/Projects/callrecorder
+./gradlew :app:assembleRelease -PversionName=1.4.5-spike -PversionCode=<N>   # N > last used (10452)
+adb install -r app/build/outputs/apk/release/*.apk
+adb shell pm grant com.baba.callvault android.permission.WRITE_SECURE_SETTINGS   # dropped on install-over
+adb logcat -c
+adb shell am force-stop com.baba.callvault
+adb shell monkey -p com.baba.callvault -c android.intent.category.LAUNCHER 1
+sleep 16
+adb logcat -d | grep -iE "AudioHandoffExe|AudioRecord:|createRecord|m3a|m2c" | grep -v "child:"
+```
+- **SAME release keystore** (cert `c875ffd0`) so it installs over v1.4.5 — never uninstall (wipes ADB pairing).
+- Keep USB **"File transfer"** for dev (charging-only drops USB adb).
+- The daemon warms at app launch; the capture helper is exec'd from `RecorderServer.main`.
+
+### Diagnostics baked in (per device-specific concern)
+
+The helper logs `ENV[phase] release/sdk/model/brand/device/abi` + every resolved symbol pointer + `set()`/`start()` status on every run (tag `CV:AudioHandoffExe`). Since this native path is Android-version/vendor-specific, **fold these same fields into the production debug report** once capture works, so user reports pinpoint an ABI break on other devices/versions.
+
+---
+
+## 5. Scorecard
+
+| Milestone | Question | Result |
+|---|---|---|
+| M1 | App process dlopen platform libs? | ❌ namespace-sealed (`clns-9`) |
+| M2 | JVM daemon `.so` dlopen platform libs? | ❌ same seal (`clns-1`), decisive |
+| M2b | Standalone exec (uid 2000) dlopen `libaudioclient`+`libbinder`? | ✅ green light |
+| M2c | Namespace-restricted app read a cross-process ashmem FIFO natively? | ✅ green light |
+| M3a | Helper creates a native `AudioRecord` + reads real PCM? | ✅ **DONE** — `set()=0`, `start()=0`, 51200 bytes captured, peak 14033 REAL (Android 14). Bug was `AUDIO_SESSION_ALLOCATE` (0, not -1) |
+| M3a-portability | Symbols/approach portable across Android versions? | ✅ symbols identical A14↔A16; attribution wire format version-specific (deviceId A15+) but auto-adapted; session fix is universal |
+| M3b-1 | Extract cblk fd + prove a 2nd mapping reads live audio | ✅ **DONE** — cblk fd found offset-free via `/proc/self/fd`; 2nd mmap sees advancing words + peak 31742 REAL |
+| M3b-2 | Locate the `IAudioRecord` binder in the object | ✅ **DONE** — `mAudioRecord`@`ar+0x190` → `BpBinder`@`+0x10` (offset-free scan; empirical vptr + tagged-ptr fixes) |
+| M3b-3 | Transfer the binder to the app + hold it | ✅ **DONE** — daemon extracts+wraps via manual symbol resolution, delivers over BinderDelivery; app holds it (ping=true) |
+| M3d | Independent ref keeps track alive after client ref released? | ✅ **CONFIRMED** (in-process, real pingBinder=0 for 6s) — refcount controls lifetime |
+| M3c | Kill daemon → track SURVIVES? | ✅ **PROVEN** — ping(alive)=true past 'Daemon binder died' |
+| M3e | App keeps the surviving track CAPTURING + real audio (no silencing)? | ✅✅ **PROVEN** — app drives the FIFO (w46 drain, no libaudioclient); after the daemon dies it keeps capturing REAL audio (rear advancing, ringPeak non-zero). Option B fully viable |
+
+---
+
+## 6. Resume checklist
+
+1. Read this file + memory `spike-audio-handoff-status.md`.
+2. Phone connected (serial `6011b07e`), USB "File transfer".
+3. **M3a is DONE.** On the **main device (A16/OnePlus 12)** just sanity-run `adb shell /data/local/tmp/cvprobe capture mic` → expect `capture=WORKS audio=REAL` (session fix is universal). Then test `capture voicecall` during a live call (source=4). If anything differs, diff via the Java ref (`docs/dev-notes/spike-tools/Ref.java` → `cvref.jar`).
+4. **M3b (extraction) is DONE** — cblk fd (via `/proc/self/fd`) + `IAudioRecord` binder (`ar+0x190`→`+0x10`) both proven offset-free on A14. Next = **M3b-3 + M3c integration** (needs the app/daemon, do it on the main device): wire the helper into the daemon, hand the cblk fd (PFD) + `IAudioRecord` (`writeStrongBinder`) to the app over `IRecorderService`, app holds the binder + reads the cblk FIFO, then **kill daemon+helper** and observe survival (cblk pos advances) + real-vs-silenced audio. MIC then VOICE_CALL. See §M3b "final phase".
+
+---
+
+## 7. Persistence-architecture implications — what Option B replaces (and what it does NOT)
+
+_(2026-07-25 — code-grounded review of the current bootstrap + recording paths on `spike/audio-handoff`, prompted by the question "the whole point was persistence — can this replace WD / loopback / keep-alive? does it work Wi-Fi off?")_
+
+### The immovable constraint
+
+Non-root `VOICE_CALL` capture requires a **shell-uid (2000) process to CREATE the `AudioRecord`** (only that uid holds `CAPTURE_AUDIO_OUTPUT`/`VOICE_CALL`; the app process is namespace-sealed and can't even `dlopen` the audio libs — M1/M2). The only non-root way to get a shell-uid process is **ADB**, which needs a transport: **WD** (`adb_wifi_enabled`, Wi-Fi-only — `AdbShell.enableWirelessDebugging`) or **classic-tcpip loopback** (off-Wi-Fi, opt-in — `AdbShell.connectLoopback`/`armLoopbackIfNeeded`, `OFFLINE_RECORDING_ENABLED`). **Option B does not touch this chain.**
+
+### The daemon's job splits into two phases
+
+| Phase | What it does today | Needs | Option B effect |
+|---|---|---|---|
+| **CREATE** (call start) | shell-uid daemon creates + `start()`s `AudioRecord(VOICE_CALL)` | ADB (WD/loopback) + shell uid | **unchanged — still required** |
+| **SUSTAIN** (during call) | daemon holds the track, `read()`s, encodes (`MediaCodec`), muxes into the app's SAF fd for the *whole call* (`DirectAudioRecorderSession`) | daemon alive for the entire call | **ELIMINATED** — daemon hands `IAudioRecord`+cblk to the app at call start; app reads the ring + encodes into its own fd; daemon may die |
+
+Today a mid-call daemon death is fatal and explicitly unrecoverable — `AudioRecordingEngine.kt:180-182` (`livenessWatch`, one-shot): _"Recorder daemon binder died while a recording is live — no audio is being captured … the daemon-mode pipeline cannot recover mid-call."_ Option B deletes that failure mode: **any recording that STARTS will COMPLETE**, regardless of what kills the daemon mid-call (screen-off adbd kill, Athena ~30-min reap, WD churn — all become harmless once capture is underway).
+
+### The three questions, answered honestly
+
+- **Is WD still necessary?** **Yes.** Still needed to launch the daemon so it can CREATE the track at call start. Option B removes the daemon's need to *survive the call*, not its need to *exist when the call begins*.
+- **Is loopback still necessary?** **Yes, for off-Wi-Fi.** Its only job is launching/relaunching the daemon without Wi-Fi. Option B provides no transport — it changes *who holds the track after creation*.
+- **Does it work Wi-Fi off?** **Only under today's condition** — offline recording opted-in + loopback armed (arming needs Wi-Fi+WD once, clears on reboot). Option B does not independently unlock off-Wi-Fi.
+
+### What CAN be replaced / degraded / removed
+
+- ✅ **The mid-call daemon-death failure mode** — `AudioRecordingEngine.livenessWatch`'s one-shot "cannot recover" becomes moot; the recording survives daemon death outright. **Headline win.**
+- ✅ **The USB "Charging only" screen-lock workaround (shipped 1.4.5) loses its critical role** — it existed to stop the screen-off adbd kill from killing a *live* recording; with Option B that kill is harmless mid-call. (May still marginally help keep the daemon warm *between* calls, but it no longer protects recordings.)
+- ✅ **Mid-call resume / fast-recovery work becomes unnecessary** — nothing to recover; the recording never stops. (This was previously flagged as "our edge over SCR"; Option B makes it obsolete by prevention.)
+
+### What CANNOT go away
+
+- ❌ **WD / ADB bootstrap** — daemon must be launchable at call start.
+- ❌ **Loopback** — still the only off-Wi-Fi launch path.
+- ❌ **Daemon keep-alive** (`DaemonKeepAliveService`) — still needed so the daemon is up (or launchable in ~1–2 s) *when a call rings*. Its role narrows from "survive the whole call" to "be ready at the start," but it doesn't disappear.
+
+### The one remaining gap for true "record no matter what"
+
+Option B guarantees the SUSTAIN half. The only surviving risk is the **START**: the daemon must be alive, or launched fast enough, at the instant a call begins (the cold-start / bootstrap problem — untouched by Option B).
+
+### 🔬 Speculative future path — eliminate the CREATE dependency too (UNPROVEN, worth investigating)
+
+> Expanded into its own research doc with code-grounded "what it replaces" + a VoIP capture track + creative ideas: **`docs/dev-notes/capture-research-directions.md`** (Track A). Summary below.
+
+Have the app hold a **pre-created, idle `VOICE_CALL` `AudioRecord`+cblk across calls** — created once by a briefly-alive daemon (e.g. post-boot / post-onboarding), then handed off and held indefinitely by the always-alive app. If an idle `VOICE_CALL` track simply starts yielding audio when a call becomes active, then **no daemon is needed at call start at all** — the app is already holding the capture, and the ADB/WD/loopback bootstrap collapses to a one-time (or occasional re-arm) event rather than a per-call requirement. This is the ONLY route that would drop the per-call daemon dependency entirely.
+
+**Open risks to validate before betting on it:**
+- **Idle silencing** — the appop/UID-state monitor may zero-fill (or the RecordThread may STANDBY) a track that has no active reader / whose creator uid goes non-foreground (the M3e silencing risk, but across hours of idle rather than seconds).
+- **Multi-hour track validity** — does an `IAudioRecord` + cblk survive doze / audio-policy reconfig / route changes for hours, and resume cleanly when a call starts?
+- **Does `VOICE_CALL` gate on an active call at CREATE or at data-time?** — if `getInputForAttr` refuses to create a `VOICE_CALL` input when no call is active, you'd have to create it *at* call start anyway (defeating the point), or hold a MIC/other-source track and switch — needs a probe.
+- **Battery** — an always-open capture track's cost.
+- **Re-arm after reboot** — tcpip/loopback clears on reboot, so the daemon still needs one connectivity moment post-boot to re-create the held track; not fully "zero daemon," but "daemon once per boot" instead of "daemon per call."
+
+Cheap first probe: on the main device, create a `VOICE_CALL` `AudioRecord` in the daemon with NO call active, hand off to the app, hold idle 10–30 min through screen-off/doze, then place a call and check whether the held track produces real audio without re-touching the daemon.
+
+---
+
+## 8. What shipped
+
+Option B shipped as **"Resilient recording"** — a Settings ▸ Reliability opt-in, default **OFF**. With the
+toggle off the recording path is unchanged, so the feature is fully reversible in-app.
+
+### Where the code lives now
+
+| Path | Role |
+|---|---|
+| `app/src/main/cpp/audiohandoff.cpp` | JNI: validate + extract the `IAudioRecord` binder, find the cblk fd, drain the ring to a pipe |
+| `.../services/recording/handoff/HandoffSource.kt` | DAEMON: creates the privileged `AudioRecord`, extracts + delivers it |
+| `.../services/recording/handoff/HandoffReceiver.kt` | APP: holds the binder (keep-alive), starts drain + encode, releases at call end |
+| `.../services/recording/handoff/HandoffEncoder.kt` | APP: PCM pipe → `MediaCodec` → `MediaMuxer` into the SAF fd |
+| `.../services/recording/handoff/HandoffGeometry.kt` | cblk ring geometry + the validation that gates every native mmap |
+| `.../services/recording/handoff/AudioHandoffNative.kt` | JNI bridge (app loads by name, daemon loads by path) |
+| `.../integrations/scrcpy/ScrcpyAudioSourceMapping.kt` | shared cliKey → `MediaRecorder.AudioSource` map (which sources support the handoff) |
+| `.../utils/PcmDownmix.kt` | shared stereo→mono downmix (both capture pipelines) |
+| `app/src/main/aidl/.../IRecorderService.aidl` | `startHandoff(source, rate, channels)` / `stopHandoff()` |
+
+Build config that is **required, not scaffolding**: `ndkVersion`, `ndk { abiFilters }`,
+`externalNativeBuild`, `buildFeatures { aidl }`, and `packaging { jniLibs { useLegacyPackaging = true } }`
+— the daemon has no classloader library-search path, so the `.so` must exist as an extracted file for it
+to `System.load` by absolute path.
+
+### What was removed
+
+All the milestone probes: the ashmem FIFO (`spikeStartFifoProbe` + `nativeCreateFifo`/`nativeReadFifo`),
+the dlopen/namespace reachability probe (`nativeProbe`), the manual-symbol-resolution test
+(`nativeResolveTest`), the cblk diagnostics (`nativeMonitorCblk`/`nativeDumpCblk`), the standalone
+`audiohandoffprobe.cpp` executable and its CMake target, the daemon-boot probe block in
+`RecorderServer.main`, and the auto-fire in `CallVaultApplication.onCreate`.
+
+Also removed: two temporary debug aids used while diagnosing on-device (an unconditional `AppLogger`
+mirror to external storage, and a daemon trace to `/data/local/tmp/cv_handoff.log`).

--- a/docs/dev-notes/spike-tools/Ref.java
+++ b/docs/dev-notes/spike-tools/Ref.java
@@ -1,0 +1,33 @@
+package cvref;
+import android.media.AudioRecord;
+import android.media.AudioFormat;
+import android.media.MediaRecorder;
+import android.util.Log;
+
+// Minimal shell-uid Java AudioRecord reference: the SAME path the working CallVault daemon uses.
+// Its native AudioRecord::set() logs "set(): inputSource... attributionSource..." — the ground truth
+// to diff against the raw-native probe. Run via: CLASSPATH=cvref.jar app_process /data/local/tmp cvref.Ref
+public class Ref {
+    static final String T = "CVRef";
+    public static void main(String[] a) {
+        int rate = 16000, chan = AudioFormat.CHANNEL_IN_MONO, fmt = AudioFormat.ENCODING_PCM_16BIT;
+        Log.i(T, "=== CVRef start uid=" + android.os.Process.myUid() + " pid=" + android.os.Process.myPid() + " ===");
+        try {
+            int min = AudioRecord.getMinBufferSize(rate, chan, fmt);
+            Log.i(T, "getMinBufferSize=" + min);
+            AudioRecord ar = new AudioRecord(MediaRecorder.AudioSource.MIC, rate, chan, fmt, Math.max(min, 4096));
+            Log.i(T, "AudioRecord.getState=" + ar.getState() + " (1=INITIALIZED)");
+            if (ar.getState() != AudioRecord.STATE_INITIALIZED) { Log.e(T, "NOT INITIALIZED -> createRecord failed"); return; }
+            ar.startRecording();
+            Log.i(T, "recordingState=" + ar.getRecordingState() + " (3=RECORDING)");
+            byte[] buf = new byte[1280]; int total = 0, peak = 0;
+            for (int i = 0; i < 30; i++) {
+                int n = ar.read(buf, 0, buf.length);
+                if (n > 0) { total += n; for (int k = 0; k + 1 < n; k += 2) { int s = (short)((buf[k] & 0xff) | (buf[k+1] << 8)); int ab = Math.abs(s); if (ab > peak) peak = ab; } }
+            }
+            Log.i(T, "CAPTURE total=" + total + " peak=" + peak + (peak > 0 ? " REAL" : " SILENT"));
+            ar.stop(); ar.release();
+        } catch (Throwable t) { Log.e(T, "FAILED: " + t, t); }
+        Log.i(T, "=== CVRef done ===");
+    }
+}

--- a/scripts/handoff-diag.sh
+++ b/scripts/handoff-diag.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Handoff diagnostics — run right after connecting the phone to establish WHY a recording failed.
+# Distinguishes the two candidate causes without needing a live call.
+#   A) leaked VOICE_CALL capture input (a handed-off track never released) -> next recording is empty
+#   B) broken ADB transport / daemon unreachable -> startPipeline hangs, recording never starts
+# Usage: scripts/handoff-diag.sh [serial]
+set -uo pipefail
+D="${1:-6011b07e}"
+A() { adb -s "$D" "$@"; }
+
+echo "=================== CallVault handoff diagnostics ==================="
+echo "--- device / build ---"
+A shell "dumpsys package com.baba.callvault | grep -m1 -E 'versionName|versionCode'"
+A shell "getprop sys.usb.config; getprop service.adb.tcp.port; settings get global adb_wifi_enabled"
+
+echo
+echo "--- (B) daemon + app processes ---"
+A shell 'ps -A -o PID,USER,NAME | awk "\$2==\"shell\" && \$3==\"app_process\"{print \"daemon pid=\" \$1}"' || echo "daemon=DEAD"
+A shell 'echo "app pid=$(pidof com.baba.callvault)"'
+
+echo
+echo "--- (A) LEAKED CAPTURE: any active record client? (uid 10xxx=app, 2000=daemon) ---"
+echo "    Expect NO active VOICE_CALL client when idle. An active one = leaked handoff track."
+A shell "dumpsys audio 2>/dev/null | grep -E 'rec (start|update)' | tail -8"
+echo "    -- audioflinger record tracks --"
+A shell "dumpsys media.audio_flinger 2>/dev/null | grep -A3 -iE 'Input thread' | grep -iE 'Tracks of which|active' | head -6"
+
+echo
+echo "--- (A) app threads: cv-handoff-* must NOT be present when idle ---"
+A shell 'P=$(pidof com.baba.callvault); for t in /proc/$P/task/*/comm; do C=$(cat $t 2>/dev/null); case "$C" in cv-*) echo "  $C";; esac; done; echo "  (nothing above = clean)"'
+
+echo
+echo "--- recent recordings (0 bytes = failed) ---"
+A shell "ls -la /sdcard/CallRecording/ 2>/dev/null | tail -6"
+echo "===================================================================="
+echo "READ: daemon DEAD or app can't reach it  -> cause (B) transport; relaunch daemon."
+echo "      active record client / cv-handoff-* while idle -> cause (A) leaked track."


### PR DESCRIPTION
## What this does

Adds **Resilient recording**, an opt-in that makes a recording survive the privileged daemon dying mid-call.

Until now the daemon held the microphone and encoded for the whole call, so anything that killed it part-way through — a screen lock restarting adbd, an OEM reaper — ended the recording there, unrecoverably. Now the daemon only *creates* the capture and hands the `IAudioRecord` binder plus the control-block ashmem fd to the app. The track's lifetime is that binder's refcount, so it stays alive on the app's reference alone; the app drains the ring and encodes locally.

It doesn't change how a recording *starts* — the daemon is still needed for that — so this is a completeness guarantee, not a replacement for the existing bootstrap.

## Reversibility

Default **OFF**. When the preference is off, or the source has no direct `AudioRecord` equivalent, the branch is skipped entirely and the daemon path runs exactly as before. Turning the switch off restores previous behaviour completely — nothing to migrate, nothing to undo.

Establishment is best-effort with the daemon path as the safety net: if the handoff doesn't come up, the engine falls back and the call is still recorded.

## Verified on device (OnePlus 12, Android 16)

On a real call with the toggle on:

- handoff established, `cv-handoff-drain`/`-encode` live
- daemon `kill -9`'d mid-call → **capture threads survived**, file grew 79 KB → 219 KB with its creating daemon dead
- **no new `rec start`** after the kill, exactly 1 active record track — the growth is the original handed-off capture, not a relaunched daemon
- finalized valid Opus/OGG 48 kHz mono, 86.1 s
- audio **before** the kill: mean −44.7 dB / max −15.8 dB · **after**: mean −46.5 dB / max −14.0 dB (silence reads −91)
- teardown clean: no leftover threads, 0 active record tracks

A separate call with the daemon path confirmed the fallback carries a full ~31-minute call.

## Also in here

- **Fixes a pre-existing bug that could lose calls.** Starting a recording read the USB default over ADB with no time limit; over a half-dead connection it blocked forever and the recording never started, leaving an empty file. Now capped at 1.5 s. This affects every recording, including with the new opt-in off.
- **Fixes the `voice-performance` source** silently falling back to scrcpy — it was matched against a cliKey that doesn't exist.
- A one-time post-update note introducing the feature, in all nine locales.
- 78 unit tests, each checked by mutation.
- README corrected: "How it works" still claimed audio is captured via scrcpy, contradicting its own intro.

## ⚠️ Behaviour change worth a look

The APK now carries a native library and is built for **`arm64-v8a` only**, so it will **not install on 32-bit-only or x86 devices** — previous releases had no native code and installed anywhere. Effectively every Android 11+ phone is arm64, so real-world impact should be near zero, but it is a genuine narrowing. Documented in README Requirements and the changelog.

## Test plan

- [x] `assembleRelease` green; all 78 unit tests pass
- [x] every commit in this PR compiles independently
- [x] real call, toggle ON, daemon killed mid-call → recording survives and finalizes with real audio
- [x] real call on the daemon path → unaffected
- [x] no leaked capture input after teardown (0 active record tracks)
- [ ] someone other than me confirms the opt-in reads clearly in the UI